### PR TITLE
Flow improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Within the `Rollup__mdt` custom metadata type, add a new record with fields:
 - `Lookup Object` - the name of the SObject you’d like to roll the values up to (in this case, Account)
 - `Rollup Type` - the operation you're looking to perform. Acceptable values are SUM / MIN / MAX / AVERAGE / COUNT / COUNT_DISTINCT / CONCAT / CONCAT_DISTINCT. Both CONCAT and CONCAT_DISTINCT separate values with commas
 - `Changed Fields On Calc Item` (optional) - comma-separated list of field API Names to filter items from being used in the rollup calculations unless all the stipulated fields have changed
+- `Full Recalculation Default Number Value` (optional) - for some rollup operations (SUM / COUNT-based operations in particular), you may want to start fresh with each batch of calculation items provided. When this value is provided, it is used as the basis for rolling values up to the "parent" record (instead of whatever the pre-existing value for that field on the "parent" is, which is the default behavior). **NB**: it's valid to use this field to override the pre-existing value on the "parent" for number-based fields, _and_ that includes Date / Datetime / Time fields as well. In order to work properly for these three field types, however, the value must be converted into UTC milliseconds. You can do this easily using Anonymous Apex, or a site such as [Current Millis](https://currentmillis.com/).
+- `Full Recalculation Default String Value` (optional) - same as `Full Recalculation Default Number Value`, but for String-based fields (including Lookup and Id fields).
 
 You can perform have as many rollups as you'd like per object/trigger -- all operations are batched.
 
@@ -87,12 +89,16 @@ Here are the arguments necessary to invoke `Rollup` from a Flow / Process Builde
 - `Rollup Context` - INSERT / UPDATE / DELETE
 - `Rollup Operation` - the operation you're looking to perform. Acceptable values are SUM / MIN / MAX / AVERAGE / COUNT / COUNT_DISTINCT / CONCAT / CONCAT_DISTINCT. Both CONCAT and CONCAT_DISTINCT separate values with commas
 - `Calc item changed fields` (optional) - comma-separated list of field API Names to filter items from being used in the rollup calculations unless all the stipulated fields have changed
+- `Full Recalculation Default Number Value` (optional) - for some rollup operations (SUM / COUNT-based operations in particular), you may want to start fresh with each batch of calculation items provided. When this value is provided, it is used as the basis for rolling values up to the "parent" record (instead of whatever the pre-existing value for that field on the "parent" is, which is the default behavior). **NB**: it's valid to use this field to override the pre-existing value on the "parent" for number-based fields, _and_ that includes Date / Datetime / Time fields as well. In order to work properly for these three field types, however, the value must be converted into UTC milliseconds. You can do this easily using Anonymous Apex, or a site such as [Current Millis](https://currentmillis.com/).
+- `Full Recalculation Default String Value` (optional) - same as `Full Recalculation Default Number Value`, but for String-based fields (including Lookup and Id fields).
 
 Unfortunately, the "Description" section for Invocable fields does not show up as help text within the Flow Builder, but hopefully it's clear how each property should be configured!
 
 ### Scheduled Job
 
-You can use the following Anonymous Apex script to schedule rollups:
+I would _highly_ recommend scheduling through Scheduled Flows.
+
+That being said, `Rollup` has options to use Scheduled Jobs if that's more your style. You can use the following Anonymous Apex script to schedule rollups:
 
 ```java
 // Method signature: (String jobName, String cronExp, String query, List<Id> rollupMetadataIds, Evaluator eval)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/main/default/classes/Rollup.cls
+++ b/rollup/main/default/classes/Rollup.cls
@@ -35,6 +35,8 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
   private final Boolean isBatched;
   private final RollupInvocationPoint invokePoint;
   private final Id rollupLimitId;
+  private final Decimal overrideForNumberRollups;
+  private final String overrideForStringRollups;
 
   // non-final instance variables
   private Boolean isNoOp;
@@ -136,7 +138,9 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
       innerRollup.oldCalcItems,
       innerRollup.eval,
       innerRollup.invokePoint,
-      innerRollup.rollupLimitId
+      innerRollup.rollupLimitId,
+      innerRollup.overrideForNumberRollups,
+      innerRollup.overrideForStringRollups
     );
     this.rollups = innerRollup.rollups;
     this.isNoOp = this.rollups.isEmpty() == false;
@@ -153,7 +157,9 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
     Map<Id, SObject> oldCalcItems,
     Evaluator eval,
     RollupInvocationPoint invokePoint,
-    Id rollupLimitId
+    Id rollupLimitId,
+    Decimal overrideForNumberRollups,
+    String overrideForStringRollups
   ) {
     this.calcItems = this.filter(calcItems, eval);
     this.eval = eval;
@@ -168,6 +174,8 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
     this.isBatched = false;
     this.invokePoint = invokePoint;
     this.rollupLimitId = rollupLimitId;
+    this.overrideForNumberRollups = overrideForNumberRollups;
+    this.overrideForStringRollups = overrideForStringRollups;
   }
 
   public interface Evaluator {
@@ -306,7 +314,9 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
       Map<Id, SObject> oldCalcItems,
       Evaluator eval,
       Id rollupLimitId,
-      RollupInvocationPoint rollupInvokePoint
+      RollupInvocationPoint rollupInvokePoint,
+      Decimal overrideForNumberRollups,
+      String overrideForStringRollups
     ) {
       super(
         calcItems,
@@ -319,7 +329,9 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
         oldCalcItems,
         eval,
         rollupInvokePoint,
-        rollupLimitId
+        rollupLimitId,
+        overrideForNumberRollups,
+        overrideForStringRollups
       );
     }
 
@@ -454,7 +466,9 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
           FullRecalculationDefaultStringValue__c = flowInput.fullRecalculationDefaultStringValue
         );
         Map<Id, SObject> oldFlowRecords = getOldFlowRecords(flowInput.recordsToRollup, sObjectType);
-        rollups.add(getRollup(new List<Rollup__mdt>{ rollupMeta }, sObjectType, flowInput.recordsToRollup, oldFlowRecords, null, RollupInvocationPoint.FROM_INVOCABLE));
+        rollups.add(
+          getRollup(new List<Rollup__mdt>{ rollupMeta }, sObjectType, flowInput.recordsToRollup, oldFlowRecords, null, RollupInvocationPoint.FROM_INVOCABLE)
+        );
       }
       batch(rollups);
     } catch (Exception ex) {
@@ -813,8 +827,8 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
 
     Set<String> fieldNames = currentRecords[0].getPopulatedFieldsAsMap().keySet();
     Set<Id> currentRecordIds = new Set<Id>();
-    for(SObject currentRecord : currentRecords) {
-      if(currentRecord.Id != null) {
+    for (SObject currentRecord : currentRecords) {
+      if (currentRecord.Id != null) {
         currentRecordIds.add(currentRecord.Id);
       }
     }
@@ -849,7 +863,9 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
             LookupFieldOnCalcItem__c,
             RollupFieldOnLookupObject__c,
             RollupType__c,
-            ChangedFieldsOnCalcItem__c
+            ChangedFieldsOnCalcItem__c,
+            FullRecalculationDefaultNumberValue__c,
+            FullRecalculationDefaultStringValue__c
           FROM Rollup__mdt
           WHERE CalcItem__c = :String.valueOf(sObjectType)
         ];
@@ -917,7 +933,9 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
         batchRollup,
         eval,
         rollupLimitId,
-        rollupInvokePoint
+        rollupInvokePoint,
+        rollupMetadata.FullRecalculationDefaultNumberValue__c,
+        rollupMetadata.FullRecalculationDefaultStringValue__c
       );
     }
     return batchRollup;
@@ -987,7 +1005,9 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
     Rollup batchRollup,
     Evaluator eval,
     Id rollupLimitId,
-    RollupInvocationPoint invokePoint
+    RollupInvocationPoint invokePoint,
+    Decimal overrideForNumberRollups,
+    String overrideForStringRollups
   ) {
     Rollup rollup = new RollupAsyncProcessor(
       calcItems,
@@ -1000,7 +1020,9 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
       oldCalcItems,
       eval,
       rollupLimitId,
-      invokePoint
+      invokePoint,
+      overrideForNumberRollups,
+      overrideForStringRollups
     );
     return loadRollups(rollup, batchRollup);
   }
@@ -1181,31 +1203,31 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
   }
 
   private Object getRollupVal(Rollup rollup, List<SObject> calcItems, Object priorVal) {
-    RollupCalculator rollupCalc = this.getRollupType(priorVal, rollup.op, rollup.opFieldOnLookupObject, rollup.opFieldOnCalcItem);
+    RollupCalculator rollupCalc = this.getRollupType(priorVal, rollup);
     rollupCalc.performRollup(rollup.op, priorVal, calcItems, rollup.oldCalcItems, rollup.opFieldOnCalcItem);
     return rollupCalc.getReturnValue();
   }
 
-  private RollupCalculator getRollupType(Object priorVal, Op operationType, SObjectField opFieldOnLookupObject, SObjectField opFieldOnCalcItem) {
-    if (operationType.name().contains(Rollup.Op.COUNT_DISTINCT.name())) {
-      return new CountDistinctRollupCalculator(0, opFieldOnLookupObject);
-    } else if (operationType.name().contains(Rollup.Op.COUNT.name())) {
-      return new CountRollupCalculator(priorVal, opFieldOnLookupObject);
-    } else if (operationType.name().contains(Rollup.Op.AVERAGE.name())) {
-      return new AverageRollupCalculator(priorVal, opFieldOnLookupObject);
+  private RollupCalculator getRollupType(Object priorVal, Rollup roll) {
+    if (roll.op.name().contains(Rollup.Op.COUNT_DISTINCT.name())) {
+      return new CountDistinctRollupCalculator(0, roll.opFieldOnLookupObject, roll.overrideForNumberRollups);
+    } else if (roll.op.name().contains(Rollup.Op.COUNT.name())) {
+      return new CountRollupCalculator(priorVal, roll.opFieldOnLookupObject, roll.overrideForNumberRollups);
+    } else if (roll.op.name().contains(Rollup.Op.AVERAGE.name())) {
+      return new AverageRollupCalculator(priorVal, roll.opFieldOnLookupObject, roll.overrideForNumberRollups);
     } else if (priorVal instanceof Decimal) {
-      return new DecimalRollupCalculator(priorVal, opFieldOnLookupObject);
+      return new DecimalRollupCalculator(priorVal, roll.opFieldOnLookupObject, roll.overrideForNumberRollups);
     } else if (priorVal instanceof String) {
-      return new PicklistRollupCalculator(priorVal, opFieldOnCalcItem);
+      return new PicklistRollupCalculator(priorVal, roll.opFieldOnCalcItem, roll.overrideForStringRollups);
     } else if (priorVal instanceof Date) {
       // not obvious: the order of these else if's is of supreme importance
       // Date has to go before Datetime; in the same way that all numbers test true as an instanceof Decimal
       // all Dates test true as Datetimes ...
-      return new DateRollupCalculator(priorVal, opFieldOnLookupObject);
+      return new DateRollupCalculator(priorVal, roll.opFieldOnLookupObject, roll.overrideForNumberRollups);
     } else if (priorVal instanceof Time) {
-      return new TimeRollupCalculator(priorVal, opFieldOnLookupObject);
+      return new TimeRollupCalculator(priorVal, roll.opFieldOnLookupObject, roll.overrideForNumberRollups);
     } else if (priorval instanceof Datetime) {
-      return new DatetimeRollupCalculator(priorVal, opFieldOnLookupObject);
+      return new DatetimeRollupCalculator(priorVal, roll.opFieldOnLookupObject, roll.overrideForNumberRollups);
     } else {
       throw new IllegalArgumentException('Calculation not defined for: ' + JSON.serialize(priorVal));
     }
@@ -1357,8 +1379,12 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
   private abstract class RollupCalculator {
     protected Boolean shouldShortCircuit = false;
     protected Object returnVal;
-    public RollupCalculator(Object priorVal, SObjectField operationField) {
-      this.returnVal = priorVal == null ? FieldInitializer.getDefaultValue(operationField) : priorVal;
+    public RollupCalculator(Object priorVal, SObjectField operationField, Object defaultVal) {
+      if (defaultVal != null) {
+        this.returnVal = defaultVal;
+      } else {
+        this.returnVal = priorVal == null ? FieldInitializer.getDefaultValue(operationField) : priorVal;
+      }
     }
     public virtual Object getReturnValue() {
       return this.returnVal;
@@ -1376,8 +1402,8 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
 
   private class CountDistinctRollupCalculator extends RollupCalculator {
     private final Set<Object> distinctValues;
-    public CountDistinctRollupCalculator(Object priorVal, SObjectField operationField) {
-      super(priorVal, operationField);
+    public CountDistinctRollupCalculator(Object priorVal, SObjectField operationField, Object defaultVal) {
+      super(priorVal, operationField, defaultVal);
       this.distinctValues = new Set<Object>();
       if (this.returnVal != FieldInitializer.getDefaultValue(operationfield)) {
         this.distinctValues.add(this.returnVal);
@@ -1441,8 +1467,8 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
   }
 
   private virtual class DecimalRollupCalculator extends RollupCalculator {
-    public DecimalRollupCalculator(Object priorVal, SObjectField operationField) {
-      super(priorVal, operationField);
+    public DecimalRollupCalculator(Object priorVal, SObjectField operationField, Object defaultVal) {
+      super(priorVal, operationField, defaultVal);
     }
 
     protected virtual Decimal getDecimalOrDefault(Object potentiallyUnitializedDecimal) {
@@ -1573,8 +1599,8 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
   }
 
   private virtual class DatetimeRollupCalculator extends DecimalRollupCalculator {
-    public DatetimeRollupCalculator(Object priorVal, SObjectField operationField) {
-      super(((Datetime) priorVal).getTime(), operationField);
+    public DatetimeRollupCalculator(Object priorVal, SObjectField operationField, Object defaultVal) {
+      super(((Datetime) priorVal).getTime(), operationField, defaultVal);
     }
 
     public virtual override Object getReturnValue() {
@@ -1617,8 +1643,8 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
   private class DateRollupCalculator extends DatetimeRollupCalculator {
     // for Date, it's not necessary to override the "getDecimalOrDefault" method in DatetimeRollupCalculator
     // because the conversion only happens in "getReturnValue"
-    public DateRollupCalculator(Object priorVal, SObjectField operationField) {
-      super(Datetime.newInstanceGmt((Date) priorVal, Time.newInstance(0, 0, 0, 0)), operationField);
+    public DateRollupCalculator(Object priorVal, SObjectField operationField, Object defaultVal) {
+      super(Datetime.newInstanceGmt((Date) priorVal, Time.newInstance(0, 0, 0, 0)), operationField, defaultVal);
     }
 
     public override Object getReturnValue() {
@@ -1627,8 +1653,8 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
   }
 
   private class TimeRollupCalculator extends DatetimeRollupCalculator {
-    public TimeRollupCalculator(Object priorVal, SObjectField operationField) {
-      super(Datetime.newInstanceGmt(FieldInitializer.defaultDateTime.dateGmt(), (Time) priorVal), operationField);
+    public TimeRollupCalculator(Object priorVal, SObjectField operationField, Object defaultVal) {
+      super(Datetime.newInstanceGmt(FieldInitializer.defaultDateTime.dateGmt(), (Time) priorVal), operationField, defaultVal);
     }
 
     public override Object getReturnValue() {
@@ -1650,8 +1676,8 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
 
   private class CountRollupCalculator extends DecimalRollupCalculator {
     private final Integer existingValue;
-    public CountRollupCalculator(Object priorVal, SObjectField operationField) {
-      super(priorVal, operationField);
+    public CountRollupCalculator(Object priorVal, SObjectField operationField, Object defaultVal) {
+      super(priorVal, operationField, defaultVal);
       // cache existing value to ensure we don't dip below 0 in "getReturnValue"
       this.existingValue = Integer.valueOf(this.returnVal);
     }
@@ -1676,8 +1702,8 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
   }
 
   private virtual class StringRollupCalculator extends RollupCalculator {
-    public StringRollupCalculator(Object priorVal, SObjectField operationField) {
-      super(priorVal, operationField);
+    public StringRollupCalculator(Object priorVal, SObjectField operationField, Object defaultVal) {
+      super(priorVal, operationField, defaultVal);
     }
 
     public override void performRollup(Op operation, Object priorVal, List<SObject> calcItems, Map<Id, SObject> oldCalcItems, SObjectField operationField) {
@@ -1760,8 +1786,8 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
 
   private class PicklistRollupCalculator extends StringRollupCalculator {
     private final PicklistController picklistController;
-    public PicklistRollupCalculator(Object priorVal, SObjectField operationField) {
-      super(priorVal, operationField);
+    public PicklistRollupCalculator(Object priorVal, SObjectField operationField, Object defaultVal) {
+      super(priorVal, operationField, defaultVal);
       this.picklistController = new PicklistController(operationField.getDescribe());
     }
 
@@ -1785,8 +1811,8 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
   }
 
   private class AverageRollupCalculator extends RollupCalculator {
-    public AverageRollupCalculator(Object priorVal, SObjectField operationField) {
-      super(priorVal, operationField);
+    public AverageRollupCalculator(Object priorVal, SObjectField operationField, Object defaultVal) {
+      super(priorVal, operationField, defaultVal);
     }
     public override void performRollup(Op operation, Object priorVal, List<SObject> calcItems, Map<Id, SObject> oldCalcItems, SObjectField operationField) {
       Decimal average = (Decimal) this.returnVal;
@@ -1836,7 +1862,9 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
           LookupFieldOnCalcItem__c,
           RollupFieldOnLookupObject__c,
           RollupType__c,
-          ChangedFieldsOnCalcItem__c
+          ChangedFieldsOnCalcItem__c,
+          FullRecalculationDefaultNumberValue__c,
+          FullRecalculationDefaultStringValue__c
         FROM Rollup__mdt
         WHERE Id = :this.rollupMetadataIds
       ];

--- a/rollup/main/default/classes/Rollup.cls
+++ b/rollup/main/default/classes/Rollup.cls
@@ -360,7 +360,7 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
     @InvocableVariable(label='Rollup Operation' description='SUM, COUNT, COUNT_DISTINCT, MAX, MIN, AVG, CONCAT' required=true)
     public String rollupOperation;
 
-    @InvocableVariable(label='Rollup Context' description='INSERT, UPDATE, or DELETE' required=true)
+    @InvocableVariable(label='Rollup Context' description='INSERT, UPDATE, UPSERT, or DELETE' required=true)
     public String rollupContext;
 
     @InvocableVariable(label='Calc Item Rollup Field' description='The API Name of the field on each of the records passed in to consider.' required=true)
@@ -387,11 +387,23 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
     )
     public String lookupFieldOnOpObject;
 
+    // optional fields
     @InvocableVariable(
       label='Calc Item Changed Fields'
       description='Provide a comma-separated list of field API Names to consider prior to using records in the rollup'
     )
     public String calcItemChangedFields;
+
+    @InvocableVariable(
+      label='Full Recalculation Default Number Value'
+      description='If provided, used in place of the existing value on the rollup field for the lookup object for number-based rollups'
+    )
+    public Decimal fullRecalculationDefaultNumberValue;
+    @InvocableVariable(
+      label='Full Recalculation Default String Value'
+      description='If provided, used in place of the existing value on the rollup field for the lookup object for String-based rollups'
+    )
+    public String fullRecalculationDefaultStringValue;
   }
 
   public class FlowOutput {
@@ -413,17 +425,12 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
   )
   public static List<FlowOutput> performRollup(List<FlowInput> flowInputs) {
     List<FlowOutput> flowOutputReturns = new List<FlowOutput>();
-    List<Rollup__mdt> rollupMetadata = new List<Rollup__mdt>();
     List<Rollup> rollups = new List<Rollup>();
 
     try {
-      Map<Id, SObject> oldRecords = new Map<Id, SObject>();
-      List<SObject> calcItems = new List<SObject>();
+      Map<Id, SObject> calcItems = new Map<Id, SObject>();
       FlowInput firstInput = flowInputs.isEmpty() == false ? flowInputs[0] : new FlowInput();
       String rollupContext = getFlowRollupContext(firstInput);
-      Boolean isFirstSObject = true;
-      SObjectType recordSObjectType;
-      Set<String> fieldNames;
 
       for (FlowInput flowInput : flowInputs) {
         FlowOutput flowOutput = new FlowOutput();
@@ -433,15 +440,7 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
           continue;
         }
 
-        for (SObject record : flowInput.recordsToRollup) {
-          if (isFirstSObject) {
-            isFirstSObject = false;
-            recordSObjectType = record.getSObjectType();
-            fieldNames = record.getPopulatedFieldsAsMap().keySet();
-          }
-          calcItems.add(record);
-          oldRecords.put(record.Id, record);
-        }
+        SObjectType sObjectType = flowInput.recordsToRollup[0].getSObjectType();
 
         Rollup__mdt rollupMeta = new Rollup__mdt(
           RollupFieldOnCalcItem__c = flowInput.rollupFieldOnCalcItem,
@@ -450,12 +449,13 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
           LookupFieldOnLookupObject__c = flowInput.lookupFieldOnOpObject,
           RollupFieldOnLookupObject__c = flowInput.rollupFieldOnOpObject,
           RollupType__c = rollupContext + flowInput.rollupOperation,
-          ChangedFieldsOnCalcItem__c = flowInput.calcItemChangedFields
+          ChangedFieldsOnCalcItem__c = flowInput.calcItemChangedFields,
+          FullRecalculationDefaultNumberValue__c = flowInput.fullRecalculationDefaultNumberValue,
+          FullRecalculationDefaultStringValue__c = flowInput.fullRecalculationDefaultStringValue
         );
-        rollupMetadata.add(rollupMeta);
+        Map<Id, SObject> oldFlowRecords = getOldFlowRecords(flowInput.recordsToRollup, sObjectType);
+        rollups.add(getRollup(new List<Rollup__mdt>{ rollupMeta }, sObjectType, flowInput.recordsToRollup, oldFlowRecords, null, RollupInvocationPoint.FROM_INVOCABLE));
       }
-      oldRecords = getOldFlowRecords(oldRecords.keySet(), fieldNames, recordSObjectType);
-      rollups.add(getRollup(rollupMetadata, recordSObjectType, calcItems, oldRecords, null, RollupInvocationPoint.FROM_INVOCABLE));
       batch(rollups);
     } catch (Exception ex) {
       for (FlowOutput flowOutput : flowOutputReturns) {
@@ -804,15 +804,37 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
     return flowContext == 'INSERT' ? '' : flowContext + '_';
   }
 
-  private static Map<Id, SObject> getOldFlowRecords(Set<Id> currentRecords, Set<String> fieldNames, SObjectType sObjectType) {
+  private static Map<Id, SObject> getOldFlowRecords(List<SObject> currentRecords, SObjectType sObjectType) {
     if (currentRecords.isEmpty()) {
       return new Map<Id, SObject>();
+    } else if (oldRecordsMap != null) {
+      return oldRecordsMap;
     }
-    return oldRecordsMap != null
-      ? oldRecordsMap
-      : new Map<Id, SObject>(
-          Database.query('SELECT ' + String.join(new List<String>(fieldNames), ',') + '\nFROM ' + String.valueOf(sObjectType) + '\nWHERE Id = :currentRecords')
-        );
+
+    Set<String> fieldNames = currentRecords[0].getPopulatedFieldsAsMap().keySet();
+    Set<Id> currentRecordIds = new Set<Id>();
+    for(SObject currentRecord : currentRecords) {
+      if(currentRecord.Id != null) {
+        currentRecordIds.add(currentRecord.Id);
+      }
+    }
+    // we need to do two things: get the old records, and initialize default values for both existing records and the ones that don't have matches in the db
+    Map<Id, SObject> existingOldRecordsMap = new Map<Id, SObject>(
+      Database.query('SELECT ' + String.join(new List<String>(fieldNames), ',') + '\nFROM ' + String.valueOf(sObjectType) + '\nWHERE Id = :currentRecordIds')
+    );
+    for (SObject currentRecord : currentRecords) {
+      DescribeSObjectResult sObjectDescribe = sObjectType.getDescribe();
+      SObject existingRecordOrDefault = currentRecord.Id != null && existingOldRecordsMap.containsKey(currentRecord.Id)
+        ? existingOldRecordsMap.get(currentRecord.Id)
+        : (SObject) Type.forName(sObjectDescribe.getName()).newInstance();
+      Map<String, SObjectField> fieldTokensForObject = sObjectDescribe.fields.getMap();
+      for (String fieldName : fieldNames) {
+        if (existingRecordOrDefault.get(fieldName) == null) {
+          existingRecordOrDefault.put(fieldName, FieldInitializer.getDefaultValue(fieldTokensForObject.get(fieldName)));
+        }
+      }
+    }
+    return existingOldRecordsMap;
   }
 
   private static List<Rollup__mdt> getTriggerRollupMetadata(SObjectType sObjectType) {
@@ -1224,7 +1246,7 @@ public without sharing virtual class Rollup implements Database.Batchable<SObjec
         when TIME {
           initializedDefault = this.defaultDateTime.timeGmt();
         }
-        when STRING, ID, TEXTAREA, URL, PHONE, EMAIL {
+        when STRING, ID, TEXTAREA, URL, PHONE, EMAIL, REFERENCE {
           initializedDefault = '';
         }
         when PICKLIST, MULTIPICKLIST {

--- a/rollup/main/default/classes/RollupTests.cls
+++ b/rollup/main/default/classes/RollupTests.cls
@@ -222,6 +222,56 @@ private class RollupTests {
   }
 
   @isTest
+  static void shouldOverrideNumberBasedDefaultBasedOnMetadata() {
+    DMLMock mock = getMock(new List<Opportunity>{ new Opportunity(Amount = 100) });
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Amount',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupType__c = 'SUM',
+        FullRecalculationDefaultNumberValue__c = 100000
+      )
+    };
+
+    Rollup.triggerContext = TriggerOperation.AFTER_INSERT;
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    System.assertEquals(1, mock.Records.size(), 'Records should have been populated based on metadata AFTER_INSERT');
+    Account updatedAcc = (Account) mock.Records[0];
+    System.assertEquals(100100, updatedAcc.AnnualRevenue, 'SUM AFTER_INSERT should add the original opportunity amount to the default override based on CMDT');
+  }
+
+  @isTest
+  static void shouldOverrideStringBasedDefaultBasedOnMetadata() {
+    DMLMock mock = getMock(new List<Opportunity>{ new Opportunity(Name = 'A') });
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Name',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'Name',
+        RollupType__c = 'MAX',
+        FullRecalculationDefaultStringValue__c = 'Z'
+      )
+    };
+
+    Rollup.triggerContext = TriggerOperation.AFTER_INSERT;
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    System.assertEquals(1, mock.Records.size(), 'Records should have been populated based on override metadata AFTER_INSERT');
+    Account updatedAcc = (Account) mock.Records[0];
+    System.assertEquals('Z', updatedAcc.Name, 'MAX AFTER_INSERT should add the default override based on CMDT if there is no greater value');
+  }
+
+  @isTest
   static void shouldRunMultipleOperationsWhenMoreMetadataIsPresent() {
     DMLMock mock = getMock(new List<Opportunity>{ new Opportunity(Amount = 100) });
     Rollup.rollupMetadata = new List<Rollup__mdt>{
@@ -1593,6 +1643,83 @@ private class RollupTests {
 
     System.assertEquals(1, flowOutputs.size());
     System.assertEquals(true, flowOutputs[0].isSuccess);
+  }
+
+  @isTest
+  static void shouldOverrideNumberBasedDefaultBasedOnMetadataForFlow() {
+    List<Opportunity> opps = new List<Opportunity>{ new Opportunity(Amount = 1000) };
+    DMLMock mock = getMock(opps);
+    List<Rollup.FlowInput> flowInputs = prepareFlowTest(opps, 'INSERT', 'SUM');
+    flowInputs[0].fullRecalculationDefaultNumberValue = -1001;
+
+    Test.startTest();
+    List<Rollup.FlowOutput> flowOutputs = Rollup.performRollup(flowInputs);
+    Test.stopTest();
+
+    System.assertEquals(1, flowOutputs.size(), 'Flow ouputs were not provided');
+    System.assertEquals('SUCCESS', flowOutputs[0].message);
+    System.assertEquals(true, flowOutputs[0].isSuccess);
+
+    System.assertEquals(1, mock.Records.size(), 'SUM AFTER_INSERT from flow did not update accounts');
+    Account updatedAcc = (Account) mock.Records[0];
+    System.assertEquals(-1, updatedAcc.AnnualRevenue, 'SUM AFTER_INSERT from flow should match input Amount + number override');
+  }
+
+  @isTest
+  static void shouldOverrideDateUsingNumberBasedDefaultForFlow() {
+    Contract con = [SELECT Id FROM Contract];
+
+    Datetime nowish = System.now();
+
+    // it only matters that the amount below is LESS than the above value, and that "nowish" is assigned to the fullRecalculationDefaultNumberValue flow input value
+    List<Event> events = new List<Event>{ new Event(ActivityDateTime = nowish.addDays(-2), WhatId = con.Id) };
+    DMLMock mock = loadMock(events);
+    Rollup.records = null;
+
+    Rollup.FlowInput flowInput = new Rollup.FlowInput();
+    flowInput.recordsToRollup = events;
+    flowInput.lookupFieldOnCalcItem = 'WhatId';
+    flowInput.lookupFieldOnOpObject = 'Id';
+    flowInput.rollupContext = 'INSERT';
+    flowInput.rollupFieldOnCalcItem = 'ActivityDateTime';
+    flowInput.rollupFieldOnOpObject = 'ActivatedDate';
+    flowInput.rollupSObjectName = 'Contract';
+    flowInput.rollupOperation = 'MAX';
+    flowInput.fullRecalculationDefaultNumberValue = nowish.getTime();
+
+    Test.startTest();
+    List<Rollup.FlowOutput> flowOutputs = Rollup.performRollup(new List<Rollup.FlowInput>{ flowInput });
+    Test.stopTest();
+
+    System.assertEquals(1, flowOutputs.size(), 'Flow ouputs were not provided');
+    System.assertEquals('SUCCESS', flowOutputs[0].message);
+    System.assertEquals(true, flowOutputs[0].isSuccess);
+
+    System.assertEquals(1, mock.Records.size(), 'MAX AFTER_INSERT from flow with override date did not update accounts');
+    Contract updatedContract = (Contract) mock.Records[0];
+    System.assertEquals(nowish, updatedContract.ActivatedDate, 'MAX AFTER_INSERT from flow should match override date');
+  }
+
+  @isTest
+  static void shouldOverrideStringBasedDefaultForFlow() {
+    List<Opportunity> opps = new List<Opportunity>{ new Opportunity(Name = 'A') };
+    DMLMock mock = getMock(opps);
+    List<Rollup.FlowInput> flowInputs = prepareFlowTest(opps, 'INSERT', 'SUM');
+    flowInputs[0].fullRecalculationDefaultStringValue = 'Z';
+    flowInputs[0].rollupFieldOnOpObject = 'Name';
+    flowInputs[0].rollupFieldOnCalcItem = 'Name';
+
+    Test.startTest();
+    List<Rollup.FlowOutput> flowOutputs = Rollup.performRollup(flowInputs);
+    Test.stopTest();
+
+    System.assertEquals(1, flowOutputs.size(), 'Flow ouputs were not provided');
+    System.assertEquals('SUCCESS', flowOutputs[0].message);
+    System.assertEquals(true, flowOutputs[0].isSuccess);
+
+    System.assertEquals(1, mock.Records.size(), 'SUM AFTER_INSERT from flow did not update accounts');
+    Account updatedAcc = (Account) mock.Records[0];
+    System.assertEquals('Z', updatedAcc.Name, 'SUM AFTER_INSERT from flow should match string override when it is greater than supplied calc values');
   }
 
   /** Batch test */

--- a/rollup/main/default/objects/Rollup__mdt/fields/FullRecalculationDefaultNumberValue__c.field-meta.xml
+++ b/rollup/main/default/objects/Rollup__mdt/fields/FullRecalculationDefaultNumberValue__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>FullRecalculationDefaultNumberValue__c</fullName>
+    <description>If provided, used in place of the existing value on the rollup field for the lookup object for number-based rollups</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <inlineHelpText>If provided, used in place of the existing value on the rollup field for the lookup object for number-based rollups</inlineHelpText>
+    <label>Full Recalculation Default Number Value</label>
+    <precision>18</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/rollup/main/default/objects/Rollup__mdt/fields/FullRecalculationDefaultStringValue__c.field-meta.xml
+++ b/rollup/main/default/objects/Rollup__mdt/fields/FullRecalculationDefaultStringValue__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>FullRecalculationDefaultStringValue__c</fullName>
+    <description>If provided, used in place of the existing value on the rollup field for the lookup object for String-based rollups</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <inlineHelpText>If provided, used in place of the existing value on the rollup field for the lookup object for String-based rollups</inlineHelpText>
+    <label>Full Recalculation Default String Value</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/rollup/main/default/objects/Rollup__mdt/validationRules/Only_one_override_can_be_set.validationRule-meta.xml
+++ b/rollup/main/default/objects/Rollup__mdt/validationRules/Only_one_override_can_be_set.validationRule-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Only_one_override_can_be_set</fullName>
+    <active>true</active>
+    <description>You can only set the string or number based override for assigning to the lookup object&apos;s rollup field</description>
+    <errorConditionFormula>AND(
+  NOT(ISBLANK(FullRecalculationDefaultStringValue__c)),
+  NOT(ISNULL(FullRecalculationDefaultNumberValue__c))
+)</errorConditionFormula>
+    <errorMessage>You can only set the string or number based override for assigning to the lookup object&apos;s rollup field</errorMessage>
+</ValidationRule>


### PR DESCRIPTION
* Fixed invocable logic - no longer assumes all passed in records are of the same SObjectType / set of fields
* Added overrides to both CMDT and Invocable that allow for default values to be set for number-based and string-based rollup fields (including Datetime, Date, and Time-based fields)
* Added tests to ensure that override were working both from CMDT and invocable-based routes