### PR TITLE
Query Archived Records & Scalability Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ These are the fields on the `Rollup Control` custom metadata type:
 - `Should Abort Run` - if done at the `Org_Defaults` level, completely shuts down all rollup operations in the org. Otherwise, can be used on an individual rollup basis to turn on/off.
 - `Should Run As` - a picklist dictating the preferred method for running rollup operations. Possible values are `Queueable`, `Batchable`, or `Synchronous Rollup`.
 - `Trigger Or Invocable Name` - If you are using custom Apex, a schedulable, or rolling up by way of the Invocable action and can't use the `Rollup` lookup field. Use the pattern `trigger_fieldOnCalcItem_to_rollupFieldOnTarget_rollup` - for example: 'trigger_opportunity_stagename_to_account_name_rollup' (use lowercase on the field names). If there is a matching Rollup Limit record, those rules will be used. The first part of the string comes from how a rollup has been invoked - either by `trigger`, `invocable`, or `schedule`. A scheduled flow still uses `invocable`!
+- `Max Query Rows` - (defaults to 100) - Configure this number to decide how many queries Rollup is allowed to issue before restarting in another context. Consider the downstream query needs when your parent objects are updated when configuring this field. By safely requeueing Rollup in conjunction with this number, we ensure no query limit is ever hit.
+- `Max Rollup Retries` - (defaults to 100) - Only configurable on the Org Default record. Use in conjunction with `Max Query Rows`. This determines the maximum possible rollup jobs (either batched or queued) that can be spawned from a single overall rollup operation due to the prior one(s) exceeding the configured query limit.
 
 ### Flow / Process Builder Invocable
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/main/default/classes/Rollup.cls
+++ b/rollup/main/default/classes/Rollup.cls
@@ -251,9 +251,6 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       }
 
       String countQuery = getQueryString(rollup.lookupObj, new List<String>{ 'Count()' }, 'Id', '=');
-      if(countQuery.contains('ALL ROWS')) {
-        countQuery = countQuery.replace('ALL ROWS', '');
-      }
       if (queryCountsToLookupIds.containsKey(countQuery)) {
         queryCountsToLookupIds.get(countQuery).addAll(uniqueLookupFields);
       } else {
@@ -264,7 +261,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     Integer totalCountOfRecords = 0;
     for (String countQuery : queryCountsToLookupIds.keySet()) {
       Set<String> objIds = queryCountsToLookupIds.get(countQuery);
-      totalCountOfRecords += Database.countQuery(countQuery);
+      totalCountOfRecords += getCountFromDb(countQuery, objIds);
     }
 
     Boolean shouldRunAsBatch =
@@ -411,11 +408,9 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     // otherwise, kick off a batch to fetch the calc items and then chain into the regular code path
     SObjectType calcItemType = getSObjectTypeFromName(calcItemSObjectName);
     String countQuery = getQueryString(calcItemType, new List<String>{ 'Count()' }, 'Id', '!=');
-    if(countQuery.contains('ALL ROWS')) {
-      countQuery.replace('ALL ROWS', '');
-    }
-    Set<Id> objIds = new Set<Id>(); // get everything that doesn't have a null Id - a pretty trick
-    Integer amountOfCalcItems = Database.countQuery(countQuery);
+
+    Set<String> objIds = new Set<String>(); // get everything that doesn't have a null Id - a pretty trick
+    Integer amountOfCalcItems = getCountFromDb(countQuery, objIds);
 
     // emptyRollup only used to call "getMaxQueryRows" below
     Rollup emptyRollup = new Rollup(RollupInvocationPoint.FROM_LWC);
@@ -847,15 +842,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     SObjectField countFieldOnOperationObject,
     SObjectType lookupSobjectType
   ) {
-    return countFromApex(
-      countFieldOnCalcItem,
-      lookupFieldOnCalcItem,
-      lookupFieldOnOperationObject,
-      countFieldOnOperationObject,
-      lookupSobjectType,
-      null,
-      null
-    );
+    return countFromApex(countFieldOnCalcItem, lookupFieldOnCalcItem, lookupFieldOnOperationObject, countFieldOnOperationObject, lookupSobjectType, null, null);
   }
 
   global static Rollup countFromApex(
@@ -982,7 +969,6 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     );
   }
 
-
   global static Rollup lastFromApex(
     SObjectField lastFieldOnCalcItem,
     SObjectField lookupFieldOnCalcItem,
@@ -1034,15 +1020,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     SObjectField maxFieldOnOperationObject,
     SObjectType lookupSobjectType
   ) {
-    return maxFromApex(
-      maxFieldOnCalcItem,
-      lookupFieldOnCalcItem,
-      lookupFieldOnOperationObject,
-      maxFieldOnOperationObject,
-      lookupSobjectType,
-      null,
-      null
-    );
+    return maxFromApex(maxFieldOnCalcItem, lookupFieldOnCalcItem, lookupFieldOnOperationObject, maxFieldOnOperationObject, lookupSobjectType, null, null);
   }
 
   global static Rollup maxFromApex(
@@ -1092,15 +1070,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     SObjectField minFieldOnOperationObject,
     SObjectType lookupSobjectType
   ) {
-    return minFromApex(
-      minFieldOnCalcItem,
-      lookupFieldOnCalcItem,
-      lookupFieldOnOperationObject,
-      minFieldOnOperationObject,
-      lookupSobjectType,
-      null,
-      null
-    );
+    return minFromApex(minFieldOnCalcItem, lookupFieldOnCalcItem, lookupFieldOnOperationObject, minFieldOnOperationObject, lookupSobjectType, null, null);
   }
 
   global static Rollup minFromApex(
@@ -1150,15 +1120,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     SObjectField sumFieldOnOpOject,
     SObjectType lookupSobjectType
   ) {
-    return sumFromApex(
-      sumFieldOnCalcItem,
-      lookupFieldOnCalcItem,
-      lookupFieldOnOperationObject,
-      sumFieldOnOpOject,
-      lookupSobjectType,
-      null,
-      null
-    );
+    return sumFromApex(sumFieldOnCalcItem, lookupFieldOnCalcItem, lookupFieldOnOperationObject, sumFieldOnOpOject, lookupSobjectType, null, null);
   }
 
   global static Rollup sumFromApex(
@@ -1347,14 +1309,29 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
   /** end global-facing section, begin public/private static helpers */
 
-  public static String getQueryString(SObjectType sObjectType, List<String> uniqueQueryFieldNames, String lookupFieldOnLookupObject, String equality, String optionalWhereClause) {
+  public static String getQueryString(
+    SObjectType sObjectType,
+    List<String> uniqueQueryFieldNames,
+    String lookupFieldOnLookupObject,
+    String equality,
+    String optionalWhereClause
+  ) {
     // again noting the coupling for consumers of this method
     // "objIds" is required to be present in the scope where the query is run
-    String baseQuery = 'SELECT ' + String.join(uniqueQueryFieldNames, ',') + '\nFROM ' + sObjectType + '\nWHERE ' + lookupFieldOnLookupObject + ' ' + equality + ' :objIds';
-    if(String.isNotBlank(optionalWhereClause)) {
+    String baseQuery =
+      'SELECT ' +
+      String.join(uniqueQueryFieldNames, ',') +
+      '\nFROM ' +
+      sObjectType +
+      '\nWHERE ' +
+      lookupFieldOnLookupObject +
+      ' ' +
+      equality +
+      ' :objIds';
+    if (String.isNotBlank(optionalWhereClause)) {
       baseQuery += optionalWhereClause;
     }
-    if(sObjectType == Task.SObjectType || sObjectType == Event.SObjectType) {
+    if (sObjectType == Task.SObjectType || sObjectType == Event.SObjectType) {
       // handle archived rows
       baseQuery += '\nAND IsDeleted = false ALL ROWS';
     }
@@ -1363,6 +1340,13 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
   public static String getQueryString(SObjectType sObjectType, List<String> uniqueQueryFieldNames, String lookupFieldOnLookupObject, String equality) {
     return getQueryString(sObjectType, uniqueQueryFieldNames, lookupFieldOnLookupObject, equality, null);
+  }
+
+  private static Integer getCountFromDb(String countQuery, Set<String> objIds) {
+    if (countQuery.contains('ALL ROWS')) {
+      countQuery = countQuery.replace('ALL ROWS', '');
+    }
+    return Database.countQuery(countQuery);
   }
 
   private static void flattenBatches(Rollup outerRollup, List<Rollup> rollups) {
@@ -1668,7 +1652,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     // there are multiple spots where testOverrideData can be supplied, which is why it's necessary to pass this value
     if (testOverrideData != null) {
       return testOverrideData;
-    } else if(whereField == RollupControl__mdt.Id) {
+    } else if (whereField == RollupControl__mdt.Id) {
       return RollupControl__mdt.getInstance((Id) whereValue);
     }
     List<RollupControl__mdt> rollupControls = RollupControl__mdt.getAll().values();
@@ -1689,7 +1673,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         DeveloperName = CONTROL_ORG_DEFAULTS,
         MaxLookupRowsBeforeBatching__c = Limits.getLimitDmlRows() / 3,
         MaxLookupRowsForQueueable__c = Limits.getLimitDmlRows() / 2,
-        MaxQueryRows__c = 100,
+        MaxQueryRows__c = Limits.getLimitQueryRows() / 2,
         ShouldAbortRun__c = false,
         ShouldRunAs__c = 'Queueable'
       );
@@ -1720,7 +1704,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     for (Integer index = 0; index < rollups.size(); index++) {
       // for each iteration, ensure we're not operating beyond the bounds of our query limits
       Rollup rollup = rollups[index];
-      if(this.hasExceededCurrentRollupQueryLimit(rollup.rollupControl)) {
+      if (this.hasExceededCurrentRollupQueryLimit(rollup.rollupControl)) {
         this.deferredRollups.add(rollup);
         continue;
       }
@@ -1755,14 +1739,14 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   }
 
   private void processDeferredRollups() {
-    if(this.deferredRollups.isEmpty() == false && isDeferralAllowed && stackDepth < this.rollupControl?.MaxRollupRetries__c) {
+    if (this.deferredRollups.isEmpty() == false && isDeferralAllowed && stackDepth < this.rollupControl?.MaxRollupRetries__c) {
       stackDepth++;
       // tragic, but necessary due to limits on requeueing allowed during testing
       isDeferralAllowed = Test.isRunningTest() == false;
       this.rollups.clear();
       this.rollups.addAll(this.deferredRollups);
       this.deferredRollups.clear();
-      if(System.isBatch()) {
+      if (System.isBatch()) {
         Database.executeBatch(this);
       } else {
         System.enqueueJob(this);

--- a/rollup/main/default/classes/Rollup.cls
+++ b/rollup/main/default/classes/Rollup.cls
@@ -220,6 +220,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   public String runCalc() {
     // clone because the RollupControl__mdt is read-only when retrieved from the cache
     RollupControl__mdt orgDefaults = getSingleControlOrDefault(RollupControl__mdt.DeveloperName, CONTROL_ORG_DEFAULTS, defaultControl).clone(true, true);
+    this.rollupControl = orgDefaults;
     // side effect in the below method - rollups can be removed from this.rollups if a limit record ShouldAbortRun__c == true
     this.ingestRollupControlData(orgDefaults);
 

--- a/rollup/main/default/classes/Rollup.cls
+++ b/rollup/main/default/classes/Rollup.cls
@@ -25,7 +25,6 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   private static Boolean isCDC = false;
 
   private static final String CONTROL_ORG_DEFAULTS = 'Org_Defaults';
-  private static final String LIMIT_INITIALIZED_HERE = 'Sensible_Defaults';
 
   private final List<SObject> calcItems;
   private final Map<Id, SObject> oldCalcItems;
@@ -1332,7 +1331,12 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   public static String getQueryString(SObjectType sObjectType, List<String> uniqueQueryFieldNames, String lookupFieldOnLookupObject, String equality) {
     // again noting the coupling for consumers of this method
     // "objIds" is required to be present in the scope where the query is run
-    return 'SELECT ' + String.join(uniqueQueryFieldNames, ',') + '\nFROM ' + sObjectType + '\nWHERE ' + lookupFieldOnLookupObject + ' ' + equality + ' :objIds';
+    String baseQuery = 'SELECT ' + String.join(uniqueQueryFieldNames, ',') + '\nFROM ' + sObjectType + '\nWHERE ' + lookupFieldOnLookupObject + ' ' + equality + ' :objIds';
+    if(sObjectType == Task.SObjectType || sObjectType == Event.SObjectType) {
+      // handle archived rows
+      baseQuery += ' AND IsDeleted = false ALL ROWS';
+    }
+    return baseQuery;
   }
 
   private static void flattenBatches(Rollup outerRollup, List<Rollup> rollups) {

--- a/rollup/main/default/classes/Rollup.cls
+++ b/rollup/main/default/classes/Rollup.cls
@@ -23,7 +23,8 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   private static Integer maxQueryRowOverride;
 
   private static Boolean isCDC = false;
-
+  private static Boolean isDeferralAllowed = true;
+  private static Integer stackDepth = 0;
   private static final String CONTROL_ORG_DEFAULTS = 'Org_Defaults';
 
   private final List<SObject> calcItems;
@@ -46,6 +47,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   private Boolean isNoOp;
   private Map<SObjectType, Set<String>> lookupObjectToUniqueFieldNames;
   private List<SObject> lookupItems;
+  private RollupControl__mdt rollupControl;
 
   /**
    * receiving an interface/subclass from a property get/set (from the book "The Art Of Unit Testing") is an old technique;
@@ -81,6 +83,16 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         rollups = new List<Rollup>();
       }
       return rollups;
+    }
+    set;
+  }
+
+  private List<Rollup> deferredRollups {
+    get {
+      if (deferredRollups == null) {
+        deferredRollups = new List<Rollup>();
+      }
+      return deferredRollups;
     }
     set;
   }
@@ -238,6 +250,9 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       }
 
       String countQuery = getQueryString(rollup.lookupObj, new List<String>{ 'Count()' }, 'Id', '=');
+      if(countQuery.contains('ALL ROWS')) {
+        countQuery = countQuery.replace('ALL ROWS', '');
+      }
       if (queryCountsToLookupIds.containsKey(countQuery)) {
         queryCountsToLookupIds.get(countQuery).addAll(uniqueLookupFields);
       } else {
@@ -395,6 +410,9 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     // otherwise, kick off a batch to fetch the calc items and then chain into the regular code path
     SObjectType calcItemType = getSObjectTypeFromName(calcItemSObjectName);
     String countQuery = getQueryString(calcItemType, new List<String>{ 'Count()' }, 'Id', '!=');
+    if(countQuery.contains('ALL ROWS')) {
+      countQuery.replace('ALL ROWS', '');
+    }
     Set<Id> objIds = new Set<Id>(); // get everything that doesn't have a null Id - a pretty trick
     Integer amountOfCalcItems = Database.countQuery(countQuery);
 
@@ -1328,15 +1346,22 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
   /** end global-facing section, begin public/private static helpers */
 
-  public static String getQueryString(SObjectType sObjectType, List<String> uniqueQueryFieldNames, String lookupFieldOnLookupObject, String equality) {
+  public static String getQueryString(SObjectType sObjectType, List<String> uniqueQueryFieldNames, String lookupFieldOnLookupObject, String equality, String optionalWhereClause) {
     // again noting the coupling for consumers of this method
     // "objIds" is required to be present in the scope where the query is run
     String baseQuery = 'SELECT ' + String.join(uniqueQueryFieldNames, ',') + '\nFROM ' + sObjectType + '\nWHERE ' + lookupFieldOnLookupObject + ' ' + equality + ' :objIds';
+    if(String.isNotBlank(optionalWhereClause)) {
+      baseQuery += optionalWhereClause;
+    }
     if(sObjectType == Task.SObjectType || sObjectType == Event.SObjectType) {
       // handle archived rows
-      baseQuery += ' AND IsDeleted = false ALL ROWS';
+      baseQuery += '\nAND IsDeleted = false ALL ROWS';
     }
     return baseQuery;
+  }
+
+  public static String getQueryString(SObjectType sObjectType, List<String> uniqueQueryFieldNames, String lookupFieldOnLookupObject, String equality) {
+    return getQueryString(sObjectType, uniqueQueryFieldNames, lookupFieldOnLookupObject, equality, null);
   }
 
   private static void flattenBatches(Rollup outerRollup, List<Rollup> rollups) {
@@ -1642,6 +1667,8 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     // there are multiple spots where testOverrideData can be supplied, which is why it's necessary to pass this value
     if (testOverrideData != null) {
       return testOverrideData;
+    } else if(whereField == RollupControl__mdt.Id) {
+      return RollupControl__mdt.getInstance((Id) whereValue);
     }
     List<RollupControl__mdt> rollupControls = RollupControl__mdt.getAll().values();
     for (RollupControl__mdt rollupControl : rollupControls) {
@@ -1650,10 +1677,10 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       }
     }
 
-    return getSensibleLimitsDefault();
+    return getSensibleControlDefault();
   }
 
-  private static RollupControl__mdt getSensibleLimitsDefault() {
+  private static RollupControl__mdt getSensibleControlDefault() {
     RollupControl__mdt sensibleDefault = RollupControl__mdt.getInstance(CONTROL_ORG_DEFAULTS);
     if (sensibleDefault == null) {
       // this *should* be impossible, since the record is included on install, but ...
@@ -1661,6 +1688,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         DeveloperName = CONTROL_ORG_DEFAULTS,
         MaxLookupRowsBeforeBatching__c = Limits.getLimitDmlRows() / 3,
         MaxLookupRowsForQueueable__c = Limits.getLimitDmlRows() / 2,
+        MaxQueryRows__c = 100,
         ShouldAbortRun__c = false,
         ShouldRunAs__c = 'Queueable'
       );
@@ -1688,7 +1716,13 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   protected void process(List<Rollup> rollups) {
     this.getFieldNamesForRollups(rollups);
     Map<String, SObject> updatedLookupRecords = new Map<String, SObject>();
-    for (Rollup rollup : rollups) {
+    for (Integer index = 0; index < rollups.size(); index++) {
+      // for each iteration, ensure we're not operating beyond the bounds of our query limits
+      Rollup rollup = rollups[index];
+      if(this.hasExceededCurrentRollupQueryLimit(rollup.rollupControl)) {
+        this.deferredRollups.add(rollup);
+        continue;
+      }
       Map<String, List<SObject>> calcItemsByLookupField = this.getCalcItemsByLookupField(rollup);
       List<SObject> lookupItems = new List<SObject>();
       Set<String> lookupItemKeys = new Set<String>(calcItemsByLookupField.keySet());
@@ -1711,6 +1745,28 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     }
 
     DML.doUpdate(updatedLookupRecords.values());
+
+    this.processDeferredRollups();
+  }
+
+  private Boolean hasExceededCurrentRollupQueryLimit(RollupControl__mdt control) {
+    return Limits.getQueries() >= control?.MaxQueryRows__c && isDeferralAllowed;
+  }
+
+  private void processDeferredRollups() {
+    if(this.deferredRollups.isEmpty() == false && isDeferralAllowed && stackDepth < this.rollupControl?.MaxRollupRetries__c) {
+      stackDepth++;
+      // tragic, but necessary due to limits on requeueing allowed during testing
+      isDeferralAllowed = Test.isRunningTest() == false;
+      this.rollups.clear();
+      this.rollups.addAll(this.deferredRollups);
+      this.deferredRollups.clear();
+      if(System.isBatch()) {
+        Database.executeBatch(this);
+      } else {
+        System.enqueueJob(this);
+      }
+    }
   }
 
   private List<SObject> filter(List<SObject> calcItems, Evaluator eval, Rollup__mdt rollupMetadata) {
@@ -1788,6 +1844,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         ? getRollupControlKey(rollup.invokePoint, rollup.opFieldOnCalcItem, rollup.lookupObj, rollup.opFieldOnLookupObject)
         : rollup.rollupControlId;
       RollupControl__mdt rollupSpecificControl = getSingleControlOrDefault(controlWhereField, controlWhereValue, specificControl);
+      rollup.rollupControl = rollupSpecificControl;
 
       if (rollupSpecificControl.ShouldAbortRun__c) {
         this.rollups.remove(index);

--- a/rollup/main/default/classes/RollupCalculator.cls
+++ b/rollup/main/default/classes/RollupCalculator.cls
@@ -328,15 +328,14 @@ public without sharing abstract class RollupCalculator {
     }
 
     protected override Object calculateNewAggregateValue(Rollup.Op op, Set<Id> objIds, SObjectType sObjectType) {
-      Boolean isGroupable = this.opFieldOnCalcItem.getDescribe().isGroupable();
-      List<String> queryFields = new List<String>{ String.valueOf(this.opFieldOnCalcItem) };
       Boolean isArchivable = sObjectType == Task.SObjectType || sObjectType == Event.SObjectType;
-      if (isGroupable && isArchivable == false) {
+      Boolean isGroupable = isArchivable == false && this.opFieldOnCalcItem.getDescribe().isGroupable();
+      List<String> queryFields = new List<String>{ String.valueOf(this.opFieldOnCalcItem) };
+      if (isGroupable) {
         queryFields.add('COUNT(Id)');
       }
       String query =
-        Rollup.getQueryString(sObjectType, queryFields, 'Id', '!=', this.lookupKeyQuery) +
-        (isGroupable && isArchivable == false ? (' GROUP BY ' + this.opFieldOnCalcItem) : '');
+        Rollup.getQueryString(sObjectType, queryFields, 'Id', '!=', this.lookupKeyQuery) + (isGroupable ? (' GROUP BY ' + this.opFieldOnCalcItem) : '');
       List<SObject> results = Database.query(query);
       for (SObject res : results) {
         // have to use the String representation of the this.opFieldOnCalcItem to avoid:

--- a/rollup/main/default/classes/RollupCalculator.cls
+++ b/rollup/main/default/classes/RollupCalculator.cls
@@ -25,113 +25,113 @@ public without sharing abstract class RollupCalculator {
 
   public virtual class Factory {
     public virtual RollupCalculator getCalculator(
-    Object priorVal,
-    Rollup.Op op,
-    SObjectfield opFieldOnCalcItem,
-    SObjectField opFieldOnLookupObject,
-    Rollup__mdt metadata,
-    String lookupRecordKey,
-    SObjectField lookupKeyField
-  ) {
-    if (op.name().contains(Rollup.Op.COUNT_DISTINCT.name())) {
-      return new CountDistinctRollupCalculator(
-        priorVal,
-        op,
-        opFieldOnCalcItem,
-        opFieldOnLookupObject,
-        metadata.FullRecalculationDefaultNumberValue__c,
-        lookupRecordKey,
-        lookupKeyField
-      );
-    } else if (op.name().contains(Rollup.Op.COUNT.name())) {
-      return new CountRollupCalculator(
-        priorVal,
-        op,
-        opFieldOnCalcItem,
-        opFieldOnLookupObject,
-        metadata.FullRecalculationDefaultNumberValue__c,
-        lookupRecordKey,
-        lookupKeyField
-      );
-    } else if (op.name().contains(Rollup.Op.AVERAGE.name())) {
-      return new AverageRollupCalculator(
-        priorVal,
-        op,
-        opFieldOnCalcItem,
-        opFieldOnLookupObject,
-        metadata.FullRecalculationDefaultNumberValue__c,
-        lookupRecordKey,
-        lookupKeyField
-      );
-    } else if (op.name().contains(Rollup.Op.FIRST.name()) || op.name().contains(Rollup.Op.LAST.name())) {
-      FirstLastRollupCalculator firstLastCalc = new FirstLastRollupCalculator(
-        priorVal,
-        op,
-        opFieldOnCalcItem,
-        opFieldOnLookupObject,
-        metadata.FullRecalculationDefaultNumberValue__c,
-        lookupRecordKey,
-        lookupKeyField
-      );
-      firstLastCalc.setOrderByField(metadata);
-      return firstLastCalc;
-    } else if (priorVal instanceof Decimal) {
-      return new DecimalRollupCalculator(
-        priorVal,
-        op,
-        opFieldOnCalcItem,
-        opFieldOnLookupObject,
-        metadata.FullRecalculationDefaultNumberValue__c,
-        lookupRecordKey,
-        lookupKeyField
-      );
-    } else if (priorVal instanceof String) {
-      return new PicklistRollupCalculator(
-        priorVal,
-        op,
-        opFieldOnCalcItem,
-        opFieldOnLookupObject,
-        metadata.FullRecalculationDefaultStringValue__c,
-        lookupRecordKey,
-        lookupKeyField
-      );
-    } else if (priorVal instanceof Date) {
-      // not obvious: the order of these else if's is of supreme importance
-      // Date has to go before Datetime; in the same way that all numbers test true as an instanceof Decimal
-      // all Dates test true as Datetimes ...
-      return new DateRollupCalculator(
-        priorVal,
-        op,
-        opFieldOnCalcItem,
-        opFieldOnLookupObject,
-        metadata.FullRecalculationDefaultNumberValue__c,
-        lookupRecordKey,
-        lookupKeyField
-      );
-    } else if (priorVal instanceof Time) {
-      return new TimeRollupCalculator(
-        priorVal,
-        op,
-        opFieldOnCalcItem,
-        opFieldOnLookupObject,
-        metadata.FullRecalculationDefaultNumberValue__c,
-        lookupRecordKey,
-        lookupKeyField
-      );
-    } else if (priorval instanceof Datetime) {
-      return new DatetimeRollupCalculator(
-        priorVal,
-        op,
-        opFieldOnCalcItem,
-        opFieldOnLookupObject,
-        metadata.FullRecalculationDefaultNumberValue__c,
-        lookupRecordKey,
-        lookupKeyField
-      );
-    } else {
-      throw new IllegalArgumentException('Calculation not defined for: ' + JSON.serialize(priorVal));
+      Object priorVal,
+      Rollup.Op op,
+      SObjectfield opFieldOnCalcItem,
+      SObjectField opFieldOnLookupObject,
+      Rollup__mdt metadata,
+      String lookupRecordKey,
+      SObjectField lookupKeyField
+    ) {
+      if (op.name().contains(Rollup.Op.COUNT_DISTINCT.name())) {
+        return new CountDistinctRollupCalculator(
+          priorVal,
+          op,
+          opFieldOnCalcItem,
+          opFieldOnLookupObject,
+          metadata.FullRecalculationDefaultNumberValue__c,
+          lookupRecordKey,
+          lookupKeyField
+        );
+      } else if (op.name().contains(Rollup.Op.COUNT.name())) {
+        return new CountRollupCalculator(
+          priorVal,
+          op,
+          opFieldOnCalcItem,
+          opFieldOnLookupObject,
+          metadata.FullRecalculationDefaultNumberValue__c,
+          lookupRecordKey,
+          lookupKeyField
+        );
+      } else if (op.name().contains(Rollup.Op.AVERAGE.name())) {
+        return new AverageRollupCalculator(
+          priorVal,
+          op,
+          opFieldOnCalcItem,
+          opFieldOnLookupObject,
+          metadata.FullRecalculationDefaultNumberValue__c,
+          lookupRecordKey,
+          lookupKeyField
+        );
+      } else if (op.name().contains(Rollup.Op.FIRST.name()) || op.name().contains(Rollup.Op.LAST.name())) {
+        FirstLastRollupCalculator firstLastCalc = new FirstLastRollupCalculator(
+          priorVal,
+          op,
+          opFieldOnCalcItem,
+          opFieldOnLookupObject,
+          metadata.FullRecalculationDefaultNumberValue__c,
+          lookupRecordKey,
+          lookupKeyField
+        );
+        firstLastCalc.setOrderByField(metadata);
+        return firstLastCalc;
+      } else if (priorVal instanceof Decimal) {
+        return new DecimalRollupCalculator(
+          priorVal,
+          op,
+          opFieldOnCalcItem,
+          opFieldOnLookupObject,
+          metadata.FullRecalculationDefaultNumberValue__c,
+          lookupRecordKey,
+          lookupKeyField
+        );
+      } else if (priorVal instanceof String) {
+        return new PicklistRollupCalculator(
+          priorVal,
+          op,
+          opFieldOnCalcItem,
+          opFieldOnLookupObject,
+          metadata.FullRecalculationDefaultStringValue__c,
+          lookupRecordKey,
+          lookupKeyField
+        );
+      } else if (priorVal instanceof Date) {
+        // not obvious: the order of these else if's is of supreme importance
+        // Date has to go before Datetime; in the same way that all numbers test true as an instanceof Decimal
+        // all Dates test true as Datetimes ...
+        return new DateRollupCalculator(
+          priorVal,
+          op,
+          opFieldOnCalcItem,
+          opFieldOnLookupObject,
+          metadata.FullRecalculationDefaultNumberValue__c,
+          lookupRecordKey,
+          lookupKeyField
+        );
+      } else if (priorVal instanceof Time) {
+        return new TimeRollupCalculator(
+          priorVal,
+          op,
+          opFieldOnCalcItem,
+          opFieldOnLookupObject,
+          metadata.FullRecalculationDefaultNumberValue__c,
+          lookupRecordKey,
+          lookupKeyField
+        );
+      } else if (priorval instanceof Datetime) {
+        return new DatetimeRollupCalculator(
+          priorVal,
+          op,
+          opFieldOnCalcItem,
+          opFieldOnLookupObject,
+          metadata.FullRecalculationDefaultNumberValue__c,
+          lookupRecordKey,
+          lookupKeyField
+        );
+      } else {
+        throw new IllegalArgumentException('Calculation not defined for: ' + JSON.serialize(priorVal));
+      }
     }
-  }
   }
 
   protected RollupCalculator(
@@ -152,7 +152,7 @@ public without sharing abstract class RollupCalculator {
     } else {
       this.returnVal = priorVal == null ? RollupFieldInitializer.Current.getDefaultValue(opFieldOnLookupObject) : priorVal;
     }
-    this.lookupKeyQuery = ' AND ' + lookupKeyField + ' = \'' + lookupRecordKey + '\'';
+    this.lookupKeyQuery = '\nAND ' + lookupKeyField + ' = \'' + lookupRecordKey + '\'';
   }
   public virtual Object getReturnValue() {
     return this.returnVal;
@@ -259,8 +259,13 @@ public without sharing abstract class RollupCalculator {
   protected virtual Object calculateNewAggregateValue(Rollup.Op op, Set<Id> objIds, SObjectType sObjectType) {
     String operationName = op.name().contains('_') ? op.name().substringAfter('_') : op.name();
     String alias = operationName.toLowerCase() + 'Field';
-    String query =
-      Rollup.getQueryString(sObjectType, new List<String>{ operationName + '(' + this.opFieldOnCalcItem + ')' + alias }, 'Id', '!=') + this.lookupKeyQuery;
+    String query = Rollup.getQueryString(
+      sObjectType,
+      new List<String>{ operationName + '(' + this.opFieldOnCalcItem + ')' + alias },
+      'Id',
+      '!=',
+      this.lookupKeyQuery
+    );
     List<SObject> aggregate = Database.query(query);
     return aggregate.isEmpty() == false ? aggregate[0].get(alias) : null;
   }
@@ -325,13 +330,13 @@ public without sharing abstract class RollupCalculator {
     protected override Object calculateNewAggregateValue(Rollup.Op op, Set<Id> objIds, SObjectType sObjectType) {
       Boolean isGroupable = this.opFieldOnCalcItem.getDescribe().isGroupable();
       List<String> queryFields = new List<String>{ String.valueOf(this.opFieldOnCalcItem) };
-      if (isGroupable) {
+      Boolean isArchivable = sObjectType == Task.SObjectType || sObjectType == Event.SObjectType;
+      if (isGroupable && isArchivable == false) {
         queryFields.add('COUNT(Id)');
       }
       String query =
-        Rollup.getQueryString(sObjectType, queryFields, 'Id', '!=') +
-        this.lookupKeyQuery +
-        (isGroupable ? (' GROUP BY ' + this.opFieldOnCalcItem) : '');
+        Rollup.getQueryString(sObjectType, queryFields, 'Id', '!=', this.lookupKeyQuery) +
+        (isGroupable && isArchivable == false ? (' GROUP BY ' + this.opFieldOnCalcItem) : '');
       List<SObject> results = Database.query(query);
       for (SObject res : results) {
         // have to use the String representation of the this.opFieldOnCalcItem to avoid:
@@ -473,7 +478,7 @@ public without sharing abstract class RollupCalculator {
       } catch (Exception ex) {
         Decimal minOrMax;
         List<SObject> allOtherItems = Database.query(
-          Rollup.getQueryString(sObjectType, new List<String>{ String.valueOf(this.opFieldOnCalcItem) }, 'Id', '!=') + this.lookupKeyQuery
+          Rollup.getQueryString(sObjectType, new List<String>{ String.valueOf(this.opFieldOnCalcItem) }, 'Id', '!=', this.lookupKeyQuery)
         );
         for (SObject otherItem : allOtherItems) {
           Decimal otherItemDate = this.getDecimalOrDefault(otherItem.get(this.opFieldOnCalcItem));
@@ -814,9 +819,9 @@ public without sharing abstract class RollupCalculator {
       // the List isn't strongly typed at this point, otherwise we could avoid this shameful statement
       SObjectType sObjectType = calcItems[0].getSobjectType();
       Set<Id> objIds = new Map<Id, SObject>(calcItems).keySet();
-      Integer countOfPreExistingItems = Database.countQuery(
-        Rollup.getQueryString(sObjectType, new List<String>{ 'Count()' }, 'Id', '!=') + this.lookupKeyQuery
-      );
+      Boolean isArchivable = sObjectType == Task.SObjectType || sObjectType == Event.SObjectType;
+      String query = Rollup.getQueryString(sObjectType, new List<String>{ isArchivable ? 'Id' : 'Count()' }, 'Id', '!=', this.lookupKeyQuery);
+      Integer countOfPreExistingItems = isArchivable ? Database.query(query).size() : Database.countQuery(query);
 
       Decimal oldSum = (Decimal) this.calculateNewAggregateValue(Rollup.Op.SUM, objIds, sObjectType);
       if (oldSum == null) {
@@ -896,25 +901,25 @@ public without sharing abstract class RollupCalculator {
       Object potentialSecondVal = objTwo.get(this.orderByField);
 
       // nulls last
-      if(potentialFirstVal == null && potentialSecondVal != null) {
+      if (potentialFirstVal == null && potentialSecondVal != null) {
         returnVal = this.moveTowardFrontOfList;
-      } else if(potentialSecondVal == null && potentialFirstVal != null) {
+      } else if (potentialSecondVal == null && potentialFirstVal != null) {
         returnVal = this.moveTowardBackOfList;
       } else if (potentialFirstVal == null && potentialSecondVal == null) {
         return returnVal;
       }
 
-      if(potentialFirstVal instanceof Datetime && potentialFirstVal != potentialSecondVal) {
+      if (potentialFirstVal instanceof Datetime && potentialFirstVal != potentialSecondVal) {
         Datetime firstVal = (Datetime) potentialFirstVal;
         Datetime secondVal = (Datetime) potentialSecondVal;
 
         returnVal = firstVal > secondVal ? this.moveTowardFrontOfList : this.moveTowardBackOfList;
-      } else if(potentialFirstVal instanceof String) {
+      } else if (potentialFirstVal instanceof String) {
         String firstVal = (String) potentialFirstVal;
         String secondVal = (String) potentialSecondVal;
 
         returnVal = firstVal > secondVal ? this.moveTowardFrontOfList : this.moveTowardBackOfList;
-      } else if(potentialFirstVal instanceof Decimal) {
+      } else if (potentialFirstVal instanceof Decimal) {
         Decimal firstVal = (Decimal) potentialFirstVal;
         Decimal secondVal = (Decimal) potentialSecondVal;
 

--- a/rollup/main/default/classes/RollupCalculatorTests.cls
+++ b/rollup/main/default/classes/RollupCalculatorTests.cls
@@ -4,6 +4,48 @@ private class RollupCalculatorTests {
 
   /** FIRST / LAST operations */
   @isTest
+  static void shouldReturnDefaultWhenNoCalcItemsFirst() {
+    Rollup__mdt metadata = new Rollup__mdt(OrderByFirstLast__c = 'CloseDate');
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      0,
+      Rollup.Op.FIRST,
+      Opportunity.Amount,
+      Account.AnnualRevenue,
+      metadata,
+      '0011g00003VDGbF002',
+      Account.Id
+    );
+
+    calc.performRollup(
+      new List<Opportunity>(),
+      new Map<Id, SObject>()
+    );
+
+    System.assertEquals(0, (Decimal) calc.getReturnValue());
+  }
+
+  @isTest
+  static void shouldReturnDefaultWhenNoCalcItemsAverage() {
+    Rollup__mdt metadata = new Rollup__mdt();
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      0,
+      Rollup.Op.Average,
+      Opportunity.Amount,
+      Account.AnnualRevenue,
+      metadata,
+      '0011g00003VDGbF002',
+      Account.Id
+    );
+
+    calc.performRollup(
+      new List<Opportunity>(),
+      new Map<Id, SObject>()
+    );
+
+    System.assertEquals(0, (Decimal) calc.getReturnValue());
+  }
+
+  @isTest
   static void shouldReturnFirstValueBasedOnMetadataField() {
     Rollup__mdt metadata = new Rollup__mdt(OrderByFirstLast__c = 'CloseDate');
     RollupCalculator calc = RollupCalculator.Factory.getCalculator(

--- a/rollup/main/default/classes/RollupTests.cls
+++ b/rollup/main/default/classes/RollupTests.cls
@@ -2777,6 +2777,7 @@ private class RollupTests {
   static void shouldRequeueRollupsWhenQueryLimitsExceeded() {
     DMLMock mock = loadAccountIdMock(new List<Opportunity>{ new Opportunity(Amount = 1) });
     Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.defaultControl = new RollupControl__mdt(MaxRollupRetries__c = 100);
     Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = 'Synchronous Rollup', MaxQueryRows__c = 0);
 
     Test.startTest();

--- a/rollup/main/default/classes/RollupTests.cls
+++ b/rollup/main/default/classes/RollupTests.cls
@@ -2749,6 +2749,29 @@ private class RollupTests {
     System.assertEquals(null, updatedOldAcc.AnnualRevenue, 'AVERAGE AFTER_UPDATE should take the diff between the current amount and the pre-existing one');
   }
 
+  /** Queries */
+  @isTest
+  static void shouldQueryAllTasks() {
+    String queryString = Rollup.getQueryString(Task.SObjectType, new List<String>{ 'Id' }, 'WhatId', '=');
+
+    // validate the query
+    Set<String> objIds = new Set<String>();
+    Database.query(queryString);
+
+    System.assertEquals(true, queryString.contains(' AND IsDeleted = false ALL ROWS'));
+  }
+
+  @isTest
+  static void shouldQueryAllEvents() {
+    String queryString = Rollup.getQueryString(Event.SObjectType, new List<String>{ 'Id' }, 'WhatId', '=');
+
+    // validate the query
+    Set<String> objIds = new Set<String>();
+    Database.query(queryString);
+
+    System.assertEquals(true, queryString.contains(' AND IsDeleted = false ALL ROWS'));
+  }
+
   //** Helpers */
 
   private static DMLMock loadAccountIdMock(List<SObject> records) {

--- a/rollup/main/default/classes/RollupTests.cls
+++ b/rollup/main/default/classes/RollupTests.cls
@@ -2591,7 +2591,7 @@ private class RollupTests {
 
   @isTest
   static void shouldCorrectlyReparentWhenBothParentsArePartOfRollup() {
-    // Happy path
+    // Happy path - all items in memory
     Account acc = [SELECT Id FROM Account];
 
     Rollup.defaultControl = new RollupControl__mdt(ShouldAbortRun__c = true);
@@ -2622,7 +2622,7 @@ private class RollupTests {
 
   @isTest
   static void shouldCorrectlyReparentWhenOnlyNewParentIsPartOfRollup() {
-    // Unhappy path
+    // Unhappy path - query for related rows
     Account acc = [SELECT Id FROM Account];
 
     Rollup.defaultControl = new RollupControl__mdt(ShouldAbortRun__c = true);
@@ -2758,7 +2758,7 @@ private class RollupTests {
     Set<String> objIds = new Set<String>();
     Database.query(queryString);
 
-    System.assertEquals(true, queryString.contains(' AND IsDeleted = false ALL ROWS'));
+    System.assertEquals(true, queryString.contains('AND IsDeleted = false ALL ROWS'));
   }
 
   @isTest
@@ -2769,7 +2769,22 @@ private class RollupTests {
     Set<String> objIds = new Set<String>();
     Database.query(queryString);
 
-    System.assertEquals(true, queryString.contains(' AND IsDeleted = false ALL ROWS'));
+    System.assertEquals(true, queryString.contains('AND IsDeleted = false ALL ROWS'));
+  }
+
+  /** Re-queueing */
+  @isTest
+  static void shouldRequeueRollupsWhenQueryLimitsExceeded() {
+    DMLMock mock = loadAccountIdMock(new List<Opportunity>{ new Opportunity(Amount = 1) });
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = 'Synchronous Rollup', MaxQueryRows__c = 0);
+
+    Test.startTest();
+    Rollup.countFromApex(Opportunity.Amount, Opportunity.AccountId, Account.Id, Account.AnnualRevenue, Account.SObjectType).runCalc();
+    Test.stopTest();
+
+    System.assertEquals(1, mock.Records.size(), 'Rollup run should have run');
+    System.assertEquals('Completed', [SELECT Status FROM AsyncApexJob WHERE JobType = 'Queueable' LIMIT 1]?.Status);
   }
 
   //** Helpers */

--- a/rollup/main/default/customMetadata/RollupControl.Org_Defaults.md-meta.xml
+++ b/rollup/main/default/customMetadata/RollupControl.Org_Defaults.md-meta.xml
@@ -11,6 +11,14 @@
         <value xsi:type="xsd:double">5000.0</value>
     </values>
     <values>
+        <field>MaxQueryRows__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>MaxRollupRetries__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
         <field>ShouldAbortRun__c</field>
         <value xsi:type="xsd:boolean">false</value>
     </values>

--- a/rollup/main/default/layouts/RollupControl__mdt-Rollup Control Layout.layout-meta.xml
+++ b/rollup/main/default/layouts/RollupControl__mdt-Rollup Control Layout.layout-meta.xml
@@ -11,24 +11,12 @@
                 <field>MasterLabel</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Required</behavior>
-                <field>DeveloperName</field>
-            </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>MaxLookupRowsBeforeBatching__c</field>
-            </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>MaxLookupRowsForQueueable__c</field>
-            </layoutItems>
-            <layoutItems>
                 <behavior>Edit</behavior>
                 <field>ShouldAbortRun__c</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Required</behavior>
-                <field>ShouldRunAs__c</field>
+                <behavior>Edit</behavior>
+                <field>MaxLookupRowsBeforeBatching__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -37,15 +25,38 @@
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
-                <behavior>Edit</behavior>
-                <field>IsProtected</field>
+                <behavior>Required</behavior>
+                <field>DeveloperName</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Required</behavior>
-                <field>NamespacePrefix</field>
+                <field>ShouldRunAs__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>MaxLookupRowsForQueueable__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>
+    </layoutSections>
+    <layoutSections>
+        <customLabel>true</customLabel>
+        <detailHeading>true</detailHeading>
+        <editHeading>true</editHeading>
+        <label>Scalability</label>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>MaxQueryRows__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>MaxRollupRetries__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <style>TwoColumnsLeftToRight</style>
     </layoutSections>
     <layoutSections>
         <customLabel>false</customLabel>
@@ -57,11 +68,19 @@
                 <behavior>Readonly</behavior>
                 <field>CreatedById</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>IsProtected</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
                 <field>LastModifiedById</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Required</behavior>
+                <field>NamespacePrefix</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>

--- a/rollup/main/default/objects/RollupControl__mdt/fields/MaxQueryRows__c.field-meta.xml
+++ b/rollup/main/default/objects/RollupControl__mdt/fields/MaxQueryRows__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>MaxQueryRows__c</fullName>
+    <defaultValue>100</defaultValue>
+    <description>Configure this number to decide how many queries Rollup is allowed to issue before restarting in another context. Consider the downstream query needs when your parent objects are updated when configuring this field. By safely requeueing Rollup in conjunction with this number, we ensure no query limit is ever hit.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <inlineHelpText>Configure this number to decide how many queries Rollup is allowed to issue before restarting in another context. Consider the downstream query needs when your parent objects are updated when configuring this field</inlineHelpText>
+    <label>Max Query Rows</label>
+    <precision>18</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/rollup/main/default/objects/RollupControl__mdt/fields/MaximumRollupRetries__c.field-meta.xml
+++ b/rollup/main/default/objects/RollupControl__mdt/fields/MaximumRollupRetries__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>MaximumRollupRetries__c</fullName>
+    <defaultValue>100</defaultValue>
+    <description>Use in conjunction with Max Query Rows. This determines the maximum possible rollup jobs (either batched or queued) that can be spawned from a single overall rollup operation. Default is 100.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <inlineHelpText>Use in conjunction with Max Query Rows. This determines the maximum possible rollup jobs (either batched or queued) that can be spawned from a single overall rollup operation. Default is 100.</inlineHelpText>
+    <label>Maximum Rollup Retries</label>
+    <precision>18</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/rollup/main/default/profiles/Admin.profile-meta.xml
+++ b/rollup/main/default/profiles/Admin.profile-meta.xml
@@ -54,6 +54,16 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>RollupControl__mdt.MaxQueryRows__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>RollupControl__mdt.MaxRollupRetries__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>RollupControl__mdt.ShouldAbortRun__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
* Fix #35 by adding ALL ROWS support for Task/Event objects
* Improve scalability by examining current queries issued - add two fields on `RollupControl__mdt`, `MaxQueryRows__c` and `MaxRollupRetries__c` to aid in configuration related to this change