### PR TITLE
V1.1.7 - easier imperative Apex, fix truncation on update

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,11 @@ public static void runFromTrigger()
 // more on that in the CDC section of "Special Considerations", below
 public static void runFromCDCTrigger()
 
+// imperatively from Apex, relying on CMDT for additional rollup info
+global static void runFromApex(List<SObject> calcItems, TriggerOperation rollupContext)
+
+// imperatively from Apex with arguments taking the place of values previously supplied by CMDT
+// can be used in conjunction with "batch" to group rollup operations (as seen in the example preceding this section)
 global static Rollup averageFromApex(
   SObjectField averageFieldOnCalcItem,
   SObjectField lookupFieldOnCalcItem,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/main/default/classes/Rollup.cls
+++ b/rollup/main/default/classes/Rollup.cls
@@ -1307,9 +1307,29 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   }
 
   global static void runFromTrigger() {
-    SObjectType sObjectType = getTriggerRecords().getSObjectType();
-    List<Rollup__mdt> rollupMetadata = getTriggerRollupMetadata(sObjectType);
-    runFromApex(rollupMetadata, null, getTriggerRecords(), getOldTriggerRecordsMap()).runCalc();
+    List<SObject> triggerRecords = getTriggerRecords();
+    List<Rollup__mdt> rollupMetadata = getTriggerRollupMetadata(triggerRecords.getSObjectType());
+    runFromApex(rollupMetadata, null, triggerRecords, getOldTriggerRecordsMap()).runCalc();
+  }
+
+  /**
+   * @param `List<SObject>` calcItems - the records whose values you'd like to roll up
+   * @param `TriggerOperation` rollupContext - acceptable values are:
+   * - TriggerOperation.AFTER_INSERT
+   * - TriggerOperation.AFTER_UDATE
+   * - TriggerOperation.BEFORE_DELETE
+   * - TriggerOperation.AFTER_UNDELETE
+   */
+  global static void runFromApex(List<SObject> calcItems, TriggerOperation rollupContext) {
+    shouldRun = true;
+    records = calcItems;
+    apexContext = rollupContext;
+
+    runFromTrigger();
+
+    records = null;
+    shouldRun = null;
+    apexContext = null;
   }
 
   private static Rollup runFromApex(List<Rollup__mdt> rollupMetadata, Evaluator eval, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
@@ -1675,7 +1695,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   }
 
   private static Boolean shouldRunFromTrigger() {
-    shouldRun = (shouldRun != null && shouldRun) || Trigger.isExecuting;
+    shouldRun = shouldRun || Trigger.isExecuting;
     // in order to accomodate CDC; we set the apexContext manually there
     // since technically all CDC is done from an AFTER_INSERT context
     if (Trigger.operationType != null && isCDC == false) {

--- a/rollup/main/default/classes/Rollup.cls
+++ b/rollup/main/default/classes/Rollup.cls
@@ -1437,14 +1437,14 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
           SELECT
             // we have to do transforms on these fields because custom objects/custom fields
             // have references that otherwise won't work with the rest of the code
-            LookupObject__c, 
+            LookupObject__c,
             LookupObject__r.QualifiedApiName,
-            CalcItem__c, 
+            CalcItem__c,
             CalcItem__r.QualifiedApiName,
             RollupFieldOnCalcItem__c,
             RollupFieldOnCalcItem__r.QualifiedApiName,
-            LookupFieldOnCalcItem__c,         
-            LookupFieldOnCalcItem__r.QualifiedApiName, 
+            LookupFieldOnCalcItem__c,
+            LookupFieldOnCalcItem__r.QualifiedApiName,
             LookupFieldOnLookupObject__c,
             LookupFieldOnLookupObject__r.QualifiedApiName,
             RollupFieldOnLookupObject__c,
@@ -2072,7 +2072,9 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   @testVisible
   private virtual class DMLHelper {
     public virtual void doUpdate(List<SObject> recordsToUpdate) {
-      update recordsToUpdate;
+      Database.DMLOptions dmlOptions = new Database.DMLOptions();
+      dmlOptions.AllowFieldTruncation = true;
+      Database.update(recordsToUpdate, dmlOptions);
     }
   }
 

--- a/rollup/main/default/classes/RollupTests.cls
+++ b/rollup/main/default/classes/RollupTests.cls
@@ -2563,6 +2563,20 @@ private class RollupTests {
   /** Integration tests */
 
   @isTest
+  static void shouldNotFailForTruncatedTextFields() {
+    Account acc = [SELECT Id FROM Account];
+    Opportunity opp = new Opportunity(AccountId = acc.Id, Description = '0'.repeat(256), Name = 'Truncate', StageName = 'Prospecting', CloseDate = System.today());
+    insert opp;
+
+    Test.startTest();
+    Rollup.performFullRecalculation('Description', 'AccountId', 'Id', 'Name', 'Account', 'Opportunity', 'CONCAT', null);
+    Test.stopTest();
+
+    acc = [SELECT Name FROM Account];
+    System.assertEquals(255, acc.Name.length(), acc.Name);
+  }
+
+  @isTest
   static void shouldEnqueueFullRecalculationWhenBelowQueryLimits() {
     Account acc = [SELECT Id FROM Account];
 

--- a/rollup/main/default/classes/RollupTests.cls
+++ b/rollup/main/default/classes/RollupTests.cls
@@ -506,6 +506,36 @@ private class RollupTests {
     System.assertEquals(1, updatedAcc.NumberOfEmployees, 'COUNT_DISTINCT AFTER_INSERT should count regardless of not pointing to a field based on CMDT');
   }
 
+  @isTest
+  static void shouldRunDirectlyFromApex() {
+    Account acc = [SELECT Id FROM Account];
+
+    List<Opportunity> opps = new List<Opportunity>{
+      new Opportunity(AccountId = acc.Id, Amount = 5),
+      new Opportunity(AccountId = acc.Id, Amount = 10)
+    };
+
+    Rollup.records = opps;
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Amount',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'SUM',
+        CalcItem__c = 'Opportunity'
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromApex(opps, TriggerOperation.AFTER_INSERT);
+    Test.stopTest();
+
+    acc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(15, acc.AnnualRevenue);
+  }
+
   /** Parent-initiated rollups */
   @isTest
   static void shouldAllowRollupToBeInitiatedFromTheParent() {


### PR DESCRIPTION
* Fix for #49 by enabling truncation on update
* Fix for #48 by exposing `runFromApex(List<SObject> records, TriggerOperation rollupContext)` method - possible values for the `rollupContext` argument are: 

- TriggerOperation.AFTER_INSERT
- TriggerOperation.AFTER_UDATE
- TriggerOperation.BEFORE_DELETE
- TriggerOperation.AFTER_UNDELETE
