### PR TITLE
V1.2.4 - Adding code coverage for RollupCalculatorTests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -519,10 +519,7 @@ public without sharing abstract class RollupCalculator {
 
     public virtual override Object getReturnValue() {
       Object superReturnVal = super.getReturnValue();
-      if (superReturnVal instanceof Decimal) {
-        return Datetime.newInstance(((Decimal) superReturnVal).longValue());
-      }
-      return superReturnVal;
+      return superReturnVal instanceof Decimal ? Datetime.newInstance(((Decimal) superReturnVal).longValue()) : superReturnVal;
     }
 
     protected virtual override Decimal getDecimalOrDefault(Object potentiallyUnitializedDecimal) {
@@ -613,10 +610,8 @@ public without sharing abstract class RollupCalculator {
         defaultDatetime = Datetime.newInstanceGmt(RollupFieldInitializer.Current.defaultDateTime.dateGmt(), (Time) potentiallyUnitializedDecimal);
       } else if (potentiallyUnitializedDecimal instanceof Decimal) {
         defaultDatetime = Datetime.newInstance(((Decimal) potentiallyUnitializedDecimal).longValue());
-      } else {
-        defaultDatetime = RollupFieldInitializer.Current.defaultDateTime;
       }
-      return defaultDatetime.getTime();
+      return (defaultDatetime != null ? defaultDatetime : RollupFieldInitializer.Current.defaultDateTime).getTime();
     }
   }
 
@@ -662,7 +657,7 @@ public without sharing abstract class RollupCalculator {
   }
 
   private virtual class StringRollupCalculator extends RollupCalculator {
-    // for now, hard-coding to comma here. We may update this to allow for CMDT-based overrides of the delimiter
+    // hard-coding to comma for now. We may update this to allow for CMDT-based overrides of the delimiter at some point
     protected String concatDelimiter = ', ';
     private String stringVal;
     public StringRollupCalculator(
@@ -681,7 +676,7 @@ public without sharing abstract class RollupCalculator {
     protected override void setReturnValue() {
       String trimmedDelimiter = this.concatDelimiter.trim();
       String possibleReturnValue = this.stringVal.normalizeSpace();
-      while(possibleReturnValue.endsWith(trimmedDelimiter)) {
+      while (possibleReturnValue.endsWith(trimmedDelimiter)) {
         possibleReturnValue = possibleReturnValue.substringBeforeLast(trimmedDelimiter).trim();
       }
 
@@ -713,7 +708,7 @@ public without sharing abstract class RollupCalculator {
     public override void handleUpdateConcat(SObject calcItem, Map<Id, SObject> oldCalcItems) {
       Boolean isConcatDistinct = this.op.name().contains(Rollup.Op.CONCAT_DISTINCT.name());
       String newVal = String.valueOf(calcItem.get(this.opFieldOnCalcItem));
-      if(newVal == null) {
+      if (newVal == null) {
         newVal = ''; // this.stringVal.contains throws for null, below
       }
       String priorString = String.valueOf((oldCalcItems.containsKey(calcItem.Id) ? oldCalcItems.get(calcItem.Id).get(this.opFieldOnCalcItem) : newVal));
@@ -724,7 +719,7 @@ public without sharing abstract class RollupCalculator {
 
     public override void handleDeleteConcat(SObject calcItem) {
       String existingVal = String.valueOf(calcItem.get(this.opFieldOnCalcItem));
-      if(existingVal == null) {
+      if (existingVal == null) {
         return;
       }
       this.stringVal = this.replaceWithDelimiter(this.stringVal, existingVal, '');

--- a/rollup/tests/RollupCalculatorTests.cls
+++ b/rollup/tests/RollupCalculatorTests.cls
@@ -142,6 +142,31 @@ private class RollupCalculatorTests {
   }
 
   @isTest
+  static void shouldReturnFirstValueWhenMiddleAndLastAreNull() {
+    Rollup__mdt metadata = new Rollup__mdt(OrderByFirstLast__c = 'CloseDate');
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      0,
+      Rollup.Op.FIRST,
+      Opportunity.Amount,
+      Account.AnnualRevenue,
+      metadata,
+      '0011g00003VDGbF002',
+      Account.Id
+    );
+
+    calc.performRollup(
+      new List<Opportunity>{
+        new Opportunity(Id = '0066g00003VDGbF001', Amount = 1, CloseDate = System.today()),
+        new Opportunity(Id = '0066g00003VDGbF002', Amount = 2),
+        new Opportunity(Id = '0066g00003VDGbF003', Amount = 15)
+      },
+      new Map<Id, SObject>()
+    );
+
+    System.assertEquals(1, (Decimal) calc.getReturnValue());
+  }
+
+  @isTest
   static void shouldReturnLastValueIfOtherOrderByValueIsNull() {
     Rollup__mdt metadata = new Rollup__mdt(OrderByFirstLast__c = 'CloseDate');
     RollupCalculator calc = RollupCalculator.Factory.getCalculator(
@@ -367,27 +392,6 @@ private class RollupCalculatorTests {
 
   @isTest
   static void shouldConcatenateProperlyToMultiSelectPicklist() {
-    Rollup__mdt metadata = new Rollup__mdt();
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
-      '',
-      Rollup.Op.MIN,
-      QuickText.Channel,
-      Opportunity.Name,
-      metadata,
-      Opportunity.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12),
-      QuickText.Name
-    );
-
-    calc.performRollup(
-      new List<QuickText>{ new QuickText(Channel = 'A;C'), new QuickText(Channel = 'A;B'), new QuickText(Channel = 'A;B;C'), new QuickText(Channel = 'B;A') },
-      new Map<Id, SObject>()
-    );
-
-    System.assert(false, calc.getReturnValue());
-  }
-
-  @isTest
-  static void shouldMinOnMultiSelectPicklist() {
     RollupCalculator calc = RollupCalculator.Factory.getCalculator(
       '',
       Rollup.Op.CONCAT,
@@ -407,6 +411,38 @@ private class RollupCalculatorTests {
       },
       new Map<Id, SObject>()
     );
+
+    System.assertEquals('Hello;World, I know;And;SSK', (String) calc.getReturnValue(), 'Multi-select should use ; to concat');
+  }
+
+  @isTest
+  static void shouldMinOnMultiSelectPicklist() {
+    Rollup__mdt metadata = new Rollup__mdt();
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      '',
+      Rollup.Op.MIN,
+      QuickText.Channel,
+      Opportunity.Name,
+      metadata,
+      Opportunity.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12),
+      QuickText.Name
+    );
+
+    List<Schema.PicklistEntry> picklistVals = QuickText.Channel.getDescribe().getPicklistValues();
+    if (picklistVals.size() < 3) {
+      return;
+    }
+
+    String firstVal = picklistVals[0].getValue();
+    String secondVal = picklistVals[1].getValue();
+    String thirdVal = picklistVals[2].getValue();
+
+    calc.performRollup(
+      new List<QuickText>{ new QuickText(Channel = firstVal + ';' + secondVal), new QuickText(Channel = secondVal + ';' + thirdVal) },
+      new Map<Id, SObject>()
+    );
+
+    System.assertEquals(firstVal + ';' + secondVal, calc.getReturnValue(), 'Min should take first entries for multi-select picklists');
   }
 
   // MIN / MAX

--- a/rollup/tests/RollupCalculatorTests.cls
+++ b/rollup/tests/RollupCalculatorTests.cls
@@ -290,6 +290,31 @@ private class RollupCalculatorTests {
     System.assertEquals(16, (Decimal) calc.getReturnValue());
   }
 
+  @isTest
+  static void regressionShouldRollupFirstLastWithQueriedOrderBy() {
+    Rollup__mdt metadata = new Rollup__mdt(OrderByFirstLast__c = 'Name');
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      0,
+      Rollup.Op.FIRST,
+      Opportunity.Amount,
+      Account.AnnualRevenue,
+      metadata,
+      '0011g00003VDGbF002',
+      Account.Id
+    );
+
+    calc.performRollup(
+      new List<Opportunity>{
+        new Opportunity(Id = '0066g00003VDGbF001', Amount = 2, Name = 'b'),
+        new Opportunity(Id = '0066g00003VDGbF002', Amount = 16, Name = 'a'),
+        new Opportunity(Id = '0066g00003VDGbF003', Amount = 1, Name = 'c')
+      },
+      new Map<Id, SObject>()
+    );
+
+    System.assertEquals(16, (Decimal) calc.getReturnValue());
+  }
+
   // AVERAGE tests
 
   @isTest
@@ -302,7 +327,7 @@ private class RollupCalculatorTests {
       Account.AnnualRevenue,
       metadata,
       '0011g00003VDGbF002',
-      Account.Id
+      Opportunity.Id
     );
 
     calc.performRollup(
@@ -318,6 +343,26 @@ private class RollupCalculatorTests {
     System.assertEquals(1, (Decimal) calc.getReturnValue(), 'Nulls should be treated as zeros for average!');
   }
 
+  // COUNT tests
+
+  @isTest
+  static void shouldReturnNewValOnCountChangeIfReparenting() {
+    Rollup__mdt metadata = new Rollup__mdt();
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      0,
+      Rollup.Op.UPDATE_COUNT,
+      Opportunity.Amount,
+      Account.AnnualRevenue,
+      metadata,
+      '0011g00003VDGbF002',
+      Opportunity.Id
+    );
+    Opportunity opp = new Opportunity(Id = '0066g00003VDGbF001', Amount = 2, AccountId = '0016g00003VDGbF001');
+    calc.performRollup(new List<Opportunity>{ opp }, new Map<Id, SObject>{ opp.Id => new Opportunity(AccountId = '0016g00003VDGbF002', Amount = 1) });
+
+    System.assertEquals(opp.Amount, (Decimal) calc.getReturnValue(), 'New value should be returned on reparenting update!');
+  }
+
   // PICKLIST tests
 
   @isTest
@@ -325,10 +370,30 @@ private class RollupCalculatorTests {
     Rollup__mdt metadata = new Rollup__mdt();
     RollupCalculator calc = RollupCalculator.Factory.getCalculator(
       '',
+      Rollup.Op.MIN,
+      QuickText.Channel,
+      Opportunity.Name,
+      metadata,
+      Opportunity.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12),
+      QuickText.Name
+    );
+
+    calc.performRollup(
+      new List<QuickText>{ new QuickText(Channel = 'A;C'), new QuickText(Channel = 'A;B'), new QuickText(Channel = 'A;B;C'), new QuickText(Channel = 'B;A') },
+      new Map<Id, SObject>()
+    );
+
+    System.assert(false, calc.getReturnValue());
+  }
+
+  @isTest
+  static void shouldMinOnMultiSelectPicklist() {
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      '',
       Rollup.Op.CONCAT,
       Opportunity.Name,
       QuickText.Channel,
-      metadata,
+      new Rollup__mdt(),
       QuickText.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12),
       QuickText.Name
     );
@@ -342,7 +407,112 @@ private class RollupCalculatorTests {
       },
       new Map<Id, SObject>()
     );
+  }
 
-    System.assertEquals('Hello;World, I know;And;SSK', (String) calc.getReturnValue(), 'Multi-select should use ; to concat');
+  // MIN / MAX
+
+  @isTest
+  static void shouldDefaultToMaxNumberOnMinIfNoMatchingItems() {
+    Rollup__mdt metadata = new Rollup__mdt();
+    Date today = System.today();
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      today,
+      Rollup.Op.UPDATE_MIN,
+      Task.ActivityDate, // not a "MIN"-able field in SOQL; crucial for this test
+      QuickText.Channel,
+      metadata,
+      QuickText.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12),
+      Task.WhatId
+    );
+
+    // the important things here: the current date is greater than both the passed in date (the "current" value on the lookup object)
+    // AND that the "current" value matches what's on the old item
+    Task t = new Task(ActivityDate = today.addDays(1), Id = Task.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12));
+
+    calc.performRollup(new List<Task>{ t }, new Map<Id, SObject>{ t.Id => new Task(ActivityDate = today) });
+
+    Datetime expectedDt = Datetime.newInstance(RollupFieldInitializer.Current.maximumLongValue);
+
+    System.assertEquals(
+      Datetime.newInstanceGmt(expectedDt.yearGmt(), expectedDt.monthGmt(), expectedDt.dayGmt(), 0, 0, 0),
+      calc.getReturnValue(),
+      'Should have hours/minutes/seconds lopped off since we are operating on a Date field'
+    );
+  }
+
+  @isTest
+  static void shouldDefaultToMinNumberOnMaxIfNoMatchingItems() {
+    Rollup__mdt metadata = new Rollup__mdt();
+    Date today = System.today();
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      today,
+      Rollup.Op.UPDATE_MAX,
+      Task.ActivityDate, // not a "MAX"-able field in SOQL; crucial for this test
+      QuickText.Channel,
+      metadata,
+      QuickText.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12),
+      Task.WhatId
+    );
+
+    // the important things here: the current date is less than both the passed in date (the "current" value on the lookup object)
+    // AND that the "current" value matches what's on the old item
+    Task t = new Task(ActivityDate = today.addDays(-1), Id = Task.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12));
+
+    calc.performRollup(new List<Task>{ t }, new Map<Id, SObject>{ t.Id => new Task(ActivityDate = today) });
+
+    Datetime expectedDt = Datetime.newInstance(RollupFieldInitializer.Current.minimumLongValue);
+
+    System.assertEquals(
+      Datetime.newInstanceGmt(expectedDt.yearGmt(), expectedDt.monthGmt(), expectedDt.dayGmt(), 0, 0, 0),
+      calc.getReturnValue(),
+      'Should have hours/minutes/seconds lopped off since we are operating on a Date field'
+    );
+  }
+
+  // Factory tests
+
+  @isTest
+  static void shouldThrowExceptionIfTypeNotSupported() {
+    Exception ex;
+
+    try {
+      RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+        Blob.valueOf(''), // unsupported type
+        Rollup.Op.CONCAT,
+        Opportunity.Name,
+        QuickText.Channel,
+        new Rollup__mdt(),
+        QuickText.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12),
+        QuickText.Name
+      );
+    } catch (Exception e) {
+      ex = e;
+    }
+
+    System.assertNotEquals(null, ex, 'Exception should have been thrown');
+  }
+
+  @isTest
+  static void shouldInvokeNoOpMethodsWithoutFail() {
+    RollupCalculator calc = new RollupCalcEmptyMock();
+    calc.handleCountDistinct(null);
+    calc.handleUpdateCountDistinct(null, null);
+    calc.handleSumOrCount(null);
+    calc.handleUpdateSumOrCount(null, null);
+    calc.handleDeleteSumOrCount(null);
+    calc.handleMin(null);
+    calc.handleMax(null);
+    calc.handleUpdateMinOrMax(null, null);
+    calc.handleConcat(null);
+    calc.handleUpdateConcat(null, null);
+    calc.handleDeleteConcat(null);
+
+    System.assert(true, 'Should make it here');
+  }
+
+  private class RollupCalcEmptyMock extends RollupCalculator {
+    public RollupCalcEmptyMock() {
+      super(0, Rollup.Op.LAST, null, null, null, null, null);
+    }
   }
 }

--- a/rollup/tests/RollupTests.cls
+++ b/rollup/tests/RollupTests.cls
@@ -1483,43 +1483,6 @@ private class RollupTests {
   }
 
   @isTest
-  static void shouldRollupFirstLastWithQueriedOrderBy() {
-    Account acc = [SELECT Id FROM Account];
-    Opportunity opp = new Opportunity(CloseDate = System.today(), Name = 'QueriedOrderBy', Amount = 10, AccountId = acc.Id, StageName = 'Order By');
-    Opportunity secondOpp = opp.clone();
-    secondOpp.Name = 'ZZZZZZZ';
-    List<Opportunity> opps = new List<Opportunity>{ opp, secondOpp };
-    insert opps;
-
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'Amount',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'AccountId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'FIRST',
-        CalcItem__c = 'Opportunity',
-        OrderByFirstLast__c = 'Name'
-      )
-    };
-    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-
-    Rollup.records = opps;
-    Rollup.shouldRun = true;
-    DMLMock mock = new DMLMock();
-    Rollup.DML = mock;
-
-    Test.startTest();
-    Rollup.runFromTrigger();
-    Test.stopTest();
-
-    System.assertEquals(1, mock.Records.size(), 'Records should have been populated FIRST AFTER_INSERT');
-    Account updatedAcc = (Account) mock.Records[0];
-    System.assertEquals(opp.Amount, updatedAcc.AnnualRevenue, 'FIRST AFTER_INSERT should correctly order by!');
-  }
-
-  @isTest
   static void shouldPassRecalcValueForAverage() {
     RollupCalculator.Factory = new FactoryMock();
     loadAccountIdMock(new List<Opportunity>{ new Opportunity(Amount = 5) });


### PR DESCRIPTION
* Cleanup from #64 - moved added test over to `RollupCalculatorTests`
* Used codecov to guide adding additional test coverage