### PR TITLE
Added Apex script to convert DLRS rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ While you can still enable/disable individual rollups from running with the use 
 - ease of installation/upgrade. Previously some users had issues when installing/upgrading due to pre-existing automation in their orgs interfering with the `Rollup` tests
 - granularity of control. Want to disable rollups from running for a specific user or profile? Easy as pie!
 
+If you are converting from DLRS to Rollup, you can automatically convert all of your DLRS rules using the included Apex script [scripts/convert-dlrs-rules.apex](scripts/convert-dlrs-rules.apex). Simply run this script in your org, and all DLRS rules (stored in `dlrs__LookupRollupSummary2__mdt`) will be converted to `Rollup__mdt` records and automatically deployed to the current org.
+
 ## Usage
 
 You have several different options when it comes to making use of `Rollup`:

--- a/scripts/convert-dlrs-rules.apex
+++ b/scripts/convert-dlrs-rules.apex
@@ -1,4 +1,4 @@
-// This script converts any DLRS rules (stored in dlrs__LookupRollupSummary2__mdt) to Rollup__mdt records and deploys them to the current org
+// This script converts all DLRS rules (stored in dlrs__LookupRollupSummary2__mdt) to Rollup__mdt records and deploys them to the current org
 
 // Use the org defaults for all converted rules
 static final RollupControl__mdt ROLLUP_CONTROL = [SELECT Id, DeveloperName FROM RollupControl__mdt WHERE DeveloperName = 'Org_Defaults'];
@@ -12,12 +12,28 @@ for (dlrs__LookupRollupSummary2__mdt dlrsRule : dlrs__LookupRollupSummary2__mdt.
   customMetadata.fullName = customMetadataTypePrefix + '.' + dlrsRule.get('DeveloperName');
   customMetadata.label = (String) dlrsRule.get('MasterLabel');
 
+  String operation;
+  switch on dlrsRule.dlrs__AggregateOperation__c {
+    when 'Concatenate' {
+      operation = 'CONCAT';
+    }
+    when 'Concatenate Distinct' {
+      operation = 'CONCAT_DISTINCT';
+    }
+    when 'Count Distinct' {
+      operation = 'COUNT_DISTINCT';
+    }
+    when else {
+      operation = dlrsRule.dlrs__AggregateOperation__c;
+    }
+  }
+
   // This code uses instances of Metadata.CustomMetadataValue for the deployment - not instances of Rollup__mdt
   // So, use a map & field tokens to store the expected values - Salesforce will store the data as Rollup__mdt records when deployed
   Map<String, Object> fieldValuesToCopy = new Map<String, Object>{
     Schema.Rollup__mdt.CalcItem__c.getDescribe().getName() => dlrsRule.dlrs__ChildObject__c,
     Schema.Rollup__mdt.CalcItemWhereClause__c.getDescribe().getName() => dlrsRule.dlrs__RelationshipCriteria__c,
-    Schema.Rollup__mdt.ConcatDelimiter__c.getDescribe().getName() => dlrsRule.dlrs__ConcatenateDelimiter__c,
+    Schema.Rollup__mdt.ConcatDelimiter__c.getDescribe().getName() => operation.startsWith('CONCAT') ? dlrsRule.dlrs__ConcatenateDelimiter__c : null,
     Schema.Rollup__mdt.LookupFieldOnCalcItem__c.getDescribe().getName() => dlrsRule.dlrs__RelationshipField__c,
     Schema.Rollup__mdt.LookupFieldOnLookupObject__c.getDescribe().getName() => 'Id',
     Schema.Rollup__mdt.LookupObject__c.getDescribe().getName() => dlrsRule.dlrs__ParentObject__c,
@@ -25,7 +41,7 @@ for (dlrs__LookupRollupSummary2__mdt dlrsRule : dlrs__LookupRollupSummary2__mdt.
     Schema.Rollup__mdt.RollupControl__c.getDescribe().getName() => ROLLUP_CONTROL.DeveloperName,
     Schema.Rollup__mdt.RollupFieldOnCalcItem__c.getDescribe().getName() => dlrsRule.dlrs__FieldToAggregate__c,
     Schema.Rollup__mdt.RollupFieldOnLookupObject__c.getDescribe().getName() => dlrsRule.dlrs__AggregateResultField__c,
-    Schema.Rollup__mdt.RollupOperation__c.getDescribe().getName() => dlrsRule.dlrs__AggregateOperation__c
+    Schema.Rollup__mdt.RollupOperation__c.getDescribe().getName() => operation.toUpperCase()
 
     // Additional DLRS fields that are not supported/used by Rollup
     // dlrs__Active__c

--- a/scripts/convert-dlrs-rules.apex
+++ b/scripts/convert-dlrs-rules.apex
@@ -1,0 +1,61 @@
+// This script converts any DLRS rules (stored in dlrs__LookupRollupSummary2__mdt) to Rollup__mdt records and deploys them to the current org
+
+// Use the org defaults for all converted rules
+static final RollupControl__mdt ROLLUP_CONTROL = [SELECT Id, DeveloperName FROM RollupControl__mdt WHERE DeveloperName = 'Org_Defaults'];
+
+// Prepare the converted Rollup__mdt CMDT records for deployment
+String customMetadataTypePrefix = Schema.Rollup__mdt.SObjectType.getDescribe().getName().replace('__mdt', '');
+Metadata.DeployContainer deployment = new Metadata.DeployContainer();
+for (dlrs__LookupRollupSummary2__mdt dlrsRule : dlrs__LookupRollupSummary2__mdt.getAll().values()) {
+
+  Metadata.CustomMetadata customMetadata = new Metadata.CustomMetadata();
+  customMetadata.fullName = customMetadataTypePrefix + '.' + dlrsRule.get('DeveloperName');
+  customMetadata.label = (String) dlrsRule.get('MasterLabel');
+
+  // This code uses instances of Metadata.CustomMetadataValue for the deployment - not instances of Rollup__mdt
+  // So, use a map & field tokens to store the expected values - Salesforce will store the data as Rollup__mdt records when deployed
+  Map<String, Object> fieldValuesToCopy = new Map<String, Object>{
+    Schema.Rollup__mdt.CalcItem__c.getDescribe().getName() => dlrsRule.dlrs__ChildObject__c,
+    Schema.Rollup__mdt.CalcItemWhereClause__c.getDescribe().getName() => dlrsRule.dlrs__RelationshipCriteria__c,
+    Schema.Rollup__mdt.ConcatDelimiter__c.getDescribe().getName() => dlrsRule.dlrs__ConcatenateDelimiter__c,
+    Schema.Rollup__mdt.LookupFieldOnCalcItem__c.getDescribe().getName() => dlrsRule.dlrs__RelationshipField__c,
+    Schema.Rollup__mdt.LookupFieldOnLookupObject__c.getDescribe().getName() => 'Id',
+    Schema.Rollup__mdt.LookupObject__c.getDescribe().getName() => dlrsRule.dlrs__ParentObject__c,
+    Schema.Rollup__mdt.OrderByFirstLast__c.getDescribe().getName() => dlrsRule.dlrs__FieldToOrderBy__c,
+    Schema.Rollup__mdt.RollupControl__c.getDescribe().getName() => ROLLUP_CONTROL.DeveloperName,
+    Schema.Rollup__mdt.RollupFieldOnCalcItem__c.getDescribe().getName() => dlrsRule.dlrs__FieldToAggregate__c,
+    Schema.Rollup__mdt.RollupFieldOnLookupObject__c.getDescribe().getName() => dlrsRule.dlrs__AggregateResultField__c,
+    Schema.Rollup__mdt.RollupOperation__c.getDescribe().getName() => dlrsRule.dlrs__AggregateOperation__c
+
+    // Additional DLRS fields that are not supported/used by Rollup
+    // dlrs__Active__c
+    // dlrs__AggregateAllRows__c
+    // dlrs__CalculationMode__c
+    // dlrs__CalculationSharingMode__c
+    // dlrs__Description__c
+    // dlrs__RelationshipCriteriaFields__c
+    // dlrs__RowLimit__c
+    // dlrs__TestCode__c
+    // dlrs__TestCode2__c
+    // dlrs__TestCodeParent__c
+    // dlrs__TestCodeSeeAllData__c
+  };
+
+  // Create the instance of Metadata.CustomMetadataValue for the current DLRS rule
+  for (String fieldName : fieldValuesToCopy.keySet()) {
+    Metadata.CustomMetadataValue customField = new Metadata.CustomMetadataValue();
+    customField.field = fieldName;
+    customField.value = fieldValuesToCopy.get(fieldName);
+
+    customMetadata.values.add(customField);
+  }
+
+  System.debug(LoggingLevel.INFO, 'customMetadata==' + JSON.serialize(customMetadata));
+
+  deployment.addMetadata(customMetadata);
+}
+
+// Deploy the converted Rollup__mdt CMDT records - these will be treated like an upsert based on DeveloperName
+System.debug('Deployment metadata==' + JSON.serialize(deployment));
+Id jobId = Metadata.Operations.enqueueDeployment(deployment, null);
+System.debug('Deployment Job ID: ' + jobId);

--- a/scripts/convert-dlrs-rules.apex
+++ b/scripts/convert-dlrs-rules.apex
@@ -66,12 +66,10 @@ for (dlrs__LookupRollupSummary2__mdt dlrsRule : dlrs__LookupRollupSummary2__mdt.
     customMetadata.values.add(customField);
   }
 
-  System.debug(LoggingLevel.INFO, 'customMetadata==' + JSON.serialize(customMetadata));
-
   deployment.addMetadata(customMetadata);
 }
 
 // Deploy the converted Rollup__mdt CMDT records - these will be treated like an upsert based on DeveloperName
-System.debug('Deployment metadata==' + JSON.serialize(deployment));
+System.debug(LoggingLevel.INFO, 'Deployment metadata==' + JSON.serialize(deployment));
 Id jobId = Metadata.Operations.enqueueDeployment(deployment, null);
-System.debug('Deployment Job ID: ' + jobId);
+System.debug(LoggingLevel.INFO, 'Deployment Job ID: ' + jobId);


### PR DESCRIPTION
Closes #84 by adding an Apex script, `scripts/convert-dlrs-rules.apex` - this can be run as anonymous Apex in an org to convert all DLRS rules to Rollup rules.

Originally, I was going to make this an Apex class - but that would require both deploying the class, as well as deleting the class, before DLRS could be uninstalled, which seemed like additional work for admins/devs. Additionally, Salesforce does not provide great options for testing or mocking the deployment logic, so there's not really any benefits to having it as an Apex class - a script will be more convenient. I've tested this using several different types of DLRS rules to try to cover all of the differences in DLRS rules vs Rollup rules.

I also considered adding logic to deactivate the converted DLRS rules, but decided against that for now - however, that means that after running this script, the org will have both DLRS and Rollup rules configured for the same rollup logic & fields. My assumption is that admins/devs would convert DLRS rules and then handle deactivating DLRS rules and/or uninstalling DLRS entirely.