### PR TITLE
V1.2.15 - Automate build pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,3 +84,4 @@ jobs:
         run: '. ./scripts/build-and-promote-package.ps1'
         env:
           SHOULD_CREATE_AND_PROMOTE: ${{ secrets.SHOULD_CREATE_AND_PROMOTE }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,9 +61,12 @@ jobs:
       # Store secret for dev hub
       - name: 'Populate auth file with DEVHUB_SFDX_URL secret'
         shell: bash
-        run: 'echo ${{ env.DEVHUB_SFDX_URL }} > ./DEVHUB_SFDX_URL.txt'
+        run: |
+         echo ${{ env.DEVHUB_SFDX_URL }} > ./DEVHUB_SFDX_URL.txt
+         echo ${{ env.PACKAGING_SFDX_URL }} > ./PACKAGING_SFDX_URL.txt
         env:
           DEVHUB_SFDX_URL: ${{ secrets.DEVHUB_SFDX_URL }}
+          PACKAGING_SFDX_URL: ${{ secrets.PACKAGING_SFDX_URL }}
 
       - name: 'Deploy & Test'
         shell: pwsh
@@ -74,3 +77,10 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: 'Package & Promote'
+        shell: pwsh
+        if: ${{ env.SHOULD_CREATE_AND_PROMOTE == '1' }}
+        run: '. ./scripts/build-and-promote-package.ps1'
+        env:
+          SHOULD_CREATE_AND_PROMOTE: ${{ secrets.SHOULD_CREATE_AND_PROMOTE }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ yarn.lock
 .localdevserver/
 debug.log
 DEVHUB_SFDX_URL.txt
+PACKAGING_SFDX_URL.txt
 tests/apex
 main/default/

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Create fast, scalable custom rollups driven by Custom Metadata in your Salesforc
 
 ### Package deployment options
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008GJlWAAW">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008GJlbAAG">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008GJlWAAW">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008GJlbAAG">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Create fast, scalable custom rollups driven by Custom Metadata in your Salesforc
 
 ### Package deployment options
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008GJjQAAW">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008GJlWAAW">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008GJjQAAW">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008GJlWAAW">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-sandbox.png">
 </a>
@@ -151,7 +151,7 @@ These are the fields on the `Rollup Control` custom metadata type:
 - `Should Abort Run` - if done at the `Org_Defaults` level, completely shuts down all rollup operations in the org. Otherwise, can be used on an individual rollup basis to turn on/off.
 - `Should Run As` - a picklist dictating the preferred method for running rollup operations. Possible values are `Queueable`, `Batchable`, or `Synchronous Rollup`.
 - `Trigger Or Invocable Name` - If you are using custom Apex, a schedulable, or rolling up by way of the Invocable action and can't use the `Rollup` lookup field. Use the pattern `trigger_fieldOnCalcItem_to_rollupFieldOnTarget_rollup` - for example: 'trigger_opportunity_stagename_to_account_name_rollup' (use lowercase on the field names). If there is a matching Rollup Limit record, those rules will be used. The first part of the string comes from how a rollup has been invoked - either by `trigger`, `invocable`, or `schedule`. A scheduled flow still uses `invocable`!
-- `Max Query Rows` - (defaults to 100) - Configure this number to decide how many queries Rollup is allowed to issue before restarting in another context. Consider the downstream query needs when your parent objects are updated when configuring this field. By safely requeueing Rollup in conjunction with this number, we ensure no query limit is ever hit.
+- `Max Number Of Queries` - (defaults to 50) - Configure this number to decide how many queries Rollup is allowed to issue before restarting in another context. Consider the downstream query needs when your parent objects are updated when configuring this field. By safely requeueing Rollup in conjunction with this number, we ensure no query limit is ever hit.
 - `Max Rollup Retries` - (defaults to 100) - Only configurable on the Org Default record. Use in conjunction with `Max Query Rows`. This determines the maximum possible rollup jobs (either batched or queued) that can be spawned from a single overall rollup operation due to the prior one(s) exceeding the configured query limit.
 - `Batch Chunk Size` - (defaults to 2000) - The amount of records passed into each batchable job in the event that Rollup batches. Default is 2000, which is the vanilla Salesforce default for batch jobs.
 

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -213,7 +213,7 @@ private class RollupIntegrationTests {
     insert appLogs;
 
     RollupRelationshipFieldFinder finder = new RollupRelationshipFieldFinder(
-      new RollupControl__mdt(MaxQueryRows__c = 1000),
+      new RollupControl__mdt(MaxLookupRowsBeforeBatching__c = 1000),
       new Rollup__mdt(GrandparentRelationshipFieldPath__c = 'Application__r.ParentApplication__r.Account__r.Name'),
       new Set<String>{ 'Id', 'Name' },
       Account.SObjectType,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.2.10",
+  "version": "1.2.15",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -43,15 +43,16 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   private final SObjectField opFieldOnLookupObject;
   private final SObjectType lookupObj;
   private final Op op;
-  private final Evaluator eval;
   private final Boolean isBatched;
   private final Id rollupControlId;
   private final Rollup__mdt metadata;
 
+  protected final SObjectType calcItemType;
   protected final RollupInvocationPoint invokePoint;
 
   // non-final instance variables
-  private Boolean isFullRecalc = false;
+  protected Boolean isFullRecalc = false;
+  private Evaluator eval;
   private Boolean isCDCUpdate = false;
   private Boolean isNoOp;
   private Map<SObjectType, Set<String>> lookupObjectToUniqueFieldNames;
@@ -153,6 +154,11 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     DELETE_LAST
   }
 
+  private class FilterResults {
+    public List<SObject> matchingItems { get; set; }
+    public Evaluator eval { get; set; }
+  }
+
   public enum RollupInvocationPoint {
     FROM_APEX,
     FROM_INVOCABLE,
@@ -176,9 +182,10 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       innerRollup.lookupFieldOnLookupObject,
       innerRollup.opFieldOnLookupObject,
       innerRollup.lookupObj,
+      innerRollup.calcItemType,
       op,
       innerRollup.oldCalcItems,
-      innerRollup.eval,
+      null, // eval gets assigned later
       innerRollup.invokePoint,
       innerRollup.rollupControlId,
       innerRollup.metadata
@@ -189,6 +196,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     this.isFullRecalc = innerRollup.isFullRecalc;
     this.isCDCUpdate = innerRollup.isCDCUpdate;
     this.rollupControl = innerRollup.rollupControl;
+    this.eval = innerRollup.eval;
   }
 
   private Rollup(Rollup innerRollup) {
@@ -202,6 +210,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     SObjectField lookupFieldOnLookupObject,
     SObjectField opFieldOnLookupObject,
     SObjectType lookupObj,
+    SObjectType calcItemType,
     Op op,
     Map<Id, SObject> oldCalcItems,
     Evaluator eval,
@@ -214,19 +223,18 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     this.lookupFieldOnLookupObject = lookupFieldOnLookupObject;
     this.opFieldOnLookupObject = opFieldOnLookupObject;
     this.lookupObj = lookupObj;
+    this.calcItemType = calcItemType;
     this.op = op;
     this.oldCalcItems = oldCalcItems;
     this.isBatched = false;
     this.invokePoint = invokePoint;
     this.rollupControlId = rollupControlId;
     this.metadata = rollupMetadata;
-    this.calcItems = this.filter(calcItems, eval);
-    // we only need to replace the eval in-situ if downstream calc item where clauses have been updated
-    if (this.calcItems.isEmpty() == false && rollupMetadata.CalcItemWhereClause__c != this.metadata.CalcItemWhereClause__c) {
-      this.eval = RollupEvaluator.getEvaluator(eval, this.metadata, oldCalcItems, this.calcItems.getSObjectType());
-    } else {
-      this.eval = eval;
-    }
+
+    FilterResults results = this.filter(calcItems, eval);
+    this.calcItems = results.matchingItems;
+    this.eval = results.eval;
+
     this.isNoOp = this.calcItems.isEmpty() && this.metadata?.IsFullRecordSet__c == false;
   }
 
@@ -348,6 +356,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       SObjectField lookupFieldOnLookupObject,
       SObjectField opFieldOnLookupObject,
       SObjectType lookupObj,
+      SObjectType calcItem,
       Op operation,
       Map<Id, SObject> oldCalcItems,
       Evaluator eval,
@@ -362,6 +371,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         lookupFieldOnLookupObject,
         opFieldOnLookupObject,
         lookupObj,
+        calcItem,
         operation,
         oldCalcItems,
         eval,
@@ -433,18 +443,18 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     Integer amountOfCalcItems = 0;
     Set<String> objIds = new Set<String>(); // will always be present as a bind var, below
     Set<Id> recordIds = new Set<Id>(); // always empty, here, but necessary for the "getCountFromDb" call
-    SObjectType calcItemType; // always the same for this route, so we can just take whatever the last assignment is
+    SObjectType childType; // always the same for this route, so we can just take whatever the last assignment is
     Set<String> queryFields = new Set<String>{ 'Id' };
 
     for (Rollup__mdt matchingMeta : matchingMetadata) {
-      calcItemType = getSObjectFromName(matchingMeta.CalcItem__c).getSObjectType();
+      childType = getSObjectFromName(matchingMeta.CalcItem__c).getSObjectType();
       queryFields.add(matchingMeta.LookupFieldOnCalcItem__c);
       queryFields.add(matchingMeta.RollupFieldOnCalcItem__c);
       if (String.isNotBlank(matchingMeta.CalcItemWhereClause__c)) {
-        queryFields.addAll(new RollupEvaluator.WhereFieldEvaluator(matchingMeta.CalcItemWhereClause__c, calcItemType).getQueryFields());
+        queryFields.addAll(new RollupEvaluator.WhereFieldEvaluator(matchingMeta.CalcItemWhereClause__c, childType).getQueryFields());
       }
 
-      String countQuery = getQueryString(calcItemType, new List<String>{ 'Count()' }, matchingMeta.LookupFieldOnLookupObject__c, '!=');
+      String countQuery = getQueryString(childType, new List<String>{ 'Count()' }, matchingMeta.LookupFieldOnLookupObject__c, '!=');
       Integer currentCount = getCountFromDb(countQuery, objIds, recordIds);
       if (currentCount == SENTINEL_COUNT_VALUE) {
         amountOfCalcItems = currentCount;
@@ -453,10 +463,10 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       amountOfCalcItems += currentCount;
     }
 
-    String queryString = getQueryString(calcItemType, new List<String>(queryFields), 'Id', '!=');
+    String queryString = getQueryString(childType, new List<String>(queryFields), 'Id', '!=');
 
     // eval always null via this route, despite having been used to get the relationship fields
-    return startFullRecalc(matchingMetadata, amountOfCalcItems, queryString, objIds, recordIds, calcItemType, null, RollupInvocationPoint.FROM_LWC);
+    return startFullRecalc(matchingMetadata, amountOfCalcItems, queryString, objIds, recordIds, childType, null, RollupInvocationPoint.FROM_LWC);
   }
 
   @AuraEnabled
@@ -608,6 +618,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       enforceValidationRules(flowInput);
       enforceFlowSpecificRules(flowInput);
 
+      // flow collections are not strongly typed, so we grab from the first record
       SObjectType sObjectType = flowInput.recordsToRollup[0].getSObjectType();
 
       Rollup__mdt rollupMeta = new Rollup__mdt(
@@ -1413,9 +1424,10 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       }
     }
 
+    SObjectType calcItemSObjectType = calcItems.getSObjectType();
     for (Rollup__mdt rollupInfo : rollupMetadata) {
       Boolean isIntermediateRollupForGrandparent =
-        rollupInfo.CalcItem__c != String.valueOf(calcItems.getSObjectType()) &&
+        rollupInfo.CalcItem__c != String.valueOf(calcItemSObjectType) &&
         String.isNotBlank(rollupInfo.GrandparentRelationshipFieldPath__c) &&
         calcItems.isEmpty() == false &&
         rollupInfo.IsRollupStartedFromParent__c == false;
@@ -1447,7 +1459,6 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     }
 
     if (shouldReturn == false) {
-      SObjectType calcItemSObjectType = calcItems.getSObjectType();
       if (CACHED_APEX_OPERATIONS.containsKey(calcItemSObjectType)) {
         CACHED_APEX_OPERATIONS.get(calcItemSObjectType).add(apexContext);
       } else {
@@ -1457,7 +1468,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
     return shouldReturn
       ? new RollupAsyncProcessor(RollupInvocationPoint.FROM_APEX)
-      : getRollup(rollupMetadata, calcItems.getSObjectType(), calcItems, oldCalcItems, eval, RollupInvocationPoint.FROM_APEX);
+      : getRollup(rollupMetadata, calcItemSObjectType, calcItems, oldCalcItems, eval, RollupInvocationPoint.FROM_APEX);
   }
 
   /** end global-facing section, begin public/private static helpers */
@@ -1606,19 +1617,19 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   private static String performFullRecalculationInner(Rollup__mdt meta, QueryWrapper queryWrapper, RollupInvocationPoint invokePoint) {
     // just how many items are we talking, here? If it's less than the query limit, we can proceed
     // otherwise, kick off a batch to fetch the calc items and then chain into the regular code path
-    SObjectType calcItemType = getSObjectFromName(meta.CalcItem__c).getSObjectType();
-    String countQuery = getQueryString(calcItemType, new List<String>{ 'Count()' }, meta.LookupFieldOnLookupObject__c, '!=', queryWrapper.getQuery());
+    SObjectType childType = getSObjectFromName(meta.CalcItem__c).getSObjectType();
+    String countQuery = getQueryString(childType, new List<String>{ 'Count()' }, meta.LookupFieldOnLookupObject__c, '!=', queryWrapper.getQuery());
 
     Set<String> objIds = new Set<String>(); // get everything that doesn't have a null Id - a pretty trick
     Set<Id> recordIds = queryWrapper.recordIds; // also used below, bound to the "queryString" variable
     Integer amountOfCalcItems = getCountFromDb(countQuery, objIds, recordIds);
 
     Set<String> queryFields = new Set<String>{ 'Id', meta.RollupFieldOnCalcItem__c, meta.LookupFieldOnCalcItem__c };
-    RollupEvaluator.WhereFieldEvaluator whereEval = new RollupEvaluator.WhereFieldEvaluator(queryWrapper.toString(), calcItemType);
+    RollupEvaluator.WhereFieldEvaluator whereEval = new RollupEvaluator.WhereFieldEvaluator(queryWrapper.toString(), childType);
     queryFields.addAll(whereEval.getQueryFields());
-    String queryString = getQueryString(calcItemType, new List<String>(queryFields), 'Id', '!=', queryWrapper.getQuery());
+    String queryString = getQueryString(childType, new List<String>(queryFields), 'Id', '!=', queryWrapper.getQuery());
 
-    return startFullRecalc(new List<Rollup__mdt>{ meta }, amountOfCalcItems, queryString, objIds, recordIds, calcItemType, whereEval, invokePoint);
+    return startFullRecalc(new List<Rollup__mdt>{ meta }, amountOfCalcItems, queryString, objIds, recordIds, childType, whereEval, invokePoint);
   }
 
   private static String startFullRecalc(
@@ -1977,11 +1988,12 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         lookupFieldOnOpObject,
         rollupFieldOnOpObject,
         lookupSObjectType,
+        sObjectType, // calc item SObjectType
         rollupOp,
         calcItems,
         oldCalcItems,
         batchRollup,
-        RollupEvaluator.getEvaluator(eval, rollupMetadata, oldCalcItems, sObjectType),
+        eval,
         localControl?.Id,
         rollupInvokePoint,
         rollupMetadata
@@ -2079,7 +2091,8 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     SObjectField lookupFieldOnCalcItem,
     SObjectField lookupFieldOnOpObject,
     SObjectField rollupFieldOnOpObject,
-    SObjectType sObjectType,
+    SObjectType lookupSObjectType,
+    SObjectType calcItemSObjectType,
     Op rollupOp,
     List<SObject> calcItems,
     Map<Id, SObject> oldCalcItems,
@@ -2095,7 +2108,8 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       lookupFieldOnCalcItem,
       lookupFieldOnOpObject,
       rollupFieldOnOpObject,
-      sObjectType,
+      lookupSObjectType,
+      calcItemSObjectType,
       rollupOp,
       oldCalcItems,
       eval,
@@ -2272,17 +2286,21 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     throw new AsyncException('Rollup failed to re-queue for: ' + JSON.serialize(failedRollupInfo));
   }
 
-  private List<SObject> filter(List<SObject> calcItems, Evaluator eval) {
+  private FilterResults filter(List<SObject> calcItems, Evaluator eval) {
+    FilterResults results = new FilterResults();
     Set<String> alwaysFullRecalcOps = new Set<String>{ 'FIRST', 'LAST', 'AVERAGE' };
     List<SObject> matchingItems = calcItems == null ? new List<SObject>() : calcItems.clone();
+    results.matchingItems = matchingItems;
     if (matchingItems.isEmpty()) {
-      return matchingItems;
+      return results;
     }
     matchingItems.clear(); // retains the strong-typing on the list for downstream calls to List.getSbjectType()
     calcItems = this.replaceCalcItemsForPolymorphicWhereClause(calcItems);
 
+    results.eval = RollupEvaluator.getEvaluator(eval, this.metadata, oldCalcItems, this.calcItemType);
+
     for (SObject item : calcItems) {
-      if (eval?.matches(item) != false) {
+      if (results.eval.matches(item)) {
         matchingItems.add(item);
         // metadata shouldn't be null, but it's good to check; unfortunately, if(null) throws so we
         // have to do this EXTRA explicit check
@@ -2292,7 +2310,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         matchingItems.add(item);
       }
     }
-    return matchingItems;
+    return results;
   }
 
   private List<SObject> replaceCalcItemsForPolymorphicWhereClause(List<SObject> calcItems) {
@@ -2470,11 +2488,10 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   }
 
   private Boolean getShouldRunSyncDeferred(Rollup roll) {
-    SObjectType calcItemType = roll.calcItems.getSObjectType();
-    if (roll.isNoOp || CACHED_APEX_OPERATIONS.containsKey(calcItemType) == false) {
+    if (roll.isNoOp || CACHED_APEX_OPERATIONS.containsKey(roll.calcItemType) == false) {
       return false;
     }
-    Set<TriggerOperation> apexOperations = CACHED_APEX_OPERATIONS.get(calcItemType);
+    Set<TriggerOperation> apexOperations = CACHED_APEX_OPERATIONS.get(roll.calcItemType);
     if (apexOperations.contains(TriggerOperation.AFTER_INSERT) && roll.op.name().contains('UPDATE')) {
       return true;
     } else if (
@@ -2552,7 +2569,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
         for (Integer index = localCalcItems.size() - 1; index >= 0; index--) {
           SObject calcItem = localCalcItems[index];
-          if (rollup.eval?.matches(calcItem) == false && rollup.metadata?.IsFullRecordSet__c == true) {
+          if (rollup.eval.matches(calcItem) == false && rollup.metadata?.IsFullRecordSet__c == true) {
             // technically it should only be possible for a calc item that doesn't match
             // to still exist if it is a Full Record Set operation; this gives people the chance
             // to reset rollup values if none of the records passed in match the eval criteria

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -185,7 +185,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       innerRollup.calcItemType,
       op,
       innerRollup.oldCalcItems,
-      null, // eval gets assigned later
+      null, // eval gets assigned below
       innerRollup.invokePoint,
       innerRollup.rollupControlId,
       innerRollup.metadata
@@ -284,7 +284,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
     Boolean shouldBatch =
       shouldRunAsBatch ||
-      (orgDefaults.ShouldRunAs__c == 'Batchable' &&
+      (orgDefaults.ShouldRunAs__c == RollupShouldRunAsPicklist.Instance.BATCHABLE &&
       totalCountOfRecords >= orgDefaults.MaxLookupRowsBeforeBatching__c) ||
       totalCountOfRecords == SENTINEL_COUNT_VALUE;
     if (this.syncRollups.isEmpty() == false) {
@@ -1607,8 +1607,8 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
   public static Boolean hasExceededCurrentRollupLimits(RollupControl__mdt control) {
     Boolean hasExceededLimits =
-      (Limits.getLimitQueries() / 2) < Limits.getQueries() ||
-      control?.MaxQueryRows__c < Limits.getQueryRows() ||
+      control?.MaxNumberOfQueries__c < Limits.getQueries() ||
+      control?.MaxLookupRowsBeforeBatching__c < Limits.getQueryRows() ||
       (Limits.getLimitHeapSize() / 2) < Limits.getHeapSize() ||
       control?.MaxParentRowsUpdatedAtOnce__c < Limits.getDmlRows();
     return hasExceededLimits && isDeferralAllowed;
@@ -1642,9 +1642,9 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     Evaluator eval,
     RollupInvocationPoint invokePoint
   ) {
-    // emptyRollup used to reference the default RollupControl__mdt.MaxQueryRows__c, as well as BatchChunkSize__c
+    // emptyRollup used to reference the default RollupControl__mdt.MaxLookupRowsBeforeBatching__c, as well as BatchChunkSize__c
     Rollup emptyRollup = new Rollup(invokePoint);
-    Boolean shouldQueue = amountOfCalcItems != SENTINEL_COUNT_VALUE && amountOfCalcItems < emptyRollup.rollupControl.MaxQueryRows__c;
+    Boolean shouldQueue = amountOfCalcItems != SENTINEL_COUNT_VALUE && amountOfCalcItems < emptyRollup.rollupControl.MaxLookupRowsBeforeBatching__c;
     if (shouldQueue) {
       List<SObject> calculationItems = Database.query(queryString);
       Rollup thisRollup = getRollup(matchingMeta, calcItemType, calculationItems, new Map<Id, SObject>(calculationItems), eval, invokePoint);
@@ -2156,12 +2156,12 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       sensibleDefault = new RollupControl__mdt(
         DeveloperName = CONTROL_ORG_DEFAULTS,
         BatchChunkSize__c = 2000,
-        MaxLookupRowsBeforeBatching__c = Limits.getLimitDmlRows() / 3,
+        MaxLookupRowsBeforeBatching__c = Limits.getLimitQueryRows() / 3,
         MaxParentRowsUpdatedAtOnce__c = Limits.getLimitDmlRows() / 2,
         MaxRollupRetries__c = 100,
-        MaxQueryRows__c = Limits.getLimitQueryRows() / 2,
+        MaxNumberOfQueries__c = Limits.getLimitQueries() / 2,
         ShouldAbortRun__c = false,
-        ShouldRunAs__c = 'Queueable'
+        ShouldRunAs__c = RollupShouldRunAsPicklist.Instance.QUEUEABLE
       );
     } else {
       sensibleDefault = sensibleDefault.clone(true, true);
@@ -2220,9 +2220,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
           lookupItemKeys.remove(lookupId);
           // this way, the updated values are persisted for each field, and the default values are initialized
           SObject updatedLookupObject = updatedLookupRecords.get(lookupId);
-          if (updatedLookupObject.get(rollup.opFieldOnLookupObject) == null || this.isFullRecalc) {
-            updatedLookupObject.put(rollup.opFieldOnLookupObject, RollupFieldInitializer.Current.getDefaultValue(rollup.opFieldOnLookupObject));
-          }
+          this.resetLookupFieldsForNullOrFullRecalcs(updatedLookupObject, rollup);
           localLookupItems.add(updatedLookupObject);
         }
       }
@@ -2444,12 +2442,16 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     return lookupFieldToCalcItems;
   }
 
-  protected void initializeRollupFieldDefaults(List<SObject> lookupItems, Rollup rollup) {
+  private void initializeRollupFieldDefaults(List<SObject> lookupItems, Rollup rollup) {
     // prior to returning, we need to ensure the default value for the rollup field is set
     for (SObject lookupItem : lookupItems) {
-      if (lookupItem.get(rollup.opFieldOnLookupObject) == null || rollup.isFullRecalc) {
-        lookupItem.put(rollup.opFieldOnLookupObject, RollupFieldInitializer.Current.getDefaultValue(rollup.opFieldOnLookupObject));
-      }
+      this.resetLookupFieldsForNullOrFullRecalcs(lookupItem, rollup);
+    }
+  }
+
+  private void resetLookupFieldsForNullOrFullRecalcs(SObject lookupItem, Rollup rollup) {
+    if (lookupItem.get(rollup.opFieldOnLookupObject) == null || rollup.isFullRecalc) {
+      lookupItem.put(rollup.opFieldOnLookupObject, RollupFieldInitializer.Current.getDefaultValue(rollup.opFieldOnLookupObject));
     }
   }
 
@@ -2465,7 +2467,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
       Boolean shouldRunSyncDeferred = this.getShouldRunSyncDeferred(rollup);
       Boolean couldRunSync =
-        rollupSpecificControl.ShouldRunAs__c == 'Synchronous Rollup' || (hasExceededCurrentRollupLimits(rollupSpecificControl) == false) && isRunningAsync;
+        rollupSpecificControl.ShouldRunAs__c == RollupShouldRunAsPicklist.Instance.SYNCHRONOUS || (hasExceededCurrentRollupLimits(rollupSpecificControl) == false) && isRunningAsync;
 
       if (rollupSpecificControl.ShouldAbortRun__c) {
         this.rollups.remove(index);

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -36,35 +36,28 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
   public abstract Boolean matches(Object calcItem);
 
   public static Rollup.Evaluator getEvaluator(Rollup.Evaluator eval, Rollup__mdt metadata, Map<Id, SObject> oldCalcItems, SObjectType sObjectType) {
-    Boolean isChangedFieldEval = String.isNotBlank(metadata.ChangedFieldsOnCalcItem__c);
-    Boolean isWhereClauseEval = String.isNotBlank(metadata.CalcItemWhereClause__c);
-    Boolean isUpdate = metadata.RollupOperation__c.contains('UPDATE');
-    RollupEvaluator secondEval;
+    List<Rollup.Evaluator> evals = new List<Rollup.Evaluator>{ eval == null ? new AlwaysTrue() : eval };
 
-    if (isChangedFieldEval && isWhereClauseEval && isUpdate) {
-      RollupEvaluator dualEval = new CombinedEvaluator(metadata, oldCalcItems, sObjectType);
-      secondEval = new CombinedEvaluator(new RecursiveUpdateEvaluator(metadata), dualEval);
-    } else if (isChangedFieldEval && isWhereClauseEval && isUpdate == false) {
-      secondEval = new CombinedEvaluator(metadata, oldCalcItems, sObjectType);
-    } else if (isChangedFieldEval && isUpdate) {
-      secondEval = new CombinedEvaluator(getChangedFieldEval(metadata, oldCalcItems), new RecursiveUpdateEvaluator(metadata));
-    } else if (isWhereClauseEval && isUpdate) {
-      secondEval = new CombinedEvaluator(new WhereFieldEvaluator(metadata, sObjectType, oldCalcItems), new RecursiveUpdateEvaluator(metadata));
-    } else if (isChangedFieldEval) {
-      secondEval = getChangedFieldEval(metadata, oldCalcItems);
-    } else if (isWhereClauseEval) {
-      secondEval = new WhereFieldEvaluator(metadata, sObjectType, oldCalcItems);
-    } else if (isUpdate) {
-      secondEval = new RecursiveUpdateEvaluator(metadata);
+    if (String.isNotBlank(metadata.CalcItemWhereClause__c)) {
+      evals.add(new WhereFieldEvaluator(metadata, sObjectType, oldCalcItems));
+    }
+    if (String.isNotBlank(metadata.ChangedFieldsOnCalcItem__c)) {
+      evals.add(getChangedFieldEval(metadata, oldCalcItems));
+    }
+    if (metadata.RollupOperation__c?.contains('UPDATE') == true) {
+      evals.add(new RecursiveUpdateEvaluator(metadata));
     }
 
-    if (eval != null && secondEval != null) {
-      return new CombinedEvaluator(eval, secondEval);
-    } else if (eval == null && secondEval != null) {
-      return secondEval;
-    }
+    return getCombinedEvals(evals);
+  }
 
-    return eval;
+  private static Rollup.Evaluator getCombinedEvals(List<Rollup.Evaluator> evals) {
+    Rollup.Evaluator eval = evals.remove(0);
+    if (evals.isEmpty()) {
+      return eval;
+    } else {
+      return new CombinedEvaluator(eval, getCombinedEvals(evals));
+    }
   }
 
   private static RollupEvaluator getChangedFieldEval(Rollup__mdt rollupMetadata, Map<Id, SObject> oldCalcItems) {
@@ -76,14 +69,17 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
     return new SObjectChangedFieldEvaluator(changedFieldNames, oldCalcItems);
   }
 
+  @testVisible
+  private class AlwaysTrue extends RollupEvaluator {
+    public override Boolean matches(Object calcItem) {
+      return true;
+    }
+  }
+
   private class CombinedEvaluator extends RollupEvaluator {
     private final Rollup.Evaluator firstEval;
     private final Rollup.Evaluator secondEval;
 
-    public CombinedEvaluator(Rollup__mdt rollupMetadata, Map<Id, SObject> oldCalcItems, SObjectType sObjectType) {
-      this.firstEval = getChangedFieldEval(rollupMetadata, oldCalcItems);
-      this.secondEval = new WhereFieldEvaluator(rollupMetadata, sObjectType, oldCalcItems);
-    }
     public CombinedEvaluator(Rollup.Evaluator firstEval, Rollup.Evaluator secondEval) {
       this.firstEval = firstEval;
       this.secondEval = secondEval;
@@ -605,10 +601,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
   }
 
   private class RecursiveTracker {
-    public RecursiveTracker() {
-      this.stackCount = 0;
-    }
-    public Integer stackCount;
+    public Integer stackCount = 0;
     public Set<Id> addedIds = new Set<Id>();
     public Set<SObject> calcItems = new Set<SObject>();
   }
@@ -629,6 +622,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
 
     // at some point, it's possible that this will be revisited, but for now we'll keep the recursion tracking only for vanilla rollups
     public override Boolean matches(Object item) {
+      Boolean matches = true;
       if (
         item instanceof SObject &&
         String.isBlank(this.metadata.GrandparentRelationshipFieldPath__c) &&
@@ -645,18 +639,12 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
         if (recursionTracker.addedIds.contains(clonedItem.Id) == false) {
           recursionTracker.addedIds.add(clonedItem.Id);
           recursionTracker.calcItems.add(clonedItem);
-          return true;
-        } else if (recursionTracker.stackCount == 0) {
-          return true;
-        } else if (recursionTracker.stackCount > 0 && recursionTracker.calcItems.contains(clonedItem) && this.metadata.IsFullRecordSet__c == false) {
-          // we'll have to forego the chance of detecting recursion for Full Record Set rollups
-          // because they're the only ones that get matched twice in Rollup
-          return false;
+        } else if (recursionTracker.stackCount > 0 && recursionTracker.calcItems.contains(clonedItem)) {
+          matches = false;
         }
       }
 
-      // don't be restrictive if it isn't recursive
-      return true;
+      return matches;
     }
   }
 }

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -12,6 +12,7 @@ public class RollupFullBatchRecalculator extends Rollup {
     Set<Id> recordIds
   ) {
     super(invokePoint);
+    this.calcItemType = calcItemType;
     this.queryString = queryString;
     this.rollupInfo = rollupInfo;
     this.recordIds = recordIds;
@@ -32,7 +33,9 @@ public class RollupFullBatchRecalculator extends Rollup {
      * being batched, even if the inner class is just extending the functionality of its
      * parent class
      */
-    this.getDelegatedRollup(this.rollupInfo, this.calcItemType, calcItems, new Map<Id, SObject>(calcItems), this.invokePoint).runCalc();
+    Rollup roll = this.getDelegatedRollup(this.rollupInfo, this.calcItemType, calcItems, new Map<Id, SObject>(calcItems), this.invokePoint);
+    roll.isFullRecalc = true;
+    roll.runCalc();
   }
 
   public override void finish(Database.BatchableContext bc) {

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -1,7 +1,6 @@
 public class RollupFullBatchRecalculator extends Rollup {
   private final String queryString;
   private final List<Rollup__mdt> rollupInfo;
-  private final SObjectType calcItemType;
   private final Set<Id> recordIds;
 
   public RollupFullBatchRecalculator(

--- a/rollup/core/classes/RollupShouldRunAsPicklist.cls
+++ b/rollup/core/classes/RollupShouldRunAsPicklist.cls
@@ -1,0 +1,39 @@
+public without sharing class RollupShouldRunAsPicklist {
+  private final Set<String> validValues;
+
+  private RollupShouldRunAsPicklist() {
+    this.validValues = new Set<String>();
+
+    List<PicklistEntry> picklistValues = RollupControl__mdt.ShouldRunAs__c.getDescribe().getPicklistValues();
+    for (PicklistEntry entry : picklistValues) {
+      this.validValues.add(entry.getValue());
+    }
+  }
+
+  public static final RollupShouldRunAsPicklist Instance = new RollupShouldRunAsPicklist();
+
+  public String SYNCHRONOUS {
+    get {
+      return this.validate('Synchronous Rollup');
+    }
+  }
+
+  public String BATCHABLE {
+    get {
+      return this.validate('Batchable');
+    }
+  }
+
+  public String QUEUEABLE {
+    get {
+      return this.validate('Queueable');
+    }
+  }
+
+  private String validate(String val) {
+    if (this.validValues.contains(val) == false) {
+      throw new IllegalArgumentException(val + ' not present in valid picklist values: ' + JSON.serialize(this.validValues));
+    }
+    return val;
+  }
+}

--- a/rollup/core/classes/RollupShouldRunAsPicklist.cls-meta.xml
+++ b/rollup/core/classes/RollupShouldRunAsPicklist.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>51.0</apiVersion>
+  <status>Active</status>
+</ApexClass>

--- a/rollup/core/customMetadata/RollupControl.Org_Defaults.md-meta.xml
+++ b/rollup/core/customMetadata/RollupControl.Org_Defaults.md-meta.xml
@@ -15,8 +15,8 @@
         <value xsi:type="xsd:double">5000.0</value>
     </values>
     <values>
-        <field>MaxQueryRows__c</field>
-        <value xsi:type="xsd:double">100.0</value>
+        <field>MaxNumberOfQueries__c</field>
+        <value xsi:type="xsd:double">50.0</value>
     </values>
     <values>
         <field>MaxRollupRetries__c</field>

--- a/rollup/core/layouts/RollupControl__mdt-Rollup Control Layout.layout-meta.xml
+++ b/rollup/core/layouts/RollupControl__mdt-Rollup Control Layout.layout-meta.xml
@@ -51,7 +51,7 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>MaxQueryRows__c</field>
+                <field>MaxNumberOfQueries__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>

--- a/rollup/core/objects/RollupControl__mdt/fields/MaxNumberOfQueries__c.field-meta.xml
+++ b/rollup/core/objects/RollupControl__mdt/fields/MaxNumberOfQueries__c.field-meta.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>MaxQueryRows__c</fullName>
+    <fullName>MaxNumberOfQueries__c</fullName>
     <defaultValue>100</defaultValue>
     <description>Configure this number to decide how many queries Rollup is allowed to issue before restarting in another context. Consider the downstream query needs when your parent objects are updated when configuring this field. By safely requeueing Rollup in conjunction with this number, we ensure no query limit is ever hit.</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
     <inlineHelpText>Configure this number to decide how many queries Rollup is allowed to issue before restarting in another context. Consider the downstream query needs when your parent objects are updated when configuring this field</inlineHelpText>
-    <label>Max Query Rows</label>
+    <label>Max Number Of Queries</label>
     <precision>18</precision>
     <required>false</required>
     <scale>0</scale>

--- a/rollup/core/profiles/Admin.profile-meta.xml
+++ b/rollup/core/profiles/Admin.profile-meta.xml
@@ -87,7 +87,7 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
-        <field>RollupControl__mdt.MaxQueryRows__c</field>
+        <field>RollupControl__mdt.MaxNumberOfQueries__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/rollup/tests/RollupEvaluatorTests.cls
+++ b/rollup/tests/RollupEvaluatorTests.cls
@@ -379,7 +379,7 @@ private class RollupEvaluatorTests {
     Rollup__mdt rollupMetadata = new Rollup__mdt(LookupFieldOnCalcItem__c = 'AccountId', RollupOperation__c = Rollup.Op.SUM.name());
 
     Rollup.Evaluator eval = RollupEvaluator.getEvaluator(
-      new AlwaysTrueEval(),
+      new RollupEvaluator.AlwaysTrue(),
       rollupMetadata,
       new Map<Id, SObject>{ oldOpp.Id => oldOpp },
       Opportunity.SObjectType
@@ -398,7 +398,7 @@ private class RollupEvaluatorTests {
     Rollup__mdt rollupMetadata = new Rollup__mdt(ChangedFieldsOnCalcItem__c = 'Amount', RollupOperation__c = Rollup.Op.SUM.name());
 
     Rollup.Evaluator eval = RollupEvaluator.getEvaluator(
-      new AlwaysTrueEval(),
+      new RollupEvaluator.AlwaysTrue(),
       rollupMetadata,
       new Map<Id, SObject>{ oldOpp.Id => oldOpp, secondOpp.Id => secondOpp },
       Opportunity.SObjectType
@@ -419,7 +419,7 @@ private class RollupEvaluatorTests {
     Rollup__mdt rollupMetadata = new Rollup__mdt(CalcItemWhereClause__c = 'Amount > 20', RollupOperation__c = Rollup.Op.SUM.name());
 
     Rollup.Evaluator eval = RollupEvaluator.getEvaluator(
-      new AlwaysTrueEval(),
+      new RollupEvaluator.AlwaysTrue(),
       rollupMetadata,
       new Map<Id, SObject>{ oldOpp.Id => oldOpp, secondOpp.Id => secondOpp },
       Opportunity.SObjectType
@@ -444,7 +444,7 @@ private class RollupEvaluatorTests {
     );
 
     Rollup.Evaluator eval = RollupEvaluator.getEvaluator(
-      new AlwaysTrueEval(),
+      new RollupEvaluator.AlwaysTrue(),
       rollupMetadata,
       new Map<Id, SObject>{ oldOpp.Id => oldOpp, secondOpp.Id => secondOpp },
       Opportunity.SObjectType
@@ -548,7 +548,7 @@ private class RollupEvaluatorTests {
 
     System.assertEquals(true, eval.matches(opp), 'Should return true when not recursive!');
 
-   eval = RollupEvaluator.getEvaluator(
+    eval = RollupEvaluator.getEvaluator(
       null,
       new Rollup__mdt(
         RollupOperation__c = Rollup.Op.UPDATE_CONCAT_DISTINCT.name(),
@@ -608,7 +608,7 @@ private class RollupEvaluatorTests {
     );
 
     Rollup.Evaluator eval = RollupEvaluator.getEvaluator(
-      new AlwaysTrueEval(),
+      new RollupEvaluator.AlwaysTrue(),
       rollupMetadata,
       new Map<Id, SObject>{ oldOpp.Id => oldOpp },
       Opportunity.SObjectType
@@ -643,7 +643,7 @@ private class RollupEvaluatorTests {
     );
 
     Rollup.Evaluator eval = RollupEvaluator.getEvaluator(
-      new AlwaysTrueEval(),
+      new RollupEvaluator.AlwaysTrue(),
       rollupMetadata,
       new Map<Id, SObject>{ oldOpp.Id => oldOpp },
       Opportunity.SObjectType
@@ -651,12 +651,7 @@ private class RollupEvaluatorTests {
 
     System.assertEquals(true, eval.matches(opp), 'Should return true when not recursive!');
 
-    eval = RollupEvaluator.getEvaluator(
-      new AlwaysTrueEval(),
-      rollupMetadata,
-      new Map<Id, SObject>{ oldOpp.Id => oldOpp },
-      Opportunity.SObjectType
-    );
+    eval = RollupEvaluator.getEvaluator(new RollupEvaluator.AlwaysTrue(), rollupMetadata, new Map<Id, SObject>{ oldOpp.Id => oldOpp }, Opportunity.SObjectType);
 
     System.assertEquals(false, eval.matches(opp), 'Should not return true when recursive and all other conditions true');
   }
@@ -673,59 +668,13 @@ private class RollupEvaluatorTests {
       LookupFieldOnCalcItem__c = 'AccountId'
     );
 
-    Rollup.Evaluator eval = RollupEvaluator.getEvaluator(
-      new AlwaysTrueEval(),
-      rollupMetadata,
-      new Map<Id, SObject>(),
-      Opportunity.SObjectType
-    );
+    Rollup.Evaluator eval = RollupEvaluator.getEvaluator(new RollupEvaluator.AlwaysTrue(), rollupMetadata, new Map<Id, SObject>(), Opportunity.SObjectType);
 
     System.assertEquals(true, eval.matches(opp), 'Should return true when not recursive!');
 
-    eval = RollupEvaluator.getEvaluator(
-      new AlwaysTrueEval(),
-      rollupMetadata,
-      new Map<Id, SObject>(),
-      Opportunity.SObjectType
-    );
+    eval = RollupEvaluator.getEvaluator(new RollupEvaluator.AlwaysTrue(), rollupMetadata, new Map<Id, SObject>(), Opportunity.SObjectType);
 
     System.assertEquals(false, eval.matches(opp), 'Should not return true when recursive and all other conditions true');
     System.assertEquals(false, eval.matches(nonMatchingOpp), 'Should not match to begin with based on calc item where clause');
-  }
-
-  @isTest
-  static void shouldBailOnRecursionDetectionForFullRecordSetRollup() {
-    Opportunity opp = new Opportunity(Id = '0066g000000000000X', Amount = 50, AccountId = '0016g000000000000X');
-
-    Rollup__mdt rollupMetadata = new Rollup__mdt(
-      RollupOperation__c = Rollup.Op.UPDATE_CONCAT_DISTINCT.name(),
-      RollupFieldOnCalcItem__c = 'Amount',
-      LookupFieldOnCalcItem__c = 'AccountId',
-      IsFullRecordSet__c = true
-    );
-
-    Rollup.Evaluator eval = RollupEvaluator.getEvaluator(
-      new AlwaysTrueEval(),
-      rollupMetadata,
-      new Map<Id, SObject>(),
-      Opportunity.SObjectType
-    );
-
-    System.assertEquals(true, eval.matches(opp), 'Should return true when not recursive!');
-
-    eval = RollupEvaluator.getEvaluator(
-      new AlwaysTrueEval(),
-      rollupMetadata,
-      new Map<Id, SObject>(),
-      Opportunity.SObjectType
-    );
-
-    System.assertEquals(true, eval.matches(opp), 'Should return true when recursive and full record set');
-  }
-
-  private class AlwaysTrueEval implements Rollup.Evaluator {
-    public Boolean matches(Object calcItem) {
-      return true;
-    }
   }
 }

--- a/rollup/tests/RollupRelationshipFieldFinderTests.cls
+++ b/rollup/tests/RollupRelationshipFieldFinderTests.cls
@@ -1,6 +1,6 @@
 @isTest
 private class RollupRelationshipFieldFinderTests {
-  static RollupControl__mdt control = new RollupControl__mdt(MaxQueryRows__c = 10000);
+  static RollupControl__mdt control = new RollupControl__mdt(MaxLookupRowsBeforeBatching__c = 10000);
 
   @isTest
   static void shouldFindParentRelationshipBetweenStandardObjects() {
@@ -68,7 +68,7 @@ private class RollupRelationshipFieldFinderTests {
     insert acc;
 
     ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Child cpa');
-    control.MaxQueryRows__c = 1;
+    control.MaxNumberOfQueries__c = 1;
 
     RollupRelationshipFieldFinder finder = new RollupRelationshipFieldFinder(
       control,

--- a/rollup/tests/RollupTests.cls
+++ b/rollup/tests/RollupTests.cls
@@ -2839,7 +2839,7 @@ private class RollupTests {
   static void shouldRunAsBatchableWhenSpecificRollupIsBatchable() {
     DMLMock mock = loadAccountIdMock(new List<ContactPointAddress>{ new ContactPointAddress(PreferenceRank = 1) });
     Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    Rollup.defaultControl = new RollupControl__mdt(ShouldRunAs__c = 'Batchable', BatchChunkSize__c = 1, MaxLookupRowsBeforeBatching__c = 0);
+    Rollup.defaultControl = new RollupControl__mdt(ShouldRunAs__c = RollupShouldRunAsPicklist.Instance.BATCHABLE, BatchChunkSize__c = 1, MaxLookupRowsBeforeBatching__c = 0);
 
     Test.startTest();
     Rollup.countFromApex(ContactPointAddress.PreferenceRank, ContactPointAddress.ParentId, Account.Id, Account.AnnualRevenue, Account.SObjectType).runCalc();
@@ -2853,7 +2853,7 @@ private class RollupTests {
   static void shouldNotRunAsBatchableWhenDefaultIsBatchableAndRecordsAreLessThanBatchableLimit() {
     DMLMock mock = loadAccountIdMock(new List<ContactPointAddress>{ new ContactPointAddress(PreferenceRank = 1) });
     Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    Rollup.defaultControl = new RollupControl__mdt(ShouldRunAs__c = 'Batchable', MaxLookupRowsBeforeBatching__c = 1000, BatchChunkSize__c = 50);
+    Rollup.defaultControl = new RollupControl__mdt(ShouldRunAs__c = RollupShouldRunAsPicklist.Instance.BATCHABLE, MaxLookupRowsBeforeBatching__c = 1000, BatchChunkSize__c = 50);
 
     Test.startTest();
     Rollup.countFromApex(ContactPointAddress.PreferenceRank, ContactPointAddress.ParentId, Account.Id, Account.AnnualRevenue, Account.SObjectType).runCalc();
@@ -2867,7 +2867,7 @@ private class RollupTests {
   static void shouldRunAsQueueableWhenSpecificControlIsQueueable() {
     DMLMock mock = loadAccountIdMock(new List<ContactPointAddress>{ new ContactPointAddress(PreferenceRank = 1) });
     Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = 'Queueable');
+    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = RollupShouldRunAsPicklist.Instance.QUEUEABLE);
 
     Test.startTest();
     Rollup.countFromApex(ContactPointAddress.PreferenceRank, ContactPointAddress.ParentId, Account.Id, Account.AnnualRevenue, Account.SObjectType).runCalc();
@@ -3001,7 +3001,10 @@ private class RollupTests {
 
   @isTest
   static void shouldBatchForFullRecalcWhenOverLimits() {
+    Rollup.defaultControl = new RollupControl__mdt(ShouldAbortRun__c = true);
     Account acc = [SELECT Id FROM Account];
+    acc.AnnualRevenue = 5; // validate that the pre-existing value is cleared
+    update acc;
 
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{
       new ContactPointAddress(Name = 'oneBatch', ParentId = acc.Id, PreferenceRank = 1),
@@ -3013,7 +3016,7 @@ private class RollupTests {
     };
     insert cpas;
 
-    Rollup.defaultControl = new RollupControl__mdt(MaxQueryRows__c = 1, BatchChunkSize__c = 10);
+    Rollup.defaultControl = new RollupControl__mdt(MaxNumberOfQueries__c = 1, BatchChunkSize__c = 10);
 
     Rollup__mdt meta = new Rollup__mdt(
       CalcItem__c = 'ContactPointAddress',
@@ -3318,7 +3321,7 @@ private class RollupTests {
     DMLMock mock = loadAccountIdMock(new List<ContactPointAddress>{ new ContactPointAddress(PreferenceRank = 1) });
     Rollup.apexContext = TriggerOperation.AFTER_INSERT;
     Rollup.defaultControl = new RollupControl__mdt(MaxRollupRetries__c = 100);
-    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = 'Synchronous Rollup', MaxQueryRows__c = -1, BatchChunkSize__c = 1);
+    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = 'Synchronous Rollup', MaxLookupRowsBeforeBatching__c = -1, BatchChunkSize__c = 1);
 
     Test.startTest();
     Rollup.countFromApex(ContactPointAddress.PreferenceRank, ContactPointAddress.ParentId, Account.Id, Account.AnnualRevenue, Account.SObjectType).runCalc();
@@ -3333,7 +3336,7 @@ private class RollupTests {
     DMLMock mock = loadAccountIdMock(new List<ContactPointAddress>{ new ContactPointAddress(PreferenceRank = 1) });
     Rollup.apexContext = TriggerOperation.AFTER_INSERT;
     Rollup.defaultControl = new RollupControl__mdt(MaxRollupRetries__c = 0);
-    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = 'Synchronous Rollup', MaxQueryRows__c = -1, BatchChunkSize__c = 0);
+    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = 'Synchronous Rollup', MaxLookupRowsBeforeBatching__c = -1, BatchChunkSize__c = 0);
 
     try {
       Test.startTest();
@@ -3470,9 +3473,9 @@ private class RollupTests {
     insert cpas;
 
     DMLMock mock = new DMLMock();
-    Rollup.defaultControl = new RollupControl__mdt(MaxQueryRows__c = 2, BatchChunkSize__c = 1, MaxRollupRetries__c = 100);
+    Rollup.defaultControl = new RollupControl__mdt(MaxNumberOfQueries__c = 2, BatchChunkSize__c = 1, MaxRollupRetries__c = 100);
     // start as synchronous rollup to allow for one deferral
-    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = 'Synchronous Rollup', MaxQueryRows__c = 2);
+    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = 'Synchronous Rollup', MaxNumberOfQueries__c = 2);
     Rollup.DML = mock;
     Rollup.shouldRun = true;
     Rollup.records = cpas;

--- a/scripts/build-and-promote-package.ps1
+++ b/scripts/build-and-promote-package.ps1
@@ -1,0 +1,85 @@
+$ErrorActionPreference = 'Stop'
+
+function Get-Current-Git-Branch() {
+  Invoke-Expression 'git rev-parse --abbrev-ref HEAD'
+}
+
+function Get-Apex-Rollup-Package-Alias {
+  param (
+    $packageVersion
+  )
+  return "apex-rollup@$packageVersion-0"
+}
+
+function Get-SFDX-Project-JSON {
+  Get-Content -Path ./sfdx-project.json | ConvertFrom-Json
+}
+
+function Update-Last-Substring {
+  param(
+      [string]$str,
+      [string]$substr,
+      [string]$newstr
+  )
+
+  return $str.Remove(($lastIndex = $str.LastIndexOf($substr)),$substr.Length).Insert($lastIndex,$newstr)
+}
+
+if(Test-Path ".\PACKAGING_SFDX_URL.txt") {
+  sfdx auth:sfdxurl:store -f ./PACKAGING_SFDX_URL.txt -a packaging-org
+  sfdx force:config:set defaultdevhubusername=packaging-org
+} else {
+  throw 'No packaging auth info!'
+}
+
+$sfdxProjectJson = Get-SFDX-Project-JSON
+$currentPackageVersion = $sfdxProjectJson.packageDirectories.versionNumber
+
+# Cache the prior package version Id to replace in the README
+$priorPackageVersionId = $null
+try {
+  $priorPackageVersionId = $sfdxProjectJson.packageAliases | Select-Object -ExpandProperty (Get-Apex-Rollup-Package-Alias $currentPackageVersion.Trim(".0"))
+} catch {
+  # if there hasn't been a current version of the package, get the previous version and its associated package Id
+  $currentPackageNumber = ([int]($currentPackageVersion | Select-String -Pattern \S\S.0).Matches.Value)
+  $currentPackageNumberString = $currentPackageNumber.ToString()
+  $priorPackageVersionString = ($currentPackageNumber - 1).ToString()
+  $priorPackageVersionNumber = (Update-Last-Substring $currentPackageVersion $currentPackageNumberString $priorPackageVersionString).Trim(".0")
+
+  $priorPackageVersionId = $sfdxProjectJson.packageAliases | Select-Object -ExpandProperty (Get-Apex-Rollup-Package-Alias $priorPackageVersionNumber)
+}
+
+Write-Output "Prior package version: $priorPackageVersionId"
+
+# Create package version
+
+Write-Output "Creating new package version"
+
+$packageVersionNotes = $sfdxProjectJson.packageDirectories.versionDescription
+sfdx force:package:version:create -d rollup -x -w 10 -e $packageVersionNotes -c --releasenotesurl "https://github.com/jamessimone/apex-rollup/releases/latest"
+
+# Now that sfdx-project.json has been updated, grab the latest package version
+$currentPackageVersionId = (Get-SFDX-Project-JSON).packageAliases | Select-Object -ExpandProperty (Get-Apex-Rollup-Package-Alias $currentPackageVersion.Trim(".0"))
+
+Write-Output "New package version: $currentPackageVersionId"
+
+if($currentPackageVersionId -ne $priorPackageVersionId) {
+  $readmePath = ".\README.md"
+  ((Get-Content -path $readmePath -Raw) -replace $priorPackageVersionId, $currentPackageVersionId) | Set-Content -Path $readmePath -NoNewline
+  git add $readmePath
+}
+
+# promote package on merge to main
+$currentBranch = Get-Current-Git-Branch
+if($currentBranch -eq "main") {
+  Write-Output "Promoting package version"
+  sfdx force:package:version:promote -p $currentPackageVersionId -n
+}
+
+git add ./sfdx-project.json
+
+git config --global user.name "James Simone"
+git config --global user.email "16430727+jamessimone@users.noreply.github.com"
+
+git commit -m "Bumping package version from Github Action"
+git push origin head

--- a/scripts/build-and-promote-package.ps1
+++ b/scripts/build-and-promote-package.ps1
@@ -64,7 +64,7 @@ $currentPackageVersionId = (Get-SFDX-Project-JSON).packageAliases | Select-Objec
 Write-Output "New package version: $currentPackageVersionId"
 
 if($currentPackageVersionId -ne $priorPackageVersionId) {
-  $readmePath = ".\README.md"
+  $readmePath = "./README.md"
   ((Get-Content -path $readmePath -Raw) -replace $priorPackageVersionId, $currentPackageVersionId) | Set-Content -Path $readmePath -NoNewline
   git add $readmePath
 }
@@ -80,6 +80,7 @@ git add ./sfdx-project.json
 
 git config --global user.name "James Simone"
 git config --global user.email "16430727+jamessimone@users.noreply.github.com"
+git remote set-url --push origin https://jamessimone:$GITHUB_TOKEN@github.com/jamessimone/apex-rollup
 
 git commit -m "Bumping package version from Github Action"
-git push origin head
+git push

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,7 +5,7 @@
             "package": "apex-rollup",
             "path": "rollup",
             "versionNumber": "1.2.15.0",
-            "versionDescription": "DLRS rule conversion script added thanks to Jonathan Gillespie, recursion detection implemented, added README documentation for Concat Delimiter, added integration test coverage for trigger-based Rollups",
+            "versionDescription": "Automated build pipeline",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest"
         }
     ],

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -22,6 +22,7 @@
         "apex-rollup@1.2.11-0": "04t6g000008GJSbAAO",
         "apex-rollup@1.2.12-0": "04t6g000008GJYBAA4",
         "apex-rollup@1.2.13-0": "04t6g000008GJeUAAW",
-        "apex-rollup@1.2.14-0": "04t6g000008GJjQAAW"
+        "apex-rollup@1.2.14-0": "04t6g000008GJjQAAW",
+        "apex-rollup@1.2.15-0": "04t6g000008GJlWAAW"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionNumber": "1.2.14.0",
+            "versionNumber": "1.2.15.0",
             "versionDescription": "DLRS rule conversion script added thanks to Jonathan Gillespie, recursion detection implemented, added README documentation for Concat Delimiter, added integration test coverage for trigger-based Rollups",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest"
         }


### PR DESCRIPTION
* Fixes #88 by automating build pipeline for package version creation, promotion, and replacement in README
* **BREAKING CHANGE** `RollupControl__mdt.MaxQueryRows__c` updated to `RollupControl__mdt.MaxNumberOfQueries__c` - this field was improperly named as part of [v1.1.2](https://github.com/jamessimone/apex-rollup/releases/tag/v1.1.2), to my chagrin. The concept for "Max Query Rows" was already encapsulated in `RollupControl__mdt.MaxLookupRowsBeforeBatching__c` field
* Fixed a bug reported by Katherine West where `RollupFullBatchRecalculator` would not properly reset field values when batching - this issue was exacerbated by the "Max Query Rows" updates, above; batching was happening way earlier than it should have because the limit that `Rollup` was looking to was 100 instead of 3000 (the default for `MaxLookupRowsBeforeBatching__c`
* Some more tooling on how `RollupEvaluator` gets initialized/passed around within `Rollup` itself, specifically in regards to the recursion detection released in #91 