### PR TITLE
V1.2.16 - Slight performance tweaks

### DIFF
--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -42,22 +42,21 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   private final SObjectField lookupFieldOnLookupObject;
   private final SObjectField opFieldOnLookupObject;
   private final SObjectType lookupObj;
+  private final Evaluator eval;
   private final Op op;
   private final Boolean isBatched;
-  private final Id rollupControlId;
   private final Rollup__mdt metadata;
+  private final RollupControl__mdt rollupControl;
 
   protected final SObjectType calcItemType;
   protected final RollupInvocationPoint invokePoint;
 
   // non-final instance variables
   protected Boolean isFullRecalc = false;
-  private Evaluator eval;
   private Boolean isCDCUpdate = false;
   private Boolean isNoOp;
   private Map<SObjectType, Set<String>> lookupObjectToUniqueFieldNames;
   private List<SObject> lookupItems;
-  private RollupControl__mdt rollupControl;
   private RollupRelationshipFieldFinder.Traversal traversal;
 
   /**
@@ -187,7 +186,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       innerRollup.oldCalcItems,
       null, // eval gets assigned below
       innerRollup.invokePoint,
-      innerRollup.rollupControlId,
+      innerRollup.rollupControl,
       innerRollup.metadata
     );
 
@@ -195,7 +194,6 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     this.isNoOp = this.rollups.isEmpty() && innerRollup.metadata?.IsFullRecordSet__c == false;
     this.isFullRecalc = innerRollup.isFullRecalc;
     this.isCDCUpdate = innerRollup.isCDCUpdate;
-    this.rollupControl = innerRollup.rollupControl;
     this.eval = innerRollup.eval;
   }
 
@@ -215,9 +213,10 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     Map<Id, SObject> oldCalcItems,
     Evaluator eval,
     RollupInvocationPoint invokePoint,
-    Id rollupControlId,
+    RollupControl__mdt rollupControl,
     Rollup__mdt rollupMetadata
   ) {
+    this.calcItems = calcItems;
     this.opFieldOnCalcItem = opFieldOnCalcItem;
     this.lookupFieldOnCalcItem = lookupFieldOnCalcItem;
     this.lookupFieldOnLookupObject = lookupFieldOnLookupObject;
@@ -228,14 +227,14 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     this.oldCalcItems = oldCalcItems;
     this.isBatched = false;
     this.invokePoint = invokePoint;
-    this.rollupControlId = rollupControlId;
+    this.rollupControl = rollupControl;
     this.metadata = rollupMetadata;
 
-    FilterResults results = this.filter(calcItems, eval);
-    this.calcItems = results.matchingItems;
-    this.eval = results.eval;
+    if (eval != null) {
+      this.eval = eval;
+    }
 
-    this.isNoOp = this.calcItems.isEmpty() && this.metadata?.IsFullRecordSet__c == false;
+    this.isNoOp = this.calcItems?.isEmpty() == true && this.metadata?.IsFullRecordSet__c == false;
   }
 
   global interface Evaluator {
@@ -269,13 +268,11 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   }
 
   public String runCalc() {
-    RollupControl__mdt orgDefaults = getSingleControlOrDefault(RollupControl__mdt.DeveloperName, CONTROL_ORG_DEFAULTS, defaultControl);
-    this.rollupControl = orgDefaults;
     // side effect in the below method - rollups can be removed from this.rollups if a control record ShouldAbortRun__c == true
-    this.ingestRollupControlData(orgDefaults);
+    this.ingestRollupControlData();
 
     this.isNoOp = this.rollups.isEmpty() && this.syncRollups.isEmpty();
-    if (this.isNoOp || orgDefaults.ShouldAbortRun__c || SETTINGS.IsEnabled__c == false) {
+    if (this.isNoOp || this.rollupControl.ShouldAbortRun__c || SETTINGS.IsEnabled__c == false) {
       return 'No process Id';
     }
 
@@ -284,15 +281,17 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
     Boolean shouldBatch =
       shouldRunAsBatch ||
-      (orgDefaults.ShouldRunAs__c == RollupShouldRunAsPicklist.Instance.BATCHABLE &&
-      totalCountOfRecords >= orgDefaults.MaxLookupRowsBeforeBatching__c) ||
+      (this.rollupControl.ShouldRunAs__c == RollupShouldRunAsPicklist.Instance.BATCHABLE &&
+      totalCountOfRecords >= this.rollupControl.MaxLookupRowsBeforeBatching__c) ||
       totalCountOfRecords == SENTINEL_COUNT_VALUE;
     if (this.syncRollups.isEmpty() == false) {
       this.process(this.syncRollups);
       return 'Running rollups flagged to go synchronously';
-    } else if (shouldBatch && hasMoreThanOneTarget == false) {
+    } else if (shouldBatch && hasMoreThanOneTarget == false && System.isBatch() == false) {
       isRunningAsync = true;
       // safe to batch because the QueryLocator will only return one type of SObject
+      // we have to re-initialize the rollup because it's the Queueable inner class
+      // at this point, and without re-initialization we get "System.UnexpectedException: Error processing messages"
       return Database.executeBatch(new Rollup(this), this.rollupControl.BatchChunkSize__c.intValue());
     } else {
       isRunningAsync = true;
@@ -360,8 +359,8 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       Op operation,
       Map<Id, SObject> oldCalcItems,
       Evaluator eval,
-      Id rollupControlId,
       RollupInvocationPoint rollupInvokePoint,
+      RollupControl__mdt rollupControl,
       Rollup__mdt metadata
     ) {
       super(
@@ -376,7 +375,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         oldCalcItems,
         eval,
         rollupInvokePoint,
-        rollupControlId,
+        rollupControl,
         metadata
       );
     }
@@ -1976,11 +1975,13 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       RollupControl__mdt localControl;
       if (rollupMetadata.RollupControl__c != null) {
         // for CMDT-driven rollups, the rollup record is always tied to a RollupControl__mdt record
-        localControl = new RollupControl__mdt(Id = rollupMetadata.RollupControl__c);
+        localControl = getSingleControlOrDefault(RollupControl__mdt.Id, rollupMetadata.RollupControl__c, Rollup.specificControl);
       } else {
         String controlKey = getRollupControlKey(rollupInvokePoint, rollupFieldOnCalcItem, lookupSObjectType, rollupFieldOnOpObject);
-        localControl = getSingleControlOrDefault(RollupControl__mdt.TriggerOrInvocableName__c, controlKey, null);
+        localControl = getSingleControlOrDefault(RollupControl__mdt.TriggerOrInvocableName__c, controlKey, Rollup.specificControl);
       }
+
+      FilterResults filterResults = filter(calcItems, oldCalcItems, eval, rollupMetadata, sObjectType);
 
       loadRollups(
         rollupFieldOnCalcItem,
@@ -1990,11 +1991,11 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         lookupSObjectType,
         sObjectType, // calc item SObjectType
         rollupOp,
-        calcItems,
+        filterResults.matchingItems,
         oldCalcItems,
         batchRollup,
-        eval,
-        localControl?.Id,
+        filterResults.eval,
+        localControl,
         rollupInvokePoint,
         rollupMetadata
       );
@@ -2098,7 +2099,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     Map<Id, SObject> oldCalcItems,
     Rollup batchRollup,
     Evaluator eval,
-    Id rollupControlId,
+    RollupControl__mdt rollupControl,
     RollupInvocationPoint invokePoint,
     Rollup__mdt rollupMetadata
   ) {
@@ -2113,8 +2114,8 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       rollupOp,
       oldCalcItems,
       eval,
-      rollupControlId,
       invokePoint,
+      rollupControl,
       rollupMetadata
     );
     return loadRollups(rollup, batchRollup);
@@ -2133,8 +2134,12 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     // there are multiple spots where testOverrideData can be supplied, which is why it's necessary to pass the argument to this method
     if (testOverrideData != null) {
       return testOverrideData;
-    } else if (whereField == RollupControl__mdt.Id) {
-      return RollupControl__mdt.getInstance((Id) whereValue)?.clone(true, true);
+    } else if (whereField == RollupControl__mdt.Id || whereField == RollupControl__mdt.DeveloperName) {
+      String whereKey = (String) whereValue;
+      RollupControl__mdt potentialControl = RollupControl__mdt.getInstance(whereKey);
+      if (potentialControl != null) {
+        return potentialControl.clone(true, true);
+      }
     }
     List<RollupControl__mdt> rollupControls = getMetadataFromCache(RollupControl__mdt.SObjectType);
     for (RollupControl__mdt rollupControl : rollupControls) {
@@ -2167,6 +2172,104 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       sensibleDefault = sensibleDefault.clone(true, true);
     }
     return sensibleDefault;
+  }
+
+  private static FilterResults filter(List<SObject> calcItems, Map<Id, SObject> oldCalcItems, Evaluator eval, Rollup__mdt metadata, SObjectType calcItemType) {
+    FilterResults results = new FilterResults();
+    Set<String> alwaysFullRecalcOps = new Set<String>{ 'FIRST', 'LAST', 'AVERAGE' };
+    List<SObject> matchingItems = calcItems == null ? new List<SObject>() : calcItems.clone();
+    results.matchingItems = matchingItems;
+    if (matchingItems.isEmpty()) {
+      return results;
+    }
+    matchingItems.clear(); // retains the strong-typing on the list for downstream calls to List.getSbjectType()
+    calcItems = replaceCalcItemsForPolymorphicWhereClause(calcItems, metadata);
+
+    results.eval = RollupEvaluator.getEvaluator(eval, metadata, oldCalcItems, calcItemType);
+
+    for (SObject item : calcItems) {
+      if (results.eval.matches(item)) {
+        matchingItems.add(item);
+        // metadata shouldn't be null, but it's good to check; unfortunately, if(null) throws so we
+        // have to do this EXTRA explicit check
+      } else if (metadata?.IsFullRecordSet__c == true) {
+        matchingItems.add(item);
+      } else if (alwaysFullRecalcOps.contains(metadata?.RollupOperation__c)) {
+        matchingItems.add(item);
+      }
+    }
+    return results;
+  }
+
+  private static List<SObject> replaceCalcItemsForPolymorphicWhereClause(List<SObject> calcItems, Rollup__mdt metadata) {
+    final String typeField = '.Type';
+    final String owner = 'Owner.';
+
+    // first we check to see if there is a calc item where clause, and that it contains any of the common polymorphic fields
+    SObject firstItem = calcItems[0];
+    if (String.isBlank(metadata?.CalcItemWhereClause__c)) {
+      return calcItems;
+    }
+    Boolean hasOwnerClause = metadata.CalcItemWhereClause__c.contains(owner);
+    Boolean hasTypeClause = metadata.CalcItemWhereClause__c.contains(typeField);
+    SObjectType sObjectType = firstItem.getSObjectType();
+    Map<String, Schema.SObjectField> fieldMap = sObjectType.getDescribe().fields.getMap();
+    Boolean hasPolyMorphicFields = hasOwnerClause || hasTypeClause || fieldMap.get(metadata.LookupFieldOnCalcItem__c)?.getDescribe().isNamePointing() == true;
+
+    if (hasPolyMorphicFields) {
+      if (hasTypeClause == false && hasOwnerClause == false) {
+        return calcItems;
+      }
+
+      // the calc item where clause contains at least one polymorphic field, but before re-querying we validate whether or not the fields are already provided
+      Map<String, Object> populatedFields = firstItem.getPopulatedFieldsAsMap();
+      Set<String> additionalQueryFields = new Set<String>();
+      List<String> optionalWhereClauses = new List<String>();
+
+      processWhereClauseForDownstreamEvals(optionalWhereClauses, additionalQueryFields, sObjectType, typeField, owner, metadata);
+
+      // we have to manually iterate through these fields because the "fieldMap" keySet is all in lowercase because it's ... special
+      // and only responds properly to proper-cased fields when you call the map "containsKey" method - if the field names in the keySet were
+      // proper-cased, we could just call additionalQueryFields.addAll(populatedFields.keySet().removeAll(fieldMap.keySet())) - alas
+      // this awesome one-liner doesn't work for us
+      for (String fieldName : populatedFields.keySet()) {
+        if (fieldMap.containsKey(fieldName)) {
+          additionalQueryFields.add(fieldName);
+        }
+      }
+
+      String queryString = getQueryString(sObjectType, new List<String>(additionalQueryFields), 'Id', '=', String.join(optionalWhereClauses, ' AND '));
+      List<String> objIds = new List<String>();
+      for (SObject record : calcItems) {
+        if (String.isNotBlank(record.Id)) {
+          objIds.add(record.Id);
+        }
+      }
+      calcItems = Database.query(queryString);
+    }
+    return calcItems;
+  }
+
+  private static void processWhereClauseForDownstreamEvals(
+    List<String> optionalWhereClauses,
+    Set<String> additionalQueryFields,
+    SObjectType sObjectType,
+    String typeField,
+    String owner,
+    Rollup__mdt metadata
+  ) {
+    RollupEvaluator.WhereFieldEvaluator whereEval = new RollupEvaluator.WhereFieldEvaluator(metadata.CalcItemWhereClause__c, sObjectType);
+    for (String whereClause : whereEval.getWhereClauses()) {
+      if (whereClause.contains(typeField) || whereClause.contains(owner)) {
+        List<String> splitWheres = whereClause.split(' ');
+        if (splitWheres.size() > 0) {
+          additionalQueryFields.add(splitWheres[0]);
+        }
+        // "consume" the metadata where clause for downstream evaluators
+        metadata.CalcItemWhereClause__c = metadata.CalcItemWhereClause__c.replace(whereClause, '');
+        optionalWhereClauses.add(whereClause);
+      }
+    }
   }
 
   /** End static section, begin protected + private instance methods */
@@ -2284,106 +2387,6 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     throw new AsyncException('Rollup failed to re-queue for: ' + JSON.serialize(failedRollupInfo));
   }
 
-  private FilterResults filter(List<SObject> calcItems, Evaluator eval) {
-    FilterResults results = new FilterResults();
-    Set<String> alwaysFullRecalcOps = new Set<String>{ 'FIRST', 'LAST', 'AVERAGE' };
-    List<SObject> matchingItems = calcItems == null ? new List<SObject>() : calcItems.clone();
-    results.matchingItems = matchingItems;
-    if (matchingItems.isEmpty()) {
-      return results;
-    }
-    matchingItems.clear(); // retains the strong-typing on the list for downstream calls to List.getSbjectType()
-    calcItems = this.replaceCalcItemsForPolymorphicWhereClause(calcItems);
-
-    results.eval = RollupEvaluator.getEvaluator(eval, this.metadata, oldCalcItems, this.calcItemType);
-
-    for (SObject item : calcItems) {
-      if (results.eval.matches(item)) {
-        matchingItems.add(item);
-        // metadata shouldn't be null, but it's good to check; unfortunately, if(null) throws so we
-        // have to do this EXTRA explicit check
-      } else if (this.metadata?.IsFullRecordSet__c == true) {
-        matchingItems.add(item);
-      } else if (alwaysFullRecalcOps.contains(this.metadata?.RollupOperation__c)) {
-        matchingItems.add(item);
-      }
-    }
-    return results;
-  }
-
-  private List<SObject> replaceCalcItemsForPolymorphicWhereClause(List<SObject> calcItems) {
-    final String typeField = '.Type';
-    final String owner = 'Owner.';
-
-    // first we check to see if there is a calc item where clause, and that it contains any of the common polymorphic fields
-    SObject firstItem = calcItems[0];
-    if (String.isBlank(this.metadata?.CalcItemWhereClause__c)) {
-      return calcItems;
-    }
-    Boolean hasOwnerClause = this.metadata.CalcItemWhereClause__c.contains(owner);
-    Boolean hasTypeClause = this.metadata.CalcItemWhereClause__c.contains(typeField);
-    SObjectType sObjectType = firstItem.getSObjectType();
-    Map<String, Schema.SObjectField> fieldMap = sObjectType.getDescribe().fields.getMap();
-    Boolean hasPolyMorphicFields =
-      hasOwnerClause ||
-      hasTypeClause ||
-      fieldMap.get(this.metadata.LookupFieldOnCalcItem__c)?.getDescribe().isNamePointing() == true;
-
-    if (hasPolyMorphicFields) {
-      if (hasTypeClause == false && hasOwnerClause == false) {
-        return calcItems;
-      }
-
-      // the calc item where clause contains at least one polymorphic field, but before re-querying we validate whether or not the fields are already provided
-      Map<String, Object> populatedFields = firstItem.getPopulatedFieldsAsMap();
-      Set<String> additionalQueryFields = new Set<String>();
-      List<String> optionalWhereClauses = new List<String>();
-
-      this.processWhereClauseForDownstreamEvals(optionalWhereClauses, additionalQueryFields, sObjectType, typeField, owner);
-
-      // we have to manually iterate through these fields because the "fieldMap" keySet is all in lowercase because it's ... special
-      // and only responds properly to proper-cased fields when you call the map "containsKey" method - if the field names in the keySet were
-      // proper-cased, we could just call additionalQueryFields.addAll(populatedFields.keySet().removeAll(fieldMap.keySet())) - alas
-      // this awesome one-liner doesn't work for us
-      for (String fieldName : populatedFields.keySet()) {
-        if (fieldMap.containsKey(fieldName)) {
-          additionalQueryFields.add(fieldName);
-        }
-      }
-
-      String queryString = getQueryString(sObjectType, new List<String>(additionalQueryFields), 'Id', '=', String.join(optionalWhereClauses, ' AND '));
-      List<String> objIds = new List<String>();
-      for (SObject record : calcItems) {
-        if (String.isNotBlank(record.Id)) {
-          objIds.add(record.Id);
-        }
-      }
-      calcItems = Database.query(queryString);
-    }
-    return calcItems;
-  }
-
-  private void processWhereClauseForDownstreamEvals(
-    List<String> optionalWhereClauses,
-    Set<String> additionalQueryFields,
-    SObjectType sObjectType,
-    String typeField,
-    String owner
-  ) {
-    RollupEvaluator.WhereFieldEvaluator whereEval = new RollupEvaluator.WhereFieldEvaluator(this.metadata.CalcItemWhereClause__c, sObjectType);
-    for (String whereClause : whereEval.getWhereClauses()) {
-      if (whereClause.contains(typeField) || whereClause.contains(owner)) {
-        List<String> splitWheres = whereClause.split(' ');
-        if (splitWheres.size() > 0) {
-          additionalQueryFields.add(splitWheres[0]);
-        }
-        // "consume" the metadata where clause for downstream evaluators
-        this.metadata.CalcItemWhereClause__c = this.metadata.CalcItemWhereClause__c.replace(whereClause, '');
-        optionalWhereClauses.add(whereClause);
-      }
-    }
-  }
-
   private void getFieldNamesForRollups(List<Rollup> rollups) {
     this.lookupObjectToUniqueFieldNames = new Map<SObjectType, Set<String>>();
     for (Rollup rollup : rollups) {
@@ -2455,21 +2458,17 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     }
   }
 
-  private void ingestRollupControlData(RollupControl__mdt orgDefaults) {
+  private void ingestRollupControlData() {
+    RollupControl__mdt orgDefaults = this.rollupControl;
     for (Integer index = this.rollups.size() - 1; index >= 0; index--) {
       Rollup rollup = this.rollups[index];
-      SObjectField controlWhereField = rollup.rollupControlId == null ? RollupControl__mdt.TriggerOrInvocableName__c : RollupControl__mdt.Id;
-      String controlWhereValue = rollup.rollupControlId == null
-        ? getRollupControlKey(rollup.invokePoint, rollup.opFieldOnCalcItem, rollup.lookupObj, rollup.opFieldOnLookupObject)
-        : rollup.rollupControlId;
-      RollupControl__mdt rollupSpecificControl = getSingleControlOrDefault(controlWhereField, controlWhereValue, specificControl);
-      rollup.rollupControl = rollupSpecificControl;
 
       Boolean shouldRunSyncDeferred = this.getShouldRunSyncDeferred(rollup);
       Boolean couldRunSync =
-        rollupSpecificControl.ShouldRunAs__c == RollupShouldRunAsPicklist.Instance.SYNCHRONOUS || (hasExceededCurrentRollupLimits(rollupSpecificControl) == false) && isRunningAsync;
+        rollup.rollupControl.ShouldRunAs__c == RollupShouldRunAsPicklist.Instance.SYNCHRONOUS ||
+        (hasExceededCurrentRollupLimits(rollup.rollupControl) == false) && isRunningAsync;
 
-      if (rollupSpecificControl.ShouldAbortRun__c) {
+      if (rollup.rollupControl.ShouldAbortRun__c || orgDefaults.ShouldAbortRun__c) {
         this.rollups.remove(index);
       } else if (couldRunSync && shouldRunSyncDeferred == false) {
         this.rollups.remove(index);
@@ -2480,11 +2479,14 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       }
 
       // you can increase the default limits, but it would be too messy to try to rank the individual rollup operations in a batched context
-      if (rollupSpecificControl.MaxLookupRowsBeforeBatching__c > orgDefaults.MaxLookupRowsBeforeBatching__c) {
-        orgDefaults.MaxLookupRowsBeforeBatching__c = rollupSpecificControl.MaxLookupRowsBeforeBatching__c;
+      if (rollup.rollupControl.MaxLookupRowsBeforeBatching__c > orgDefaults.MaxLookupRowsBeforeBatching__c) {
+        orgDefaults.MaxLookupRowsBeforeBatching__c = rollup.rollupControl.MaxLookupRowsBeforeBatching__c;
       }
-      if (rollupSpecificControl.MaxParentRowsUpdatedAtOnce__c == null) {
-        rollupSpecificControl.MaxParentRowsUpdatedAtOnce__c = orgDefaults.MaxParentRowsUpdatedAtOnce__c;
+      if (rollup.rollupControl.ShouldRunAs__c != orgDefaults.ShouldRunAs__c) {
+        orgDefaults.ShouldRunAs__c = rollup.rollupControl.ShouldRunAs__c;
+      }
+      if (rollup.rollupControl.MaxParentRowsUpdatedAtOnce__c == null) {
+        rollup.rollupControl.MaxParentRowsUpdatedAtOnce__c = orgDefaults.MaxParentRowsUpdatedAtOnce__c;
       }
     }
   }

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -3,6 +3,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
   private static final String TRUE_VAL = 'true';
   private static final String FALSE_VAL = 'false';
   private static final Set<String> POLYMORPHIC_FIELDS = new Set<String>{ 'Owner', 'Type' };
+  private static final AlwaysTrueEvaluator ALWAYS_TRUE_SINGLETON = new AlwaysTrueEvaluator();
 
   // totally not obvious ranking going on here - it's absolutely imperative that
   // the two-word conditions go first; otherwise replacing will fail on the whole string
@@ -36,7 +37,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
   public abstract Boolean matches(Object calcItem);
 
   public static Rollup.Evaluator getEvaluator(Rollup.Evaluator eval, Rollup__mdt metadata, Map<Id, SObject> oldCalcItems, SObjectType sObjectType) {
-    List<Rollup.Evaluator> evals = new List<Rollup.Evaluator>{ eval == null ? new AlwaysTrue() : eval };
+    List<Rollup.Evaluator> evals = new List<Rollup.Evaluator>{ eval == null ? ALWAYS_TRUE_SINGLETON : eval };
 
     if (String.isNotBlank(metadata.CalcItemWhereClause__c)) {
       evals.add(new WhereFieldEvaluator(metadata, sObjectType, oldCalcItems));
@@ -70,7 +71,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
   }
 
   @testVisible
-  private class AlwaysTrue extends RollupEvaluator {
+  private class AlwaysTrueEvaluator extends RollupEvaluator {
     public override Boolean matches(Object calcItem) {
       return true;
     }

--- a/rollup/tests/RollupEvaluatorTests.cls
+++ b/rollup/tests/RollupEvaluatorTests.cls
@@ -379,7 +379,7 @@ private class RollupEvaluatorTests {
     Rollup__mdt rollupMetadata = new Rollup__mdt(LookupFieldOnCalcItem__c = 'AccountId', RollupOperation__c = Rollup.Op.SUM.name());
 
     Rollup.Evaluator eval = RollupEvaluator.getEvaluator(
-      new RollupEvaluator.AlwaysTrue(),
+      new RollupEvaluator.AlwaysTrueEvaluator(),
       rollupMetadata,
       new Map<Id, SObject>{ oldOpp.Id => oldOpp },
       Opportunity.SObjectType
@@ -398,7 +398,7 @@ private class RollupEvaluatorTests {
     Rollup__mdt rollupMetadata = new Rollup__mdt(ChangedFieldsOnCalcItem__c = 'Amount', RollupOperation__c = Rollup.Op.SUM.name());
 
     Rollup.Evaluator eval = RollupEvaluator.getEvaluator(
-      new RollupEvaluator.AlwaysTrue(),
+      new RollupEvaluator.AlwaysTrueEvaluator(),
       rollupMetadata,
       new Map<Id, SObject>{ oldOpp.Id => oldOpp, secondOpp.Id => secondOpp },
       Opportunity.SObjectType
@@ -419,7 +419,7 @@ private class RollupEvaluatorTests {
     Rollup__mdt rollupMetadata = new Rollup__mdt(CalcItemWhereClause__c = 'Amount > 20', RollupOperation__c = Rollup.Op.SUM.name());
 
     Rollup.Evaluator eval = RollupEvaluator.getEvaluator(
-      new RollupEvaluator.AlwaysTrue(),
+      new RollupEvaluator.AlwaysTrueEvaluator(),
       rollupMetadata,
       new Map<Id, SObject>{ oldOpp.Id => oldOpp, secondOpp.Id => secondOpp },
       Opportunity.SObjectType
@@ -444,7 +444,7 @@ private class RollupEvaluatorTests {
     );
 
     Rollup.Evaluator eval = RollupEvaluator.getEvaluator(
-      new RollupEvaluator.AlwaysTrue(),
+      new RollupEvaluator.AlwaysTrueEvaluator(),
       rollupMetadata,
       new Map<Id, SObject>{ oldOpp.Id => oldOpp, secondOpp.Id => secondOpp },
       Opportunity.SObjectType
@@ -608,7 +608,7 @@ private class RollupEvaluatorTests {
     );
 
     Rollup.Evaluator eval = RollupEvaluator.getEvaluator(
-      new RollupEvaluator.AlwaysTrue(),
+      new RollupEvaluator.AlwaysTrueEvaluator(),
       rollupMetadata,
       new Map<Id, SObject>{ oldOpp.Id => oldOpp },
       Opportunity.SObjectType
@@ -643,7 +643,7 @@ private class RollupEvaluatorTests {
     );
 
     Rollup.Evaluator eval = RollupEvaluator.getEvaluator(
-      new RollupEvaluator.AlwaysTrue(),
+      new RollupEvaluator.AlwaysTrueEvaluator(),
       rollupMetadata,
       new Map<Id, SObject>{ oldOpp.Id => oldOpp },
       Opportunity.SObjectType
@@ -651,7 +651,7 @@ private class RollupEvaluatorTests {
 
     System.assertEquals(true, eval.matches(opp), 'Should return true when not recursive!');
 
-    eval = RollupEvaluator.getEvaluator(new RollupEvaluator.AlwaysTrue(), rollupMetadata, new Map<Id, SObject>{ oldOpp.Id => oldOpp }, Opportunity.SObjectType);
+    eval = RollupEvaluator.getEvaluator(new RollupEvaluator.AlwaysTrueEvaluator(), rollupMetadata, new Map<Id, SObject>{ oldOpp.Id => oldOpp }, Opportunity.SObjectType);
 
     System.assertEquals(false, eval.matches(opp), 'Should not return true when recursive and all other conditions true');
   }
@@ -668,11 +668,11 @@ private class RollupEvaluatorTests {
       LookupFieldOnCalcItem__c = 'AccountId'
     );
 
-    Rollup.Evaluator eval = RollupEvaluator.getEvaluator(new RollupEvaluator.AlwaysTrue(), rollupMetadata, new Map<Id, SObject>(), Opportunity.SObjectType);
+    Rollup.Evaluator eval = RollupEvaluator.getEvaluator(new RollupEvaluator.AlwaysTrueEvaluator(), rollupMetadata, new Map<Id, SObject>(), Opportunity.SObjectType);
 
     System.assertEquals(true, eval.matches(opp), 'Should return true when not recursive!');
 
-    eval = RollupEvaluator.getEvaluator(new RollupEvaluator.AlwaysTrue(), rollupMetadata, new Map<Id, SObject>(), Opportunity.SObjectType);
+    eval = RollupEvaluator.getEvaluator(new RollupEvaluator.AlwaysTrueEvaluator(), rollupMetadata, new Map<Id, SObject>(), Opportunity.SObjectType);
 
     System.assertEquals(false, eval.matches(opp), 'Should not return true when recursive and all other conditions true');
     System.assertEquals(false, eval.matches(nonMatchingOpp), 'Should not match to begin with based on calc item where clause');

--- a/rollup/tests/RollupTests.cls
+++ b/rollup/tests/RollupTests.cls
@@ -2846,6 +2846,8 @@ private class RollupTests {
     Test.stopTest();
 
     System.assertEquals(1, mock.Records.size(), 'Rollup run should have run');
+    Account acc = (Account) mock.Records[0];
+    System.assertEquals(1, acc.AnnualRevenue);
     System.assertEquals('Completed', [SELECT Status FROM AsyncApexJob WHERE JobType = 'BatchApexWorker'].Status);
   }
 
@@ -2860,6 +2862,8 @@ private class RollupTests {
     Test.stopTest();
 
     System.assertEquals(1, mock.Records.size(), 'Rollup run should have run');
+    Account acc = (Account) mock.Records[0];
+    System.assertEquals(1, acc.AnnualRevenue);
     System.assertEquals('Completed', [SELECT Status FROM AsyncApexJob WHERE JobType = 'Queueable' LIMIT 1]?.Status);
   }
 
@@ -3016,7 +3020,7 @@ private class RollupTests {
     };
     insert cpas;
 
-    Rollup.defaultControl = new RollupControl__mdt(MaxNumberOfQueries__c = 1, BatchChunkSize__c = 10);
+    Rollup.defaultControl = new RollupControl__mdt(MaxLookupRowsBeforeBatching__c = 1, BatchChunkSize__c = 10, ShouldRunAs__c = RollupShouldRunAsPicklist.Instance.BATCHABLE);
 
     Rollup__mdt meta = new Rollup__mdt(
       CalcItem__c = 'ContactPointAddress',

--- a/scripts/build-and-promote-package.ps1
+++ b/scripts/build-and-promote-package.ps1
@@ -1,3 +1,8 @@
+# This script is invoked by the Github Action on pull requests / merges to main
+# It relies on two pieces of information being set manually in your sfdx-project.json:
+# the versionDescription and versionNumber for the default package. Using those two pieces of information,
+# this script generates a new package version Id per unique Action run, and promotes that package on merges to main
+# it also updates the Ids referenced in the README, and bumps the package version number in the package.json file
 $ErrorActionPreference = 'Stop'
 
 function Get-Current-Git-Branch() {
@@ -65,7 +70,7 @@ Write-Output "Prior package version number: $priorPackageVersionNumber"
 Write-Output "Creating new package version"
 
 $packageVersionNotes = $sfdxProjectJson.packageDirectories.versionDescription
-sfdx force:package:version:create -d rollup -x -w 10 -e $packageVersionNotes -c --releasenotesurl "https://github.com/jamessimone/apex-rollup/releases/latest"
+sfdx force:package:version:create -d rollup -x -w 10 -e $packageVersionNotes -c --releasenotesurl $sfdxProjectJson.packageDirectories.releaseNotesUrl
 
 # Now that sfdx-project.json has been updated, grab the latest package version
 $currentPackageVersionId = $null

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionNumber": "1.2.15.0",
-            "versionDescription": "Automated build pipeline",
+            "versionNumber": "1.2.16.0",
+            "versionDescription": "Slight performance improvements",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest"
         }
     ],


### PR DESCRIPTION
* Additional cleanup spurred by having temporarily moved each Rollup's instance `eval` evaluator variable to be non-final, which in addition to being bothersome exposed some hand-off issues between the batch class version of Rollup and its queueable inner class. This also revealed a few spots where the `RollupControl__mdt` was being fetched twice for no reason.
* Introduced an explanatory comment on the `Database.executeBatch` section of Rollup's `runCalc` method, as a newcomer might find themselves ... wondering ... why we were re-initializing the class 😅🔍
* small heap size improvement in `RollupEvaluator` (cc @ssk42, in the event you had broken ground there, but this shouldn't be a merge-conflict scenario of any kind); holdover from #91; empty object pattern (`AlwaysTrueEvaluator`) should always be implemented as a singleton