### PR TITLE
V1.2.18 - Correct hashCode implementation, deferred rollup bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Create fast, scalable custom rollups driven by Custom Metadata in your Salesforc
 
 ### Package deployment options
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008nt3WAAQ">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008nt4PAAQ">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008nt3WAAQ">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008nt4PAAQ">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -584,10 +584,10 @@ private class RollupIntegrationTests {
 
   @isTest
   static void shouldNotBlowUpForRecursiveCheckOnFormulaFields() {
-    String oppId = Opportunity.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12);
+    String oppId = RollupTestUtils.createId(Opportunity.SObjectType);
     Opportunity opp = new Opportunity(
       Amount = 15,
-      AccountId = Account.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12),
+      AccountId = RollupTestUtils.createId(Account.SObjectType),
       Id = oppId
     );
     List<Opportunity> opps = new List<Opportunity>{ opp };
@@ -620,7 +620,7 @@ private class RollupIntegrationTests {
 
     System.assertEquals(false, eval.matches(opp), 'Should not match when recursive!');
 
-    opp.Id = oppId.removeEnd('0') + '1';
+    opp.Id = oppId.substring(0, oppId.length() - 1) + 'Y';
 
     System.assertEquals(true, eval.matches(opp), 'Should match recursively if values do not match');
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.2.17.0",
+  "version": "1.2.18.0",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -697,10 +697,10 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         fromInvocable
       );
       if (flowInput.deferProcessing == true) {
-        staticLogMessage('deferring processing for rollup', roll);
+        ROLLUP_LOGGER.log('deferring processing for rollup', roll);
         CACHED_ROLLUPS.add(roll);
       } else {
-        staticLogMessage('adding invocable rollup to list', roll);
+        ROLLUP_LOGGER.log('adding invocable rollup to list', roll);
         rollups.add(roll);
       }
     }
@@ -710,7 +710,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         batch(rollups, fromInvocable);
       }
     } catch (Exception ex) {
-      staticLogException('an error occurred during invocable action', ex);
+       ROLLUP_LOGGER.log('an error occurred during invocable action', ex);
       for (FlowOutput flowOutput : flowOutputs) {
         flowOutput.IsSuccess = false;
         flowOutput.Message = ex.getMessage() + '\n' + ex.getStackTraceString();
@@ -1576,7 +1576,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   }
 
   public static void processStoredFlowRollups() {
-    staticLogMessage('processing deferred flow rollups', CACHED_ROLLUPS);
+    ROLLUP_LOGGER.log('processing deferred flow rollups', CACHED_ROLLUPS);
     batch(CACHED_ROLLUPS, RollupInvocationPoint.FROM_INVOCABLE);
     CACHED_ROLLUPS.clear();
   }
@@ -1739,7 +1739,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
     if (String.isNotBlank(errorMessage)) {
       Exception ex = new IllegalArgumentException(errorMessage);
-      staticLogException('an error occurred while validating flow inputs', ex);
+       ROLLUP_LOGGER.log('an error occurred while validating flow inputs', ex);
       throw ex;
     }
   }
@@ -1763,7 +1763,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         (flowInput.isRollupStartedFromParent ? firstRecord : lookupItem).get(flowInput.lookupFieldOnOpObject);
       }
     } catch (Exception ex) {
-      staticLogException('an error occurred while validating flow-specific rules', ex);
+       ROLLUP_LOGGER.log('an error occurred while validating flow-specific rules', ex);
       throw ex;
     }
   }
@@ -1800,7 +1800,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         optionalWhereClause = optionalWhereClause.substringBeforeLast('OR').trim();
       }
     } catch (Exception ex) {
-      staticLogException('an error occurred while formatting where clause', ex);
+       ROLLUP_LOGGER.log('an error occurred while formatting where clause', ex);
     }
     return optionalWhereClause;
   }
@@ -1911,7 +1911,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     try {
       return Database.countQuery(countQuery);
     } catch (Exception ex) {
-      staticLogException('an error occurred while trying to get count query:\n' + countQuery, ex);
+       ROLLUP_LOGGER.log('an error occurred while trying to get count query:\n' + countQuery, ex);
       // not all queries are valid, particularly those with polymorphic fields referencing parent fields
       // return a sentinel value instead, to be checked for downstream
       return SENTINEL_COUNT_VALUE;
@@ -2346,14 +2346,6 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
   private static String getBareOperationName(String fullOpName) {
     return fullOpName.contains('_') ? fullOpName.substringAfter('_') : fullOpName;
-  }
-
-  private static void staticLogException(String customizedError, Exception ex) {
-    ROLLUP_LOGGER.log(customizedError, ex);
-  }
-
-  private static void staticLogMessage(String customMessage, Object logObject) {
-    ROLLUP_LOGGER.log(customMessage, logObject);
   }
 
   /** End static section, begin protected + private instance methods */

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -2483,8 +2483,8 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       this.deferredRollups.clear();
 
       // swap off on which async process is running to achieve infinite scaling
-      if (System.isQueueable()) {
-        Database.executeBatch(this, this.rollupControl.BatchChunkSize__c.intValue());
+      if (System.isQueueable() || shouldRunAsBatch) {
+        Database.executeBatch(new Rollup(this), this.rollupControl.BatchChunkSize__c.intValue());
       } else if (Limits.getLimitQueueableJobs() > Limits.getQueueableJobs()) {
         System.enqueueJob(this);
       } else {

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -589,42 +589,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
   private class RecursiveTracker {
     public Integer stackCount = 0;
     public Set<Id> addedIds = new Set<Id>();
-    public Set<RollupItem> calcItems = new Set<RollupItem>();
-  }
-
-  private class RollupItem {
-    private RollupItem(SObject item, Rollup__mdt metadata) {
-      this.lookupKey = (String) item.get(metadata.LookupFieldOnCalcItem__c);
-      this.rollupValue = item.get(metadata.RollupFieldOnCalcItem__c);
-      this.Id = item.Id;
-    }
-
-    private final String lookupKey;
-    private final Object rollupValue;
-    private final Id Id;
-
-    public Boolean equals(Object thatItem) {
-      if (thatItem instanceof RollupItem) {
-        RollupItem that = (RollupItem) thatItem;
-        return this.lookupKey == that.lookupKey && this.rollupValue == that.rollupValue && this.Id == that.Id;
-      }
-
-      return false;
-    }
-
-    public Integer hashCode() {
-      Integer hashToReturn;
-      Integer idHash = this.Id == null ? 0 : ((Object) this.Id).hashCode();
-      Integer lookupHash = String.isBlank(this.lookupKey) ? 1 : this.lookupKey.hashCode();
-      Integer valHash = this.rollupValue == null ? 2 : this.rollupValue.hashCode();
-      try {
-        hashToReturn = idHash + lookupHash + valHash;
-      } catch (Exception ex) {
-        // in the event the integer overflows
-        hashToReturn = idHash + valHash - lookupHash;
-      }
-      return hashToReturn;
-    }
+    public Set<RollupRecursionItem> recursionItems = new Set<RollupRecursionItem>();
   }
 
   private class RecursiveUpdateEvaluator extends RollupEvaluator {
@@ -652,13 +617,13 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       ) {
         SObject calcItem = (SObject) item;
         // only populate the item with the rollup field and lookup field
-        RollupItem rollupItem = new RollupItem(calcItem, this.metadata);
+        RollupRecursionItem rollupItem = new RollupRecursionItem(calcItem, this.metadata);
         RecursiveTracker recursionTracker = OPERATION_TO_RECURSION_TRACKER.get(this.metadata.RollupOperation__c);
 
         if (recursionTracker.addedIds.contains(rollupItem.Id) == false) {
           recursionTracker.addedIds.add(rollupItem.Id);
-          recursionTracker.calcItems.add(rollupItem);
-        } else if (recursionTracker.stackCount > 0 && recursionTracker.calcItems.contains(rollupItem)) {
+          recursionTracker.recursionItems.add(rollupItem);
+        } else if (recursionTracker.stackCount > 0 && recursionTracker.recursionItems.contains(rollupItem)) {
           matches = false;
         }
       }

--- a/rollup/core/classes/RollupRecursionItem.cls
+++ b/rollup/core/classes/RollupRecursionItem.cls
@@ -1,0 +1,53 @@
+public without sharing class RollupRecursionItem {
+
+  public final String lookupKey;
+  public final Object rollupValue;
+  public final Id Id;
+
+  public RollupRecursionItem(SObject item, Rollup__mdt metadata) {
+    this.lookupKey = (String) item.get(metadata.LookupFieldOnCalcItem__c);
+    this.rollupValue = item.get(metadata.RollupFieldOnCalcItem__c);
+    this.Id = item.Id;
+  }
+
+  public Boolean equals(Object thatItem) {
+    if (thatItem instanceof RollupRecursionItem) {
+      RollupRecursionItem that = (RollupRecursionItem) thatItem;
+      return this.lookupKey == that.lookupKey && this.rollupValue == that.rollupValue && this.Id == that.Id;
+    }
+
+    return false;
+  }
+
+  /*
+  * The below is taken, in part, from the excellent HashCodeUtils written by George Doenlen
+  * https://github.com/gdoenlen/apexstruct/blob/master/src/classes/HashCodeUtil.cls
+  * anything that works about it is solely due to him; anything that doesn't is due to me
+  */
+  private static final Integer NULL_HASH = 0;
+  private static final Integer PRIME = 31;
+  private Integer hash = 7;
+
+  public Integer hashCode() {
+    Integer hashToReturn;
+    Integer idHash = this.getHash(this.Id);
+    Integer lookupHash = this.getHash(this.lookupKey);
+    Integer valHash = this.getHash(this.rollupValue);
+    try {
+      hashToReturn = idHash + lookupHash + valHash;
+    } catch (Exception ex) {
+      // in the event the integer overflows
+      hashToReturn = idHash + valHash - lookupHash;
+    }
+    return hashToReturn;
+  }
+
+  private Integer getHash(Object potentialVal) {
+    this.hash = potentialVal == null ? this.getHash(NULL_HASH) : potentialVal.hashCode() + this.calculateSeed(this.hash);
+    return hash;
+  }
+
+  private Integer calculateSeed(Integer hashSeed) {
+    return hashSeed * PRIME;
+  }
+}

--- a/rollup/core/classes/RollupRecursionItem.cls
+++ b/rollup/core/classes/RollupRecursionItem.cls
@@ -1,15 +1,22 @@
 public without sharing class RollupRecursionItem {
-
   public final String lookupKey;
   public final Object rollupValue;
   public final Id Id;
 
+  private final Hasher hasher;
+
   public RollupRecursionItem(SObject item, Rollup__mdt metadata) {
-    this.lookupKey = (String) item.get(metadata.LookupFieldOnCalcItem__c);
-    this.rollupValue = item.get(metadata.RollupFieldOnCalcItem__c);
-    this.Id = item.Id;
+    this.lookupKey = (String) item?.get(metadata.LookupFieldOnCalcItem__c);
+    this.rollupValue = item?.get(metadata.RollupFieldOnCalcItem__c);
+    this.Id = item?.Id;
+    this.hasher = new Hasher()
+      .add(this.lookupKey)
+      .add(this.rollupValue)
+      .add(this.Id);
   }
 
+  // need to define both "equals" and "hashCode" so that a Set<RollupRecursionItem> can use "contains"
+  // properly, as both Maps and Sets use these methods to define equality between keyed items
   public Boolean equals(Object thatItem) {
     if (thatItem instanceof RollupRecursionItem) {
       RollupRecursionItem that = (RollupRecursionItem) thatItem;
@@ -19,35 +26,35 @@ public without sharing class RollupRecursionItem {
     return false;
   }
 
+  public Integer hashCode() {
+    return this.hasher.get();
+  }
+
   /*
-  * The below is taken, in part, from the excellent HashCodeUtils written by George Doenlen
-  * https://github.com/gdoenlen/apexstruct/blob/master/src/classes/HashCodeUtil.cls
-  * anything that works about it is solely due to him; anything that doesn't is due to me
-  */
+   * The below is taken, in part, from the excellent HashCodeUtils written by George Doenlen
+   * https://github.com/gdoenlen/apexstruct/blob/master/src/classes/HashCodeUtil.cls
+   * anything that works about it is solely due to him; anything that doesn't is due to me.
+   * Many thanks to him for code reviewing this section and helping to improve it; apexstruct was the
+   * first repository associated with Salesforce that I ever visited on Github, so it seems nice
+   * that we've come full circle since that moment!
+   */
   private static final Integer NULL_HASH = 0;
   private static final Integer PRIME = 31;
-  private Integer hash = 7;
 
-  public Integer hashCode() {
-    Integer hashToReturn;
-    Integer idHash = this.getHash(this.Id);
-    Integer lookupHash = this.getHash(this.lookupKey);
-    Integer valHash = this.getHash(this.rollupValue);
-    try {
-      hashToReturn = idHash + lookupHash + valHash;
-    } catch (Exception ex) {
-      // in the event the integer overflows
-      hashToReturn = idHash + valHash - lookupHash;
+  private class Hasher {
+    private Integer hash = 7; // chosen at random to start seeding the hash
+
+    public Hasher add(Object o) {
+      this.addHash(o == null ? NULL_HASH : o.hashCode());
+      return this;
     }
-    return hashToReturn;
-  }
 
-  private Integer getHash(Object potentialVal) {
-    this.hash = potentialVal == null ? this.getHash(NULL_HASH) : potentialVal.hashCode() + this.calculateSeed(this.hash);
-    return hash;
-  }
+    private void addHash(Integer i) {
+      this.hash = (this.hash * PRIME) + i;
+    }
 
-  private Integer calculateSeed(Integer hashSeed) {
-    return hashSeed * PRIME;
+    public Integer get() {
+      return this.hash;
+    }
   }
 }

--- a/rollup/core/classes/RollupRecursionItem.cls-meta.xml
+++ b/rollup/core/classes/RollupRecursionItem.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/rollup/tests/RollupCalculatorTests.cls
+++ b/rollup/tests/RollupCalculatorTests.cls
@@ -571,7 +571,7 @@ private class RollupCalculatorTests {
       Opportunity.Name,
       QuickText.Channel,
       new Rollup__mdt(),
-      QuickText.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12),
+      RollupTestUtils.createId(QuickText.SObjectType),
       QuickText.Name
     );
 
@@ -597,7 +597,7 @@ private class RollupCalculatorTests {
       QuickText.Channel,
       Opportunity.Name,
       metadata,
-      Opportunity.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12),
+      RollupTestUtils.createId(Opportunity.SObjectType),
       QuickText.Name
     );
 
@@ -630,7 +630,7 @@ private class RollupCalculatorTests {
       ContactPointAddress.BestTimeToContactEndTime,
       ContactPointAddress.BestTimeToContactEndTime,
       metadata,
-      ContactPointAddress.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12),
+      RollupTestUtils.createId(ContactPointAddress.SObjectType),
       ContactPointAddress.Id
     );
     calc.setEvaluator(new RollupEvaluator.WhereFieldEvaluator(metadata.CalcItemWhereClause__c, ContactPointAddress.SObjectType));
@@ -656,13 +656,13 @@ private class RollupCalculatorTests {
       Task.ActivityDate, // not a "MIN"-able field in SOQL; crucial for this test
       Opportunity.CloseDate,
       metadata,
-      Opportunity.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12),
+      RollupTestUtils.createId(Opportunity.SObjectType),
       Task.WhatId
     );
 
     // the important things here: the current date is greater than both the passed in date (the "current" value on the lookup object)
     // AND that the "current" value matches what's on the old item
-    Task t = new Task(ActivityDate = today.addDays(1), Id = Task.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12));
+    Task t = new Task(ActivityDate = today.addDays(1), Id = RollupTestUtils.createId(Task.SObjectType));
 
     calc.performRollup(new List<Task>{ t }, new Map<Id, SObject>{ t.Id => new Task(ActivityDate = today) });
 
@@ -683,7 +683,7 @@ private class RollupCalculatorTests {
       ContactPointAddress.BestTimeToContactEndTime,
       ContactPointAddress.BestTimeToContactEndTime,
       metadata,
-      ContactPointAddress.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12),
+      RollupTestUtils.createId(ContactPointAddress.SObjectType),
       ContactPointAddress.Id
     );
 
@@ -709,7 +709,7 @@ private class RollupCalculatorTests {
       ContactPointAddress.BestTimeToContactEndTime,
       ContactPointAddress.BestTimeToContactEndTime,
       metadata,
-      ContactPointAddress.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12),
+      RollupTestUtils.createId(ContactPointAddress.SObjectType),
       ContactPointAddress.Id
     );
 
@@ -735,13 +735,13 @@ private class RollupCalculatorTests {
       Task.ActivityDate, // not a "MAX"-able field in SOQL; crucial for this test
       Opportunity.CloseDate,
       metadata,
-      Opportunity.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12),
+      RollupTestUtils.createId(Opportunity.SObjectType),
       Task.WhatId
     );
 
     // the important things here: the current date is less than both the passed in date (the "current" value on the lookup object)
     // AND that the "current" value matches what's on the old item
-    Task t = new Task(ActivityDate = today.addDays(-1), Id = Task.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12));
+    Task t = new Task(ActivityDate = today.addDays(-1), Id = RollupTestUtils.createId(Task.SObjectType));
 
     calc.performRollup(new List<Task>{ t }, new Map<Id, SObject>{ t.Id => new Task(ActivityDate = today) });
 
@@ -765,7 +765,7 @@ private class RollupCalculatorTests {
         Opportunity.Name,
         QuickText.Channel,
         new Rollup__mdt(),
-        QuickText.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12),
+        RollupTestUtils.createId(QuickText.SObjectType),
         QuickText.Name
       );
     } catch (Exception e) {

--- a/rollup/tests/RollupRecursionItemTests.cls
+++ b/rollup/tests/RollupRecursionItemTests.cls
@@ -1,0 +1,54 @@
+@isTest
+private class RollupRecursionItemTests {
+
+  @isTest
+  static void shouldReportFalseForNonRollupRecursionItemEquals() {
+    RollupRecursionItem recursionItem = new RollupRecursionItem(null, new Rollup__mdt());
+
+    System.assertEquals(false, recursionItem.equals(new Account()));
+  }
+
+  @isTest
+  static void shouldReportTrueForEquivalentWrappedValues() {
+    Account acc = new Account(Name = 'Hi', Id = RollupTestUtils.createId(Account.SObjectType));
+    Rollup__mdt meta = new Rollup__mdt(RollupFieldOnCalcItem__c = 'Name', LookupFieldOnCalcItem__c = 'Id');
+
+    RollupRecursionItem item = new RollupRecursionItem(acc, meta);
+    RollupRecursionItem secondItem = new RollupRecursionItem(acc, meta);
+
+    System.assertEquals(item, secondItem, 'Items with the same properties should match!');
+
+    acc.Name = 'Hello';
+    item = new RollupRecursionItem(acc, meta);
+
+    System.assertNotEquals(item, secondItem);
+  }
+
+  @isTest
+  static void shouldReportTrueForItemsWithSameNulledProps() {
+    Rollup__mdt meta = new Rollup__mdt(RollupFieldOnCalcItem__c = 'Name', LookupFieldOnCalcItem__c = 'Id');
+
+    RollupRecursionItem item = new RollupRecursionItem(new Account(), meta);
+    RollupRecursionItem secondItem = new RollupRecursionItem(new Account(), meta);
+
+    System.assertEquals(item, secondItem, 'Null properties should receive matching hash!');
+
+    item = new RollupRecursionItem(new Account(Name = 'Some other string'), meta);
+    System.assertNotEquals(item, secondItem, 'Once any prop is not null, equivalency should fail!');
+  }
+
+  @isTest
+  static void shouldUseHashCodeWhenPerformingSetEquality() {
+    Rollup__mdt meta = new Rollup__mdt(LookupFieldOnCalcItem__c = 'Id', RollupFieldOnCalcItem__c = 'Name');
+    RollupRecursionItem item = new RollupRecursionItem(null, meta);
+    RollupRecursionItem secondItem = new RollupRecursionItem(null, meta);
+
+    Set<RollupRecursionItem> recursionItems = new Set<RollupRecursionItem>{ item };
+
+    System.assertEquals(true, recursionItems.contains(secondItem));
+
+    RollupRecursionItem nonMatchingItem = new RollupRecursionItem(new Account(Name = 'Test hashing'), meta);
+
+    System.assertNotEquals(true, recursionItems.contains(nonMatchingItem));
+  }
+}

--- a/rollup/tests/RollupRecursionItemTests.cls-meta.xml
+++ b/rollup/tests/RollupRecursionItemTests.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/rollup/tests/RollupTestUtils.cls
+++ b/rollup/tests/RollupTestUtils.cls
@@ -1,0 +1,10 @@
+@isTest
+public class RollupTestUtils {
+
+  // from https://salesforce.stackexchange.com/questions/21137/creating-unit-tests-without-interacting-with-the-database-creating-fake-ids
+  private static Integer startingNumber = 1;
+  public static String createId(Schema.SObjectType sObjectType) {
+    String result = String.valueOf(startingNumber++);
+    return sObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12 - result.length()) + result;
+  }
+}

--- a/rollup/tests/RollupTestUtils.cls-meta.xml
+++ b/rollup/tests/RollupTestUtils.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/rollup/tests/RollupTests.cls
+++ b/rollup/tests/RollupTests.cls
@@ -169,7 +169,7 @@ private class RollupTests {
 
   @isTest
   static void shouldSumFromTriggerAfterUpdate() {
-    ContactPointAddress cpa = new ContactPointAddress(Id = generateId(ContactPointAddress.SObjectType), PreferenceRank = 50);
+    ContactPointAddress cpa = new ContactPointAddress(Id = RollupTestUtils.createId(ContactPointAddress.SObjectType), PreferenceRank = 50);
     DMLMock mock = loadAccountIdMock(new List<ContactPointAddress>{ cpa });
     Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
 
@@ -224,7 +224,7 @@ private class RollupTests {
     insert new ContactPointAddress(Name = 'Test Count Distinct Insert One', ParentId = acc.Id);
     Rollup.defaultControl = null;
 
-    ContactPointAddress cpa = new ContactPointAddress(Name = 'Test Count Distinct Insert Two', Id = generateId(ContactPointAddress.SObjectType));
+    ContactPointAddress cpa = new ContactPointAddress(Name = 'Test Count Distinct Insert Two', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType));
     DMLMock mock = loadAccountIdMock(new List<ContactPointAddress>{ cpa });
     Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
     // the important part here is that the old value differs
@@ -281,7 +281,7 @@ private class RollupTests {
     update acc;
     Rollup.defaultControl = null;
 
-    ContactPointAddress cpa = new ContactPointAddress(Id = generateId(ContactPointAddress.SObjectType));
+    ContactPointAddress cpa = new ContactPointAddress(Id = RollupTestUtils.createId(ContactPointAddress.SObjectType));
     DMLMock mock = loadAccountIdMock(new List<ContactPointAddress>{ cpa });
     Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
     Rollup.oldRecordsMap = new Map<Id, ContactPointAddress>{ cpa.Id => new ContactPointAddress(ParentId = cpa.ParentId, Id = cpa.Id, PreferenceRank = 1) };
@@ -303,7 +303,7 @@ private class RollupTests {
     update acc;
     Rollup.defaultControl = null;
 
-    ContactPointAddress cpa = new ContactPointAddress(Id = generateId(ContactPointAddress.SObjectType), PreferenceRank = 50);
+    ContactPointAddress cpa = new ContactPointAddress(Id = RollupTestUtils.createId(ContactPointAddress.SObjectType), PreferenceRank = 50);
     DMLMock mock = loadAccountIdMock(new List<ContactPointAddress>{ cpa });
     Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
     Rollup.oldRecordsMap = new Map<Id, ContactPointAddress>{ cpa.Id => new ContactPointAddress(ParentId = cpa.ParentId, Id = cpa.Id, PreferenceRank = 1) };
@@ -323,7 +323,7 @@ private class RollupTests {
     update acc;
     Rollup.defaultControl = null;
 
-    ContactPointAddress cpa = new ContactPointAddress(Id = generateId(ContactPointAddress.SObjectType), PreferenceRank = 50);
+    ContactPointAddress cpa = new ContactPointAddress(Id = RollupTestUtils.createId(ContactPointAddress.SObjectType), PreferenceRank = 50);
     DMLMock mock = loadAccountIdMock(new List<ContactPointAddress>{ cpa });
     Rollup.apexContext = TriggerOperation.BEFORE_DELETE;
     Rollup.oldRecordsMap = new Map<Id, ContactPointAddress>{ cpa.Id => new ContactPointAddress(Id = cpa.Id, PreferenceRank = 1) };
@@ -747,8 +747,8 @@ private class RollupTests {
   @isTest
   static void shouldMaxNumbersSuccessfullyAfterInsert() {
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{
-      new ContactPointAddress(PreferenceRank = 100, Id = generateId(ContactPointAddress.SObjectType)),
-      new ContactPointAddress(PreferenceRank = 200, Id = generateId(ContactPointAddress.SObjectType))
+      new ContactPointAddress(PreferenceRank = 100, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)),
+      new ContactPointAddress(PreferenceRank = 200, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
     };
     DMLMock mock = loadAccountIdMock(cpas);
     Rollup.apexContext = TriggerOperation.AFTER_INSERT;
@@ -765,8 +765,8 @@ private class RollupTests {
   @isTest
   static void shouldMaxNumbersSuccessfullyAfterUpdate() {
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{
-      new ContactPointAddress(PreferenceRank = 100, Id = generateId(ContactPointAddress.SObjectType)),
-      new ContactPointAddress(PreferenceRank = 200, Id = generateId(ContactPointAddress.SObjectType))
+      new ContactPointAddress(PreferenceRank = 100, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)),
+      new ContactPointAddress(PreferenceRank = 200, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
     };
     DMLMock mock = loadAccountIdMock(cpas);
     Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
@@ -862,13 +862,13 @@ private class RollupTests {
       PreferenceRank = acc.AnnualRevenue.intValue(),
       ParentId = acc.Id,
       Name = 'testCpa',
-      Id = generateId(ContactPointAddress.SObjectType)
+      Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)
     );
     ContactPointAddress secondCpa = new ContactPointAddress(
       PreferenceRank = 175,
       ParentId = acc.Id,
       Name = 'testCpaTwo',
-      Id = generateId(ContactPointAddress.SObjectType)
+      Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)
     );
     List<ContactPointAddress> originalCpas = new List<ContactPointAddress>{ cpa, secondCpa };
 
@@ -922,8 +922,8 @@ private class RollupTests {
   @isTest
   static void shouldMinNumbersSuccessfullyAfterInsert() {
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{
-      new ContactPointAddress(PreferenceRank = 100, Id = generateId(ContactPointAddress.SObjectType)),
-      new ContactPointAddress(PreferenceRank = 200, Id = generateId(ContactPointAddress.SObjectType))
+      new ContactPointAddress(PreferenceRank = 100, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)),
+      new ContactPointAddress(PreferenceRank = 200, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
     };
     DMLMock mock = loadAccountIdMock(cpas);
     Rollup.apexContext = TriggerOperation.AFTER_INSERT;
@@ -940,8 +940,8 @@ private class RollupTests {
   @isTest
   static void shouldMinNumbersSuccessfullyAfterUpdate() {
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{
-      new ContactPointAddress(PreferenceRank = 100, Id = generateId(ContactPointAddress.SObjectType)),
-      new ContactPointAddress(PreferenceRank = 200, Id = generateId(ContactPointAddress.SObjectType))
+      new ContactPointAddress(PreferenceRank = 100, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)),
+      new ContactPointAddress(PreferenceRank = 200, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
     };
     DMLMock mock = loadAccountIdMock(cpas);
     Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
@@ -1037,13 +1037,13 @@ private class RollupTests {
       PreferenceRank = acc.AnnualRevenue.intValue(),
       ParentId = acc.Id,
       Name = 'testCpa',
-      Id = generateId(ContactPointAddress.SObjectType)
+      Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)
     );
     ContactPointAddress secondCpa = new ContactPointAddress(
       PreferenceRank = 175,
       ParentId = acc.Id,
       Name = 'testCpaTwo',
-      Id = generateId(ContactPointAddress.SObjectType)
+      Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)
     );
     List<ContactPointAddress> originalCpas = new List<ContactPointAddress>{ cpa, secondCpa };
 
@@ -1106,7 +1106,7 @@ private class RollupTests {
     update acc;
     Rollup.defaultControl = null;
 
-    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'second test string', Id = generateId(ContactPointAddress.SObjectType));
+    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'second test string', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType));
     ContactPointAddress oldCpa = cpa.clone(true, true);
     oldCpa.Name = acc.AccountNumber;
 
@@ -1179,8 +1179,8 @@ private class RollupTests {
     update acc;
     Rollup.defaultControl = null;
 
-    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'second test string', Id = generateId(ContactPointAddress.SObjectType));
-    ContactPointAddress secondCpa = new ContactPointAddress(ParentId = acc.Id, Name = 'third test string', Id = generateId(ContactPointAddress.SObjectType));
+    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'second test string', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType));
+    ContactPointAddress secondCpa = new ContactPointAddress(ParentId = acc.Id, Name = 'third test string', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType));
     ContactPointAddress oldCpa = cpa.clone(true, true);
     oldCpa.Name = acc.AccountNumber;
     ContactPointAddress secondoldCpa = secondCpa.clone(true, true);
@@ -1282,8 +1282,8 @@ private class RollupTests {
   @isTest
   static void shouldMinOnStringsOnUpdate() {
     List<ContactPointAddress> testCpas = new List<ContactPointAddress>{
-      new ContactPointAddress(Name = 'B', Id = generateId(ContactPointAddress.SObjectType)),
-      new ContactPointAddress(Name = 'A', Id = generateId(ContactPointAddress.SObjectType))
+      new ContactPointAddress(Name = 'B', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)),
+      new ContactPointAddress(Name = 'A', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
     };
 
     DMLMock mock = loadAccountIdMock(testCpas);
@@ -1305,8 +1305,8 @@ private class RollupTests {
   @isTest
   static void shouldMaxOnStringsOnUpdate() {
     List<ContactPointAddress> testCpas = new List<ContactPointAddress>{
-      new ContactPointAddress(Name = '', Id = generateId(ContactPointAddress.SObjectType)),
-      new ContactPointAddress(Name = 'A', Id = generateId(ContactPointAddress.SObjectType))
+      new ContactPointAddress(Name = '', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)),
+      new ContactPointAddress(Name = 'A', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
     };
 
     DMLMock mock = loadAccountIdMock(testCpas);
@@ -1330,7 +1330,7 @@ private class RollupTests {
     update acc;
     Rollup.defaultControl = null;
 
-    List<ContactPointAddress> testCpas = new List<ContactPointAddress>{ new ContactPointAddress(Name = 'A', Id = generateId(ContactPointAddress.SObjectType)) };
+    List<ContactPointAddress> testCpas = new List<ContactPointAddress>{ new ContactPointAddress(Name = 'A', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)) };
 
     DMLMock mock = loadAccountIdMock(testCpas);
     Rollup.apexContext = TriggerOperation.BEFORE_DELETE;
@@ -1358,7 +1358,7 @@ private class RollupTests {
     // ensure that if any automation has changed the name, we keep track of it
     cpa = [SELECT Name FROM ContactPointAddress WHERE Id = :cpa.Id];
 
-    List<ContactPointAddress> testCpas = new List<ContactPointAddress>{ new ContactPointAddress(Name = 'A', Id = generateId(ContactPointAddress.SObjectType)) };
+    List<ContactPointAddress> testCpas = new List<ContactPointAddress>{ new ContactPointAddress(Name = 'A', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)) };
 
     DMLMock mock = loadAccountIdMock(testCpas);
     Rollup.apexContext = TriggerOperation.BEFORE_DELETE;
@@ -1453,8 +1453,8 @@ private class RollupTests {
     Rollup.defaultControl = null;
 
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{
-      new ContactPointAddress(PreferenceRank = 200000, Id = generateId(ContactPointAddress.SObjectType)),
-      new ContactPointAddress(PreferenceRank = 200000, Id = generateId(ContactPointAddress.SObjectType))
+      new ContactPointAddress(PreferenceRank = 200000, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)),
+      new ContactPointAddress(PreferenceRank = 200000, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
     };
     DMLMock mock = loadAccountIdMock(cpas);
     Rollup.apexContext = TriggerOperation.AFTER_INSERT;
@@ -1484,8 +1484,8 @@ private class RollupTests {
     Rollup.defaultControl = null;
 
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{
-      new ContactPointAddress(PreferenceRank = 200000, Id = generateId(ContactPointAddress.SObjectType)),
-      new ContactPointAddress(PreferenceRank = 200000, Id = generateId(ContactPointAddress.SObjectType))
+      new ContactPointAddress(PreferenceRank = 200000, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)),
+      new ContactPointAddress(PreferenceRank = 200000, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
     };
     DMLMock mock = loadAccountIdMock(cpas);
     Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
@@ -1774,7 +1774,7 @@ private class RollupTests {
     insert taskOne;
     Rollup.defaultControl = null;
 
-    Task taskTwo = new Task(Subject = 'Test Two', ActivityDate = con.BirthDate.addDays(5), Id = generateId(Task.SObjectType), WhoId = con.Id);
+    Task taskTwo = new Task(Subject = 'Test Two', ActivityDate = con.BirthDate.addDays(5), Id = RollupTestUtils.createId(Task.SObjectType), WhoId = con.Id);
 
     DMLMock mock = getTaskMock(new List<Task>{ taskTwo }, con.Id);
     Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
@@ -1836,8 +1836,8 @@ private class RollupTests {
     Rollup.defaultControl = null;
 
     // now the "new" version of eventOne is no longer the min
-    Event eventOne = new Event(ActivityDateTime = con.ActivatedDate.addDays(50), WhatId = con.Id, Id = generateId(Event.SObjectType));
-    Event eventTwo = new Event(ActivityDateTime = con.ActivatedDate.addDays(-25), WhatId = con.Id, Id = generateId(Event.SObjectType));
+    Event eventOne = new Event(ActivityDateTime = con.ActivatedDate.addDays(50), WhatId = con.Id, Id = RollupTestUtils.createId(Event.SObjectType));
+    Event eventTwo = new Event(ActivityDateTime = con.ActivatedDate.addDays(-25), WhatId = con.Id, Id = RollupTestUtils.createId(Event.SObjectType));
 
     DMLMock mock = loadMock(new List<Event>{ eventOne, eventTwo });
     Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
@@ -1862,8 +1862,8 @@ private class RollupTests {
     Rollup.defaultControl = null;
 
     // now the "new" version of eventOne is no longer the max
-    Event eventOne = new Event(ActivityDateTime = con.ActivatedDate.addDays(-25), WhatId = con.Id, Id = generateId(Event.SObjectType));
-    Event eventTwo = new Event(ActivityDateTime = con.ActivatedDate.addDays(50), WhatId = con.Id, Id = generateId(Event.SObjectType));
+    Event eventOne = new Event(ActivityDateTime = con.ActivatedDate.addDays(-25), WhatId = con.Id, Id = RollupTestUtils.createId(Event.SObjectType));
+    Event eventTwo = new Event(ActivityDateTime = con.ActivatedDate.addDays(50), WhatId = con.Id, Id = RollupTestUtils.createId(Event.SObjectType));
 
     DMLMock mock = loadMock(new List<Event>{ eventOne, eventTwo });
     Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
@@ -1886,7 +1886,7 @@ private class RollupTests {
     con.ActivatedDate = System.now();
     update con;
 
-    Event eventOne = new Event(ActivityDateTime = con.ActivatedDate, WhatId = con.Id, Id = generateId(Event.SObjectType));
+    Event eventOne = new Event(ActivityDateTime = con.ActivatedDate, WhatId = con.Id, Id = RollupTestUtils.createId(Event.SObjectType));
     Event eventTwo = new Event(ActivityDateTime = con.ActivatedDate.addDays(50), WhatId = con.Id, DurationInMinutes = 50);
     insert eventTwo;
     Rollup.defaultControl = null;
@@ -1911,7 +1911,7 @@ private class RollupTests {
     con.ActivatedDate = System.now();
     update con;
 
-    Event eventOne = new Event(ActivityDateTime = con.ActivatedDate, WhatId = con.Id, Id = generateId(Event.SObjectType));
+    Event eventOne = new Event(ActivityDateTime = con.ActivatedDate, WhatId = con.Id, Id = RollupTestUtils.createId(Event.SObjectType));
     Event eventTwo = new Event(ActivityDateTime = con.ActivatedDate.addDays(-50), WhatId = con.Id, DurationInMinutes = 50);
     insert eventTwo;
     Rollup.defaultControl = null;
@@ -2007,12 +2007,12 @@ private class RollupTests {
     ContactPointAddress cp1 = new ContactPointAddress(
       BestTimeToContactEndTime = Time.newInstance(5, 5, 5, 5),
       Name = cpe.EmailDomain,
-      Id = generateId(ContactPointAddress.SObjectType)
+      Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)
     );
     ContactPointAddress cp2 = new ContactPointAddress(
       BestTimeToContactEndTime = Time.newInstance(6, 6, 6, 6),
       Name = cpe.EmailDomain,
-      Id = generateId(ContactPointAddress.SObjectType)
+      Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)
     );
 
     DMLMock mock = loadMock(new List<ContactPointAddress>{ cp1, cp2 });
@@ -2050,12 +2050,12 @@ private class RollupTests {
     ContactPointAddress cp1 = new ContactPointAddress(
       BestTimeToContactEndTime = Time.newInstance(5, 5, 5, 5),
       Name = cpe.EmailDomain,
-      Id = generateId(ContactPointAddress.SObjectType)
+      Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)
     );
     ContactPointAddress cp2 = new ContactPointAddress(
       BestTimeToContactEndTime = Time.newInstance(6, 6, 6, 6),
       Name = cpe.EmailDomain,
-      Id = generateId(ContactPointAddress.SObjectType)
+      Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)
     );
 
     DMLMock mock = loadMock(new List<ContactPointAddress>{ cp1, cp2 });
@@ -2092,7 +2092,7 @@ private class RollupTests {
     ContactPointAddress cp1 = new ContactPointAddress(
       BestTimeToContactEndTime = cpe.BestTimeToContactEndTime,
       Name = cpe.EmailDomain,
-      Id = generateId(ContactPointAddress.SObjectType)
+      Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)
     );
     ContactPointAddress cp2 = new ContactPointAddress(BestTimeToContactEndTime = Time.newInstance(6, 6, 6, 6), Name = cpe.EmailDomain);
     insert cp2;
@@ -2133,7 +2133,7 @@ private class RollupTests {
     ContactPointAddress cp1 = new ContactPointAddress(
       BestTimeToContactEndTime = Time.newInstance(5, 5, 5, 5),
       Name = cpe.EmailDomain,
-      Id = generateId(ContactPointAddress.SObjectType)
+      Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)
     );
     ContactPointAddress cp2 = new ContactPointAddress(BestTimeToContactEndTime = Time.newInstance(4, 4, 4, 4), Name = cpe.EmailDomain);
     insert cp2;
@@ -2353,7 +2353,7 @@ private class RollupTests {
   @isTest
   static void shouldBeInvokedSuccessfullyAfterSaveFromFlow() {
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{
-      new ContactPointAddress(PreferenceRank = 1000, Id = generateId(ContactPointAddress.SObjectType))
+      new ContactPointAddress(PreferenceRank = 1000, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
     };
     DMLMock mock = loadAccountIdMock(cpas);
     List<Rollup.FlowInput> flowInputs = prepareFlowTest(cpas, 'UPDATE', 'SUM');
@@ -2379,7 +2379,7 @@ private class RollupTests {
     // testing for static log entries, as well
     Rollup.defaultControl = new RollupControl__mdt(IsRollupLoggingEnabled__c = true);
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{
-      new ContactPointAddress(PreferenceRank = 1000, Id = generateId(ContactPointAddress.SObjectType))
+      new ContactPointAddress(PreferenceRank = 1000, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
     };
     DMLMock mock = loadAccountIdMock(cpas);
     List<Rollup.FlowInput> flowInputs = prepareFlowTest(cpas, 'UPDATE', 'SUM');
@@ -2397,7 +2397,7 @@ private class RollupTests {
   @isTest
   static void shouldThrowValidationErrorOnUpsertFromFlowIfNoOldCalcItems() {
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{
-      new ContactPointAddress(PreferenceRank = 1000, Id = generateId(ContactPointAddress.SObjectType))
+      new ContactPointAddress(PreferenceRank = 1000, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
     };
     DMLMock mock = loadAccountIdMock(cpas);
     List<Rollup.FlowInput> flowInputs = prepareFlowTest(cpas, 'UPSERT', 'SUM');
@@ -2672,7 +2672,7 @@ private class RollupTests {
     // inserting the both of these at the same time caused a gack, and I have no idea why ... so singular inserts it is!
     insert new ContactPointAddress(PreferenceRank = 0, ActiveFromDate = today.addDays(-1), ParentId = acc.Id, Name = 'Non match on where clause');
 
-    ContactPointAddress cpa = new ContactPointAddress(PreferenceRank = 5, ActiveFromDate = today, Id = generateId(ContactPointAddress.SObjectType));
+    ContactPointAddress cpa = new ContactPointAddress(PreferenceRank = 5, ActiveFromDate = today, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType));
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{ cpa };
 
     DMLMock mock = loadAccountIdMock(cpas);
@@ -2694,7 +2694,7 @@ private class RollupTests {
   static void shouldReportErrorWhenOrderByNotIncludedForFirstLast() {
     List<Rollup.FlowInput> flowInputs = prepareFlowTest(
       new List<ContactPointAddress>{
-        new ContactPointAddress(PreferenceRank = 5, ActiveFromDate = System.today(), Id = generateId(ContactPointAddress.SObjectType))
+        new ContactPointAddress(PreferenceRank = 5, ActiveFromDate = System.today(), Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
       },
       'INSERT',
       'FIRST'
@@ -2715,7 +2715,7 @@ private class RollupTests {
   static void shouldReportErrorWhenUltimateParentRollupAndNoLookupField() {
     List<Rollup.FlowInput> flowInputs = prepareFlowTest(
       new List<ContactPointAddress>{
-        new ContactPointAddress(PreferenceRank = 5, ActiveFromDate = System.today(), Id = generateId(ContactPointAddress.SObjectType))
+        new ContactPointAddress(PreferenceRank = 5, ActiveFromDate = System.today(), Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
       },
       'INSERT',
       'MAX'
@@ -2737,7 +2737,7 @@ private class RollupTests {
   static void shouldReportErrorWhenConcatDelimiterSetAndNotConcat() {
     List<Rollup.FlowInput> flowInputs = prepareFlowTest(
       new List<ContactPointAddress>{
-        new ContactPointAddress(PreferenceRank = 5, ActiveFromDate = System.today(), Id = generateId(ContactPointAddress.SObjectType))
+        new ContactPointAddress(PreferenceRank = 5, ActiveFromDate = System.today(), Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
       },
       'INSERT',
       'MAX'
@@ -2759,7 +2759,7 @@ private class RollupTests {
   static void shouldReportErrorWhenBothOverridesSet() {
     List<Rollup.FlowInput> flowInputs = prepareFlowTest(
       new List<ContactPointAddress>{
-        new ContactPointAddress(PreferenceRank = 5, ActiveFromDate = System.today(), Id = generateId(ContactPointAddress.SObjectType))
+        new ContactPointAddress(PreferenceRank = 5, ActiveFromDate = System.today(), Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
       },
       'INSERT',
       'MAX'
@@ -2786,7 +2786,7 @@ private class RollupTests {
     // the important part here is that this one SHOULDN'T be first if the passed in calc item is not winnowed properly
     insert new ContactPointAddress(PreferenceRank = 5, ActiveFromDate = today.addDays(1), ParentId = acc.Id, Name = 'match on where clause');
 
-    ContactPointAddress cpa = new ContactPointAddress(PreferenceRank = 0, ActiveFromDate = today, Id = generateId(ContactPointAddress.SObjectType));
+    ContactPointAddress cpa = new ContactPointAddress(PreferenceRank = 0, ActiveFromDate = today, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType));
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{ cpa };
     List<Rollup.FlowInput> flowInputs = prepareFlowTest(cpas, 'INSERT', 'FIRST');
     flowInputs[0].calcItemWhereClause = 'PreferenceRank != 0';
@@ -2807,8 +2807,8 @@ private class RollupTests {
   @isTest
   static void shouldOnlyIncludeObjectChangedFieldsWhenSuppliedFromFlow() {
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{
-      new ContactPointAddress(PreferenceRank = 1000, Name = 'Acme cpa', Id = generateId(ContactPointAddress.SObjectType)),
-      new ContactPointAddress(PreferenceRank = 500, Name = 'Test name changed cpa', Id = generateId(ContactPointAddress.SObjectType))
+      new ContactPointAddress(PreferenceRank = 1000, Name = 'Acme cpa', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)),
+      new ContactPointAddress(PreferenceRank = 500, Name = 'Test name changed cpa', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
     };
     DMLMock mock = loadAccountIdMock(cpas);
 
@@ -3335,9 +3335,9 @@ private class RollupTests {
     insert oldAcc;
     Rollup.defaultControl = null;
 
-    ContactPointAddress cpa = new ContactPointAddress(Id = generateId(ContactPointAddress.SObjectType), PreferenceRank = 50, ParentId = acc.Id);
+    ContactPointAddress cpa = new ContactPointAddress(Id = RollupTestUtils.createId(ContactPointAddress.SObjectType), PreferenceRank = 50, ParentId = acc.Id);
     ContactPointAddress reparentedCpa = new ContactPointAddress(
-      Id = generateId(ContactPointAddress.SObjectType),
+      Id = RollupTestUtils.createId(ContactPointAddress.SObjectType),
       PreferenceRank = oldAcc.AnnualRevenue.intValue(),
       ParentId = acc.Id
     );
@@ -3371,7 +3371,7 @@ private class RollupTests {
 
     Rollup.defaultControl = null;
 
-    ContactPointAddress cpa = new ContactPointAddress(Id = generateId(ContactPointAddress.SObjectType), PreferenceRank = 50, ParentId = acc.Id);
+    ContactPointAddress cpa = new ContactPointAddress(Id = RollupTestUtils.createId(ContactPointAddress.SObjectType), PreferenceRank = 50, ParentId = acc.Id);
     DMLMock mock = loadMock(new List<ContactPointAddress>{ cpa });
     Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
 
@@ -3404,8 +3404,8 @@ private class RollupTests {
     Rollup.defaultControl = null;
 
     List<ContactPointAddress> testCpas = new List<ContactPointAddress>{
-      new ContactPointAddress(ParentId = acc.Id, Name = 'X', Id = generateId(ContactPointAddress.SObjectType)),
-      new ContactPointAddress(ParentId = acc.Id, Name = 'Y', Id = generateId(ContactPointAddress.SObjectType))
+      new ContactPointAddress(ParentId = acc.Id, Name = 'X', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)),
+      new ContactPointAddress(ParentId = acc.Id, Name = 'Y', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
     };
 
     DMLMock mock = loadMock(testCpas);
@@ -3438,9 +3438,9 @@ private class RollupTests {
     Rollup.defaultControl = null;
 
     List<ContactPointAddress> testCpas = new List<ContactPointAddress>{
-      new ContactPointAddress(ParentId = acc.Id, Name = 'X', Id = generateId(ContactPointAddress.SObjectType)),
-      new ContactPointAddress(ParentId = acc.Id, Name = 'X', Id = generateId(ContactPointAddress.SObjectType)),
-      new ContactPointAddress(ParentId = acc.Id, Name = 'Y', Id = generateId(ContactPointAddress.SObjectType))
+      new ContactPointAddress(ParentId = acc.Id, Name = 'X', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)),
+      new ContactPointAddress(ParentId = acc.Id, Name = 'X', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)),
+      new ContactPointAddress(ParentId = acc.Id, Name = 'Y', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
     };
 
     DMLMock mock = loadMock(testCpas);
@@ -3474,9 +3474,9 @@ private class RollupTests {
 
     Rollup.defaultControl = null;
 
-    ContactPointAddress cpa = new ContactPointAddress(Id = generateId(ContactPointAddress.SObjectType), PreferenceRank = 50, ParentId = acc.Id);
+    ContactPointAddress cpa = new ContactPointAddress(Id = RollupTestUtils.createId(ContactPointAddress.SObjectType), PreferenceRank = 50, ParentId = acc.Id);
     ContactPointAddress reparentedCpa = new ContactPointAddress(
-      Id = generateId(ContactPointAddress.SObjectType),
+      Id = RollupTestUtils.createId(ContactPointAddress.SObjectType),
       PreferenceRank = oldAcc.AnnualRevenue.intValue(),
       ParentId = acc.Id
     );
@@ -3789,12 +3789,5 @@ private class RollupTests {
     flowInput.rollupOperation = rollupOperation;
 
     return new List<Rollup.FlowInput>{ flowInput };
-  }
-
-  // from https://salesforce.stackexchange.com/questions/21137/creating-unit-tests-without-interacting-with-the-database-creating-fake-ids
-  private static Integer startingNumber = 1;
-  private static String generateId(Schema.SObjectType sObjectType) {
-    String result = String.valueOf(startingNumber++);
-    return sObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12 - result.length()) + result;
   }
 }

--- a/rollup/tests/RollupTests.cls
+++ b/rollup/tests/RollupTests.cls
@@ -3712,6 +3712,46 @@ private class RollupTests {
   }
 
   @isTest
+  static void shouldDeferGrandparentRollupSafelyTillAllParentRecordsAreRetrievedWithBatch() {
+    Rollup.shouldRunAsBatch = true;
+    Account acc = [SELECT Id, OwnerId FROM Account];
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
+      new ContactPointAddress(ParentId = acc.Id, Name = 'One'),
+      new ContactPointAddress(ParentId = acc.Id, Name = 'Two')
+    };
+    insert cpas;
+
+    DMLMock mock = new DMLMock();
+    Rollup.defaultControl = new RollupControl__mdt(MaxNumberOfQueries__c = 2, BatchChunkSize__c = 1, MaxRollupRetries__c = 100);
+    // start as synchronous rollup to allow for one deferral
+    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = 'Synchronous Rollup', MaxNumberOfQueries__c = 2);
+    Rollup.DML = mock;
+    Rollup.shouldRun = true;
+    Rollup.records = cpas;
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        RollupFieldOnCalcItem__c = 'Name',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupObject__c = 'User',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AboutMe',
+        RollupOperation__c = 'CONCAT',
+        GrandparentRelationshipFieldPath__c = 'Parent.Owner.AboutMe'
+      )
+    };
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    System.assertEquals(1, mock.Records.size(), 'Grandparent record should have been found!');
+    User updatedUser = (User) mock.Records[0];
+    System.assertEquals(cpas[0].Name + ', ' + cpas[1].Name, updatedUser.AboutMe, 'Grandparent rollup should have worked!');
+  }
+
+  @isTest
   static void shouldRollupEntireHierarchyWhenEnabled() {
     Account acc = [SELECT Id, Name FROM Account];
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionNumber": "1.2.17.0",
-            "versionDescription": "Fix too-permissiveness for some update operations in RollupEvaluator",
+            "versionNumber": "1.2.18.0",
+            "versionDescription": "Fix hashCode implementation for recursive checks. Removed some duplicate methods from Rollup.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest"
         }
     ],

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -25,6 +25,7 @@
         "apex-rollup@1.2.14-0": "04t6g000008GJjQAAW",
         "apex-rollup@1.2.15-0": "04t6g000008GJlbAAG",
         "apex-rollup@1.2.16-0": "04t6g000008GJm0AAG",
-        "apex-rollup@1.2.17-0": "04t6g000008nt3WAAQ"
+        "apex-rollup@1.2.17-0": "04t6g000008nt3WAAQ",
+        "apex-rollup@1.2.18-0": "04t6g000008nt4PAAQ"
     }
 }


### PR DESCRIPTION
* Added `RollupTestUtils.cls` to centralize mocking Id creation
* Added `RollupRecursionItem.cls` to properly encapsulate `equals()` and `hashCode()` implementation - big thanks again to @gdoenlen for contributing on this one
* Fixed an issue with the `deferredRollups` section that could lead to a gack when deferred rollups are being processed (thanks to Katherine West for reporting this one!)