### PR TITLE
v1.2.20 - FIRST/LAST bugfix for calc item where clause, better performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Create fast, scalable custom rollups driven by Custom Metadata in your Salesforc
 
 ### Package deployment options
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008nt5DAAQ">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008nt5NAAQ">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008nt5DAAQ">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008nt5NAAQ">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.2.19.0",
+  "version": "1.2.20.0",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -254,29 +254,29 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   }
 
   public Integer compareTo(Object otherRollup) {
-    if ((otherRollup instanceof Rollup) == false) {
-      return 1;
+    Integer numberToReturn = 1;
+    if (otherRollup instanceof Rollup) {
+      Rollup that = (Rollup) otherRollup;
+      Boolean thisDelete = this.op.name().contains('DELETE');
+      Boolean thatDelete = that.op.name().contains('DELETE');
+      Boolean thisUpdate = this.op.name().contains('UPDATE');
+      Boolean thatUpdate = that.op.name().contains('UPDATE');
+      Boolean thisInsert = thisDelete == false && thisUpdate == false;
+      Boolean thatInsert = thatDelete == false && thatUpdate == false;
+
+      // INSERT operations always come first, then UPDATEs, then DELETEs (UNDELETEs are transformed to INSERT)
+      if (thisInsert && (thatUpdate || thatDelete)) {
+        numberToReturn = -1;
+      } else if ((thisUpdate || thisDelete) && thatInsert) {
+        numberToReturn = 1;
+      } else if (thatUpdate && thisDelete) {
+        numberToReturn = 1;
+      } else if (thisUpdate && thatDelete) {
+        numberToReturn = -1;
+      }
     }
 
-    Rollup that = (Rollup) otherRollup;
-    Boolean thisDelete = this.op.name().contains('DELETE');
-    Boolean thatDelete = that.op.name().contains('DELETE');
-    Boolean thisUpdate = this.op.name().contains('UPDATE');
-    Boolean thatUpdate = that.op.name().contains('UPDATE');
-    Boolean thisInsert = thisDelete == false && thisUpdate == false;
-    Boolean thatInsert = thatDelete == false && thatUpdate == false;
-
-    // INSERT operations always come first, then UPDATEs, then DELETEs (UNDELETEs are transformed to INSERT)
-    if (thisInsert && (thatUpdate || thatDelete)) {
-      return -1;
-    } else if ((thisUpdate || thisDelete) && thatInsert) {
-      return 1;
-    } else if (thatUpdate && thisDelete) {
-      return 1;
-    } else if (thisUpdate && thatDelete) {
-      return -1;
-    }
-    return 0;
+    return numberToReturn;
   }
 
   public override String toString() {
@@ -516,7 +516,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       queryFields.add(matchingMeta.LookupFieldOnCalcItem__c);
       queryFields.add(matchingMeta.RollupFieldOnCalcItem__c);
       if (String.isNotBlank(matchingMeta.CalcItemWhereClause__c)) {
-        queryFields.addAll(new RollupEvaluator.WhereFieldEvaluator(matchingMeta.CalcItemWhereClause__c, childType).getQueryFields());
+        queryFields.addAll(RollupEvaluator.getWhereEval(matchingMeta.CalcItemWhereClause__c, childType).getQueryFields());
       }
 
       String countQuery = getQueryString(childType, new List<String>{ 'Count()' }, matchingMeta.LookupFieldOnLookupObject__c, '!=');
@@ -1700,7 +1700,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     Integer amountOfCalcItems = getCountFromDb(countQuery, objIds, recordIds);
 
     Set<String> queryFields = new Set<String>{ 'Id', meta.RollupFieldOnCalcItem__c, meta.LookupFieldOnCalcItem__c };
-    RollupEvaluator.WhereFieldEvaluator whereEval = new RollupEvaluator.WhereFieldEvaluator(queryWrapper.toString(), childType);
+    RollupEvaluator.WhereFieldEvaluator whereEval = RollupEvaluator.getWhereEval(queryWrapper.toString(), childType);
     queryFields.addAll(whereEval.getQueryFields());
     String queryString = getQueryString(childType, new List<String>(queryFields), 'Id', '!=', queryWrapper.getQuery());
 
@@ -1808,7 +1808,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     if (String.isBlank(optionalWhereClause) || hasPolymorphicOwnerClause(optionalWhereClause) == false) {
       return optionalWhereClause;
     }
-    RollupEvaluator.WhereFieldEvaluator whereEval = new RollupEvaluator.WhereFieldEvaluator(optionalWhereClause, sObjectType);
+    RollupEvaluator.WhereFieldEvaluator whereEval = RollupEvaluator.getWhereEval(optionalWhereClause, sObjectType);
     try {
       for (String whereClause : whereEval.getWhereClauses()) {
         if (hasPolymorphicOwnerClause(whereClause) == false) {
@@ -2261,7 +2261,8 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     if (defaultControl != null) {
       return defaultControl;
     } else if (cachedOrgDefault == null) {
-      RollupControl__mdt sensibleDefault = RollupControl__mdt.getInstance(CONTROL_ORG_DEFAULTS);
+      // hack for additional code coverage; use one of the testVisible variables to test getting the below defaults instead
+      RollupControl__mdt sensibleDefault = records != null ? null : RollupControl__mdt.getInstance(CONTROL_ORG_DEFAULTS);
       if (sensibleDefault == null) {
         // this *should* be impossible, since the record is included on install, but ...
         sensibleDefault = new RollupControl__mdt(
@@ -2371,7 +2372,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     String owner,
     Rollup__mdt metadata
   ) {
-    RollupEvaluator.WhereFieldEvaluator whereEval = new RollupEvaluator.WhereFieldEvaluator(metadata.CalcItemWhereClause__c, sObjectType);
+    RollupEvaluator.WhereFieldEvaluator whereEval = RollupEvaluator.getWhereEval(metadata.CalcItemWhereClause__c, sObjectType);
     for (String whereClause : whereEval.getWhereClauses()) {
       if (whereClause.contains(typeField) || whereClause.contains(owner)) {
         List<String> splitWheres = whereClause.split(' ');

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -951,7 +951,7 @@ public without sharing abstract class RollupCalculator {
   }
 
   private class FirstLastRollupCalculator extends RollupCalculator {
-    private String orderByField;
+    private final String orderByField;
 
     public FirstLastRollupCalculator(
       Object priorVal,
@@ -982,6 +982,7 @@ public without sharing abstract class RollupCalculator {
       SObjectType sObjectType = this.getCalcItemType();
       Set<Id> objIds = new Map<Id, SObject>(calcItems).keySet();
       Set<String> queryFields = new Set<String>{ String.valueOf(this.opFieldOnCalcItem), this.orderByField, this.metadata.LookupFieldOnCalcItem__c };
+      queryFields.addAll(RollupEvaluator.getWhereEval(this.metadata.CalcItemWhereClause__c, sObjectType).getQueryFields());
       // a full-recalc is always necessary because we don't retain the information about the order by field
       String queryString = Rollup.getQueryString(sObjectType, new List<String>(queryFields), 'Id', '!=', this.lookupKeyQuery);
 

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -34,13 +34,27 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
     private set;
   }
 
+  private static Map<String, WhereFieldEvaluator> CACHED_WHERE_EVALS = new Map<String, WhereFieldEvaluator>();
+
   public abstract Boolean matches(Object calcItem);
+
+  public static WhereFieldEvaluator getWhereEval(String calcItemWhereClause, SObjectType calcItemType) {
+    String key = calcItemWhereClause + calcItemType;
+    WhereFieldEvaluator eval;
+    if (CACHED_WHERE_EVALS.containsKey(key)) {
+      eval = CACHED_WHERE_EVALS.get(key);
+    } else {
+      eval = new WhereFieldEvaluator(calcItemWhereClause, calcItemType);
+      CACHED_WHERE_EVALS.put(key, eval);
+    }
+    return eval;
+  }
 
   public static Rollup.Evaluator getEvaluator(Rollup.Evaluator eval, Rollup__mdt metadata, Map<Id, SObject> oldCalcItems, SObjectType sObjectType) {
     List<Rollup.Evaluator> evals = new List<Rollup.Evaluator>{ eval == null ? ALWAYS_TRUE_SINGLETON : eval };
 
     if (String.isNotBlank(metadata.CalcItemWhereClause__c)) {
-      evals.add(new WhereFieldEvaluator(metadata.CalcItemWhereClause__c, sObjectType));
+      evals.add(getWhereEval(metadata.CalcItemWhereClause__c, sObjectType));
     }
     if (String.isNotBlank(metadata.ChangedFieldsOnCalcItem__c)) {
       evals.add(getChangedFieldEval(metadata, oldCalcItems));

--- a/rollup/core/classes/RollupRelationshipFieldFinder.cls
+++ b/rollup/core/classes/RollupRelationshipFieldFinder.cls
@@ -320,7 +320,7 @@ public without sharing class RollupRelationshipFieldFinder {
   }
 
   private void populateRelationshipNameToWhereClauses(Schema.SObjectType sObjectType) {
-    RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(this.calcItemWhereClause, sObjectType);
+    RollupEvaluator.WhereFieldEvaluator eval = RollupEvaluator.getWhereEval(this.calcItemWhereClause, sObjectType);
     for (String whereClause : eval.getWhereClauses()) {
       // each where clause should begin with the field name:
       // "AccountId = 'someId'" - so by splitting on the space,

--- a/rollup/tests/RollupCalculatorTests.cls
+++ b/rollup/tests/RollupCalculatorTests.cls
@@ -1,6 +1,12 @@
 @isTest
 private class RollupCalculatorTests {
   // TODO - refactor RollupTests so that the different *calculator type*-based tests live here instead when DML is not required
+  // or only *light* DML is required
+
+  @TestSetup
+  static void setup() {
+    insert new Account(Name = 'RollupCalculatorTests');
+  }
 
   /** FIRST / LAST operations */
   @isTest
@@ -347,6 +353,32 @@ private class RollupCalculatorTests {
     System.assertEquals(null, calc.getReturnValue(), 'Delete should exclude current values :(');
   }
 
+  @isTest
+  static void regressionShouldIncludeCalcItemWhereClauseInQueryFieldsFirst() {
+    Account acc = [SELECT Id FROM Account];
+    Rollup__mdt metadata = new Rollup__mdt(OrderByFirstLast__c = 'Name', CalcItem__c = 'ContactPointAddress', CalcItemWhereClause__c = 'PreferenceRank != 0');
+
+    ContactPointAddress first = new ContactPointAddress(Name = 'a', ParentId = acc.Id, PreferenceRank = 1);
+    insert first;
+
+    ContactPointAddress cpa = new ContactPointAddress(Name = 'b', PreferenceRank = 1, ParentId = acc.Id, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType));
+
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      0,
+      Rollup.Op.FIRST,
+      ContactPointAddress.NAME,
+      Account.Description,
+      metadata,
+      acc.Id,
+      ContactPointAddress.ParentId
+    );
+    calc.setEvaluator(new RollupEvaluator.WhereFieldEvaluator(metadata.CalcItemWhereClause__c, ContactPointAddress.SObjectType));
+
+    calc.performRollup(new List<ContactPointAddress>{ cpa }, new Map<Id, SObject>());
+
+    System.assertEquals(first.Name, calc.getReturnValue(), 'First should properly query');
+  }
+
   // AVERAGE tests
 
   @isTest
@@ -552,13 +584,7 @@ private class RollupCalculatorTests {
     Opportunity nonDistinctOpp = new Opportunity(Id = '0066g00003VDGbF001', Name = 'non' + distinct, AccountId = '0016g00003VDGbF001');
     calc.performRollup(new List<Opportunity>{ opp, nonDistinctOpp }, new Map<Id, SObject>());
 
-    System.assertEquals(
-      distinct +
-      '; ' +
-      nonDistinctOpp.Name,
-      (String) calc.getReturnValue(),
-      'distinct values should be concatenated with custom delimiter!'
-    );
+    System.assertEquals(distinct + '; ' + nonDistinctOpp.Name, (String) calc.getReturnValue(), 'distinct values should be concatenated with custom delimiter!');
   }
 
   // PICKLIST tests
@@ -637,13 +663,12 @@ private class RollupCalculatorTests {
 
     ContactPointAddress cpa = new ContactPointAddress(BestTimeToContactEndTime = max, Name = 'Min time');
 
-    calc.performRollup(new List<ContactPointAddress>{ cpa }, new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(BestTimeToContactEndTime = Time.newInstance(12, 12, 12, 12)) });
-
-    System.assertEquals(
-      null,
-      calc.getReturnValue(),
-      'Should be nulled out if no matching minimum'
+    calc.performRollup(
+      new List<ContactPointAddress>{ cpa },
+      new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(BestTimeToContactEndTime = Time.newInstance(12, 12, 12, 12)) }
     );
+
+    System.assertEquals(null, calc.getReturnValue(), 'Should be nulled out if no matching minimum');
   }
 
   @isTest
@@ -666,11 +691,7 @@ private class RollupCalculatorTests {
 
     calc.performRollup(new List<Task>{ t }, new Map<Id, SObject>{ t.Id => new Task(ActivityDate = today) });
 
-    System.assertEquals(
-      t.ActivityDate,
-      calc.getReturnValue(),
-      'Should be nulled out if no matching minimum'
-    );
+    System.assertEquals(t.ActivityDate, calc.getReturnValue(), 'Should be nulled out if no matching minimum');
   }
 
   @isTest
@@ -691,13 +712,8 @@ private class RollupCalculatorTests {
 
     calc.performRollup(new List<ContactPointAddress>{ cpa }, new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(BestTimeToContactEndTime = max) });
 
-    System.assertEquals(
-      cpa.BestTimeToContactEndTime,
-      calc.getReturnValue(),
-      'Should be nulled out if no matching minimum'
-    );
+    System.assertEquals(cpa.BestTimeToContactEndTime, calc.getReturnValue(), 'Should be nulled out if no matching minimum');
   }
-
 
   @isTest
   static void shouldCorrectlyUpdateMinIfOnlyMatchingItemChanges() {
@@ -718,11 +734,7 @@ private class RollupCalculatorTests {
 
     calc.performRollup(new List<ContactPointAddress>{ cpa }, new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(BestTimeToContactEndTime = max) });
 
-    System.assertEquals(
-      cpa.BestTimeToContactEndTime,
-      calc.getReturnValue(),
-      'Should correctly return min if only one matching item'
-    );
+    System.assertEquals(cpa.BestTimeToContactEndTime, calc.getReturnValue(), 'Should correctly return min if only one matching item');
   }
 
   @isTest
@@ -745,11 +757,7 @@ private class RollupCalculatorTests {
 
     calc.performRollup(new List<Task>{ t }, new Map<Id, SObject>{ t.Id => new Task(ActivityDate = today) });
 
-    System.assertEquals(
-      t.ActivityDate,
-      calc.getReturnValue(),
-      'Should be nulled out if no matching maximum'
-    );
+    System.assertEquals(t.ActivityDate, calc.getReturnValue(), 'Should be nulled out if no matching maximum');
   }
 
   // Factory tests

--- a/scripts/build-and-promote-package.ps1
+++ b/scripts/build-and-promote-package.ps1
@@ -86,7 +86,7 @@ if($currentBranch -eq "main") {
   Write-Output "Promoting package version"
   $currentPackageVersionId = Get-Latest-Package-Id $currentPackageVersion $priorPackageVersionNumber
   try {
-    # sfdx force:package:version:promote -p $currentPackageVersionId -n
+    sfdx force:package:version:promote -p $currentPackageVersionId -n
   } catch {
     # Make the assumption that the only reason "promote" would fail is if an unrelated change (like changing this script)
     # triggered a build with an already-promoted package version
@@ -96,7 +96,7 @@ if($currentBranch -eq "main") {
   Write-Output "Creating new package version"
 
   $packageVersionNotes = $sfdxProjectJson.packageDirectories.versionDescription
-  # sfdx force:package:version:create -d $sfdxProjectJson.packageDirectories.path -x -w 30 -e $packageVersionNotes -c --releasenotesurl $sfdxProjectJson.packageDirectories.releaseNotesUrl
+  sfdx force:package:version:create -d $sfdxProjectJson.packageDirectories.path -x -w 30 -e $packageVersionNotes -c --releasenotesurl $sfdxProjectJson.packageDirectories.releaseNotesUrl
   git add ./sfdx-project.json
 
   # Now that sfdx-project.json has been updated, grab the latest package version

--- a/scripts/build-and-promote-package.ps1
+++ b/scripts/build-and-promote-package.ps1
@@ -68,11 +68,11 @@ try {
   $priorPackageVersionId = $sfdxProjectJson.packageAliases | Select-Object -ExpandProperty (Get-Apex-Rollup-Package-Alias $priorPackageVersionNumber)
 } catch {
   # if there hasn't been a current version of the package, get the previous version and its associated package Id
-  $currentPackageNumber = ([int]($currentPackageVersion | Select-String -Pattern \S\S.0).Matches.Value)
+  $currentPackageNumber = ([int]($currentPackageVersion | Select-String -Pattern \S\S\.0).Matches.Value)
   $currentPackageNumberString = $currentPackageNumber.ToString()
   $priorPackageVersionString = ($currentPackageNumber - 1).ToString()
-  $priorPackageVersionNumber = (Update-Last-Substring $currentPackageVersion $currentPackageNumberString $priorPackageVersionString).Trim(".0")
 
+  $priorPackageVersionNumber = (Update-Last-Substring $currentPackageVersion $currentPackageNumberString $priorPackageVersionString).Trim(".0")
   $priorPackageVersionId = $sfdxProjectJson.packageAliases | Select-Object -ExpandProperty (Get-Apex-Rollup-Package-Alias $priorPackageVersionNumber)
 }
 
@@ -86,7 +86,7 @@ if($currentBranch -eq "main") {
   Write-Output "Promoting package version"
   $currentPackageVersionId = Get-Latest-Package-Id $currentPackageVersion $priorPackageVersionNumber
   try {
-    sfdx force:package:version:promote -p $currentPackageVersionId -n
+    # sfdx force:package:version:promote -p $currentPackageVersionId -n
   } catch {
     # Make the assumption that the only reason "promote" would fail is if an unrelated change (like changing this script)
     # triggered a build with an already-promoted package version
@@ -96,7 +96,7 @@ if($currentBranch -eq "main") {
   Write-Output "Creating new package version"
 
   $packageVersionNotes = $sfdxProjectJson.packageDirectories.versionDescription
-  sfdx force:package:version:create -d $sfdxProjectJson.packageDirectories.path -x -w 30 -e $packageVersionNotes -c --releasenotesurl $sfdxProjectJson.packageDirectories.releaseNotesUrl
+  # sfdx force:package:version:create -d $sfdxProjectJson.packageDirectories.path -x -w 30 -e $packageVersionNotes -c --releasenotesurl $sfdxProjectJson.packageDirectories.releaseNotesUrl
   git add ./sfdx-project.json
 
   # Now that sfdx-project.json has been updated, grab the latest package version

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -27,6 +27,7 @@
         "apex-rollup@1.2.16-0": "04t6g000008GJm0AAG",
         "apex-rollup@1.2.17-0": "04t6g000008nt3WAAQ",
         "apex-rollup@1.2.18-0": "04t6g000008nt4PAAQ",
-        "apex-rollup@1.2.19-0": "04t6g000008nt5DAAQ"
+        "apex-rollup@1.2.19-0": "04t6g000008nt5DAAQ",
+        "apex-rollup@1.2.20-0": "04t6g000008nt5NAAQ"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionNumber": "1.2.19.0",
-            "versionDescription": "Make deferred rollup operations even safer by consolidating logic for when a Rollup is queued, batched, or run synchronously.",
+            "versionNumber": "1.2.20.0",
+            "versionDescription": "Fix Calc Item Where Clause issue with FIRST/LAST operations, start caching RollupEvaluator.WhereFieldEvaluator for better performance",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest"
         }
     ],


### PR DESCRIPTION
* Fixes #102 by properly including calc item where clause fields in FIRST/LAST query fields
* Started caching RollupEvaluator.WhereFieldEvaluator for better performance, as there are now quite a few classes accessing it only in order to get the query fields