### PR TITLE
v1.2.24 - COUNT reparenting bugfix & better separation of concerns

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Create fast, scalable custom rollups driven by Custom Metadata in your Salesforc
 
 ### Package deployment options
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SgDcAAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SgEQAA0">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SgDcAAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SgEQAA0">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.2.23.0",
+  "version": "1.2.24.0",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -45,10 +45,10 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   private final SObjectType lookupObj;
   private final Evaluator eval;
   private final Op op;
-  private final Boolean isBatched;
   private final Rollup__mdt metadata;
-  private final RollupControl__mdt rollupControl;
 
+  protected final Boolean isBatched;
+  protected final RollupControl__mdt rollupControl;
   protected final SObjectType calcItemType;
   protected final InvocationPoint invokePoint;
 
@@ -88,7 +88,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     set;
   }
 
-  private List<Rollup> rollups {
+  protected List<Rollup> rollups {
     get {
       if (rollups == null) {
         rollups = new List<Rollup>();
@@ -130,16 +130,6 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         }
       }
       return invokeNameToInvokePoint;
-    }
-    set;
-  }
-
-  private static Rollup ROLLUP_LOGGER {
-    get {
-      if (ROLLUP_LOGGER == null) {
-        ROLLUP_LOGGER = new Rollup(InvocationPoint.FROM_STATIC_LOGGER);
-      }
-      return ROLLUP_LOGGER;
     }
     set;
   }
@@ -188,6 +178,17 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       Database.DMLOptions dmlOptions = new Database.DMLOptions();
       dmlOptions.AllowFieldTruncation = true;
       Database.update(recordsToUpdate, dmlOptions);
+    }
+  }
+
+  private class RollupAsyncSaver implements System.Queueable {
+    private final List<SObject> records;
+    public RollupAsyncSaver(List<SObject> records) {
+      this.records = records;
+    }
+
+    public void execute(QueueableContext context) {
+      new DMLHelper().doUpdate(this.records);
     }
   }
 
@@ -324,7 +325,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
     this.isNoOp = this.rollups.isEmpty() && this.syncRollups.isEmpty();
     if (this.isNoOp || this.rollupControl.ShouldAbortRun__c || SETTINGS.IsEnabled__c == false) {
-      this.log('aborting run, no-op');
+      RollupLogger.Instance.log('aborting run, no-op');
       return 'No process Id';
     }
 
@@ -337,7 +338,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       ((this.rollupControl.ShouldRunAs__c == RollupMetaPicklists.ShouldRunAs.BATCHABLE &&
       totalCountOfRecords >= this.rollupControl.MaxLookupRowsBeforeBatching__c) || totalCountOfRecords == SENTINEL_COUNT_VALUE);
     if (this.syncRollups.isEmpty() == false) {
-      this.log('about to process sync rollups');
+      RollupLogger.Instance.log('about to process sync rollups');
       this.process(this.syncRollups);
       return 'Running rollups flagged to go synchronously';
     } else {
@@ -369,7 +370,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   }
 
   protected virtual String beginAsyncRollup() {
-    this.log('about to start batch');
+    RollupLogger.Instance.log('about to start batch');
     return Database.executeBatch(this, this.rollupControl.BatchChunkSize__c.intValue());
   }
 
@@ -394,8 +395,13 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       lookupFieldForLookupObject = rollup.lookupFieldOnLookupObject.getDescribe().getName();
       objIds.addAll(this.getCalcItemsByLookupField(rollup, this.lookupObjectToUniqueFieldNames.get(sObjectType)).keySet());
     }
-    String query = getQueryString(sObjectType, new List<String>(this.lookupObjectToUniqueFieldNames.get(sObjectType)), lookupFieldForLookupObject, '=');
-    this.log('starting batch with query: ', query);
+    String query = RollupQueryBuilder.Current.getQuery(
+      sObjectType,
+      new List<String>(this.lookupObjectToUniqueFieldNames.get(sObjectType)),
+      lookupFieldForLookupObject,
+      '='
+    );
+    RollupLogger.Instance.log('starting batch with query: ', query);
     return Database.getQueryLocator(query);
   }
 
@@ -408,18 +414,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   }
 
   public virtual void finish(Database.BatchableContext context) {
-    this.log('batch finished successfully');
-  }
-
-  private class RollupAsyncSaver implements System.Queueable {
-    private final List<SObject> records;
-    public RollupAsyncSaver(List<SObject> records) {
-      this.records = records;
-    }
-
-    public void execute(QueueableContext context) {
-      new DMLHelper().doUpdate(this.records);
-    }
+    RollupLogger.Instance.log('batch finished successfully');
   }
 
   private class RollupAsyncProcessor extends Rollup implements System.Queueable {
@@ -464,12 +459,8 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     }
 
     protected override String beginAsyncRollup() {
-      this.log('about to queue');
+      RollupLogger.Instance.log('about to queue');
       return System.enqueueJob(this);
-    }
-
-    public override void finish(Database.BatchableContext nullContextDontUse) {
-      this.log('queueable finished successfully');
     }
 
     protected override List<SObject> getExistingLookupItems(Set<String> objIds, Rollup rollup, Set<String> uniqueQueryFieldNames) {
@@ -488,7 +479,12 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
             }
           }
         } else {
-          String queryString = getQueryString(rollup.lookupObj, new List<String>(uniqueQueryFieldNames), String.valueOf(rollup.lookupFieldOnLookupObject), '=');
+          String queryString = RollupQueryBuilder.Current.getQuery(
+            rollup.lookupObj,
+            new List<String>(uniqueQueryFieldNames),
+            String.valueOf(rollup.lookupFieldOnLookupObject),
+            '='
+          );
           // non-obvious coupling between "objIds" and the computed "queryString", which uses dynamic variable binding
           localLookupItems = Database.query(queryString);
         }
@@ -499,7 +495,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
     public void execute(System.QueueableContext qc) {
       this.process(this.rollups);
-      this.finish(null);
+      RollupLogger.Instance.log('queueable finished successfully');
     }
   }
 
@@ -544,7 +540,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         queryFields.addAll(RollupEvaluator.getWhereEval(matchingMeta.CalcItemWhereClause__c, childType).getQueryFields());
       }
 
-      String countQuery = getQueryString(childType, new List<String>{ 'Count()' }, matchingMeta.LookupFieldOnLookupObject__c, '!=');
+      String countQuery = RollupQueryBuilder.Current.getQuery(childType, new List<String>{ 'Count()' }, matchingMeta.LookupFieldOnLookupObject__c, '!=');
       Integer currentCount = getCountFromDb(countQuery, objIds, recordIds);
       if (currentCount == SENTINEL_COUNT_VALUE) {
         amountOfCalcItems = currentCount;
@@ -553,7 +549,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       amountOfCalcItems += currentCount;
     }
 
-    String queryString = getQueryString(childType, new List<String>(queryFields), 'Id', '!=');
+    String queryString = RollupQueryBuilder.Current.getQuery(childType, new List<String>(queryFields), 'Id', '!=');
 
     // eval always null via this route, despite having been used to get the relationship fields
     return startFullRecalc(matchingMetadata, amountOfCalcItems, queryString, objIds, recordIds, childType, null, localInvokePoint);
@@ -750,10 +746,10 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
       Rollup roll = getRollup(new List<Rollup__mdt>{ rollupMeta }, sObjectType, flowInput.recordsToRollup, oldFlowRecords, null, fromInvocable);
       if (flowInput.deferProcessing == true) {
-        ROLLUP_LOGGER.log('deferring processing for rollup', roll);
+        RollupLogger.Instance.log('deferring processing for rollup', roll);
         CACHED_ROLLUPS.add(roll);
       } else {
-        ROLLUP_LOGGER.log('adding invocable rollup to list', roll);
+        RollupLogger.Instance.log('adding invocable rollup to list', roll);
         rollups.add(roll);
       }
     }
@@ -763,7 +759,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         batch(rollups, fromInvocable);
       }
     } catch (Exception ex) {
-      ROLLUP_LOGGER.log('an error occurred during invocable action', ex);
+      RollupLogger.Instance.log('an error occurred during invocable action', ex);
       for (FlowOutput flowOutput : flowOutputs) {
         flowOutput.IsSuccess = false;
         flowOutput.Message = ex.getMessage() + '\n' + ex.getStackTraceString();
@@ -1443,7 +1439,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       objIds.add(header.getRecordIds()[0]);
     }
 
-    String fullQuery = getQueryString(sObjectType, new List<String>(uniqueFieldNames), 'Id', '=');
+    String fullQuery = RollupQueryBuilder.Current.getQuery(sObjectType, new List<String>(uniqueFieldNames), 'Id', '=');
     // getting the items back from the database before putting them into the map is an important step
     // we COULD just initialize the map with the query, but then the map's .values() list doesn't return
     // anything for .getSObjectType() - which we need, further downstream
@@ -1566,70 +1562,8 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
   /** end global-facing section, begin public/private static helpers */
 
-  public static String getQueryString(
-    SObjectType sObjectType,
-    List<String> uniqueQueryFieldNames,
-    String lookupFieldOnLookupObject,
-    String equality,
-    String optionalWhereClause
-  ) {
-    DescribeSObjectResult sObjectToken = sObjectType.getDescribe();
-    Map<String, SObjectField> baseFields = sObjectToken.fields.getMap();
-    for (Integer index = uniqueQueryFieldNames.size() - 1; index >= 0; index--) {
-      String uniqueFieldName = uniqueQueryFieldNames[index];
-      if (String.isBlank(uniqueFieldName)) {
-        uniqueQueryFieldNames.remove(index);
-      }
-      // ensure that the base relationship name field is transformed appropriately
-      if (baseFields.containsKey(uniqueFieldName + 'Id') || baseFields.containsKey(uniqueFieldName + '__c')) {
-        SObjectField baseField = baseFields.get(uniqueFieldName + 'Id') == null
-          ? baseFields.get(uniqueFieldName + '__c')
-          : baseFields.get(uniqueFieldName + 'Id');
-        DescribeFieldResult fieldToken = baseField.getDescribe();
-        if (fieldToken.getType() == DisplayType.REFERENCE && uniqueQueryFieldNames.contains(fieldToken.getName()) == false) {
-          uniqueQueryFieldNames[index] = fieldToken.getName();
-        }
-      } else if (
-        baseFields.containsKey(uniqueFieldName) &&
-        sObjectToken.getName() == uniqueFieldName.substringBefore('.') &&
-        uniqueQueryFieldNames.contains(uniqueFieldName) == false
-      ) {
-        uniqueQueryFieldNames[index] = uniqueFieldName;
-      }
-    }
-    // again noting the coupling for consumers of this method
-    // "objIds" is required to be present in the scope where the query is run
-    optionalWhereClause = adjustWhereClauseForPolymorphicFields(sObjectType, uniqueQueryFieldNames, optionalWhereClause);
-    String baseQuery =
-      'SELECT ' +
-      String.join(uniqueQueryFieldNames, ',') +
-      '\nFROM ' +
-      sObjectType +
-      '\nWHERE ' +
-      lookupFieldOnLookupObject +
-      ' ' +
-      equality +
-      ' :objIds';
-    if (String.isNotBlank(optionalWhereClause)) {
-      if (optionalWhereClause.startsWith('\nAND') || optionalWhereClause.startsWith('\nOR')) {
-        baseQuery += optionalWhereClause;
-      } else {
-        baseQuery += '\nAND ' + optionalWhereClause;
-      }
-    }
-    if (sObjectType == Task.SObjectType || sObjectType == Event.SObjectType) {
-      // handle archived rows
-      baseQuery += '\nAND IsDeleted = false ALL ROWS';
-    }
-    return baseQuery;
-  }
-
-  public static String getQueryString(SObjectType sObjectType, List<String> uniqueQueryFieldNames, String lookupFieldOnLookupObject, String equality) {
-    return getQueryString(sObjectType, uniqueQueryFieldNames, lookupFieldOnLookupObject, equality, null);
-  }
-
   public static void processStoredFlowRollups() {
-    ROLLUP_LOGGER.log('processing deferred flow rollups', CACHED_ROLLUPS);
+    RollupLogger.Instance.log('processing deferred flow rollups', CACHED_ROLLUPS);
     batch(CACHED_ROLLUPS, InvocationPoint.FROM_INVOCABLE);
     CACHED_ROLLUPS.clear();
   }
@@ -1712,7 +1646,13 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     // just how many items are we talking, here? If it's less than the query limit, we can proceed
     // otherwise, kick off a batch to fetch the calc items and then chain into the regular code path
     SObjectType childType = getSObjectFromName(meta.CalcItem__c).getSObjectType();
-    String countQuery = getQueryString(childType, new List<String>{ 'Count()' }, meta.LookupFieldOnLookupObject__c, '!=', queryWrapper.getQuery());
+    String countQuery = RollupQueryBuilder.Current.getQuery(
+      childType,
+      new List<String>{ 'Count()' },
+      meta.LookupFieldOnLookupObject__c,
+      '!=',
+      queryWrapper.getQuery()
+    );
 
     Set<String> objIds = new Set<String>(); // get everything that doesn't have a null Id - a pretty trick
     Set<Id> recordIds = queryWrapper.recordIds; // also used below, bound to the "queryString" variable
@@ -1721,7 +1661,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     Set<String> queryFields = new Set<String>{ 'Id', meta.RollupFieldOnCalcItem__c, meta.LookupFieldOnCalcItem__c };
     RollupEvaluator.WhereFieldEvaluator whereEval = RollupEvaluator.getWhereEval(queryWrapper.toString(), childType);
     queryFields.addAll(whereEval.getQueryFields());
-    String queryString = getQueryString(childType, new List<String>(queryFields), 'Id', '!=', queryWrapper.getQuery());
+    String queryString = RollupQueryBuilder.Current.getQuery(childType, new List<String>(queryFields), 'Id', '!=', queryWrapper.getQuery());
 
     return startFullRecalc(new List<Rollup__mdt>{ meta }, amountOfCalcItems, queryString, objIds, recordIds, childType, whereEval, invokePoint);
   }
@@ -1736,9 +1676,10 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     Evaluator eval,
     InvocationPoint invokePoint
   ) {
-    // ROLLUP_LOGGER used to reference the default RollupControl__mdt.MaxLookupRowsBeforeBatching__c, as well as BatchChunkSize__c
-    ROLLUP_LOGGER.log('Starting full recalc');
-    Boolean shouldQueue = amountOfCalcItems != SENTINEL_COUNT_VALUE && amountOfCalcItems < ROLLUP_LOGGER.rollupControl.MaxLookupRowsBeforeBatching__c;
+    // RollupLogger used to reference the default RollupControl__mdt.MaxLookupRowsBeforeBatching__c, as well as BatchChunkSize__c
+    RollupLogger rollupLogger = RollupLogger.Instance;
+    rollupLogger.log('Starting full recalc');
+    Boolean shouldQueue = amountOfCalcItems != SENTINEL_COUNT_VALUE && amountOfCalcItems < rollupLogger.rollupControl.MaxLookupRowsBeforeBatching__c;
     if (shouldQueue) {
       List<SObject> calculationItems = Database.query(queryString);
       Rollup thisRollup = getRollup(matchingMeta, calcItemType, calculationItems, new Map<Id, SObject>(calculationItems), eval, invokePoint);
@@ -1748,7 +1689,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       // batch to get calc items and then batch to rollup
       return Database.executeBatch(
         new RollupFullBatchRecalculator(queryString, invokePoint, matchingMeta, calcItemType, recordIds),
-        ROLLUP_LOGGER.rollupControl.BatchChunkSize__c.intValue()
+        rollupLogger.rollupControl.BatchChunkSize__c.intValue()
       );
     }
   }
@@ -1792,7 +1733,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
     if (String.isNotBlank(errorMessage)) {
       Exception ex = new IllegalArgumentException(errorMessage);
-      ROLLUP_LOGGER.log('an error occurred while validating flow inputs', ex);
+      RollupLogger.Instance.log('an error occurred while validating flow inputs', ex);
       throw ex;
     }
   }
@@ -1816,50 +1757,9 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         (flowInput.isRollupStartedFromParent ? firstRecord : lookupItem).get(flowInput.lookupFieldOnOpObject);
       }
     } catch (Exception ex) {
-      ROLLUP_LOGGER.log('an error occurred while validating flow-specific rules', ex);
+      RollupLogger.Instance.log('an error occurred while validating flow-specific rules', ex);
       throw ex;
     }
-  }
-
-  private static String adjustWhereClauseForPolymorphicFields(SObjectType sObjectType, List<String> uniqueQueryFieldNames, String optionalWhereClause) {
-    // you can't filter on *.Owner for polymorphic fields - or even select them, for that matter. Instead we have to massage the query to use
-    // TYPEOF instead
-    if (String.isBlank(optionalWhereClause) || hasPolymorphicOwnerClause(optionalWhereClause) == false) {
-      return optionalWhereClause;
-    }
-    RollupEvaluator.WhereFieldEvaluator whereEval = RollupEvaluator.getWhereEval(optionalWhereClause, sObjectType);
-    try {
-      for (String whereClause : whereEval.getWhereClauses()) {
-        if (hasPolymorphicOwnerClause(whereClause) == false) {
-          continue;
-        }
-        String fieldName = whereClause.split(' ')[0];
-        List<String> fieldParts = fieldName.split('\\.');
-        String whoOrWhat = fieldParts.remove(0);
-        String indexer = whoOrWhat + '.Type = \'';
-        String relationshipName = optionalWhereClause.substring(optionalWhereClause.indexOf(indexer) + indexer.length()).substringBeforeLast('\'');
-        String typeOfField = String.join(fieldParts, '.');
-
-        uniqueQueryFieldNames.add('TYPEOF ' + whoOrWhat + ' WHEN ' + relationshipName + ' THEN ' + typeOfField + ' END');
-
-        optionalWhereClause = optionalWhereClause.replace(indexer + relationshipName + '\'', '').trim();
-        optionalWhereClause = optionalWhereClause.replace(whereClause, '').trim();
-      }
-      // sanitize what's left of the where clause
-      while (optionalWhereClause.endsWith('AND')) {
-        optionalWhereClause = optionalWhereClause.substringBeforeLast('AND').trim();
-      }
-      while (optionalWhereClause.endsWith('OR')) {
-        optionalWhereClause = optionalWhereClause.substringBeforeLast('OR').trim();
-      }
-    } catch (Exception ex) {
-      ROLLUP_LOGGER.log('an error occurred while formatting where clause', ex);
-    }
-    return optionalWhereClause;
-  }
-
-  private static Boolean hasPolymorphicOwnerClause(String whereClause) {
-    return whereClause.contains('.Owner');
   }
 
   private static QueryWrapper getIntermediateGrandparentQueryWrapper(String grandparentFieldPath, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
@@ -1964,7 +1864,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     try {
       return Database.countQuery(countQuery);
     } catch (Exception ex) {
-      ROLLUP_LOGGER.log('an error occurred while trying to get count query:\n' + countQuery, ex);
+      RollupLogger.Instance.log('an error occurred while trying to get count query:\n' + countQuery, ex);
       // not all queries are valid, particularly those with polymorphic fields referencing parent fields
       // return a sentinel value instead, to be checked for downstream
       return SENTINEL_COUNT_VALUE;
@@ -2371,7 +2271,13 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         }
       }
 
-      String queryString = getQueryString(sObjectType, new List<String>(additionalQueryFields), 'Id', '=', String.join(optionalWhereClauses, ' AND '));
+      String queryString = RollupQueryBuilder.Current.getQuery(
+        sObjectType,
+        new List<String>(additionalQueryFields),
+        'Id',
+        '=',
+        String.join(optionalWhereClauses, ' AND ')
+      );
       List<String> objIds = new List<String>();
       for (SObject record : calcItems) {
         if (String.isNotBlank(record.Id)) {
@@ -2411,53 +2317,6 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
   /** End static section, begin protected + private instance methods */
 
-  private void log(String logString, Object logObject) {
-    if (this.rollupControl?.IsRollupLoggingEnabled__c == true) {
-      String appended = this.getLogStringFromObject(logObject);
-      List<String> messages = new List<String>{ logString };
-      if (String.isNotBlank(appended)) {
-        messages.add(appended);
-      }
-      // not all Rollup-generated exceptions come with stacktraces - this is a known issue, where using "new DMLException().getStackTraceString()"
-      // works to re-create the stacktrace for all of the calling code
-      messages.add(new DMLException().getStackTraceString());
-      System.debug('Rollup: ' + String.join(messages, '\n') + '\n');
-    }
-  }
-
-  private String getLogStringFromObject(Object logObject) {
-    String appended = '';
-    if (logObject instanceof String) {
-      appended = (String) logObject;
-    } else if (logObject instanceof List<Rollup>) {
-      List<Rollup> rolls = (List<Rollup>) logObject;
-      for (Rollup roll : rolls) {
-        appended += this.getLogStringFromObject(roll) + '\n';
-      }
-      appended = appended.removeEnd('\n');
-    } else if (logObject instanceof Rollup) {
-      Rollup roll = (Rollup) logObject;
-      if (roll.isBatched && roll.rollups.isEmpty() == false) {
-        appended = this.getLogStringFromObject(roll.rollups);
-      } else {
-        appended = logObject.toString();
-      }
-    } else if (logObject instanceof Exception) {
-      Exception ex = (Exception) logObject;
-      appended = ex.getMessage();
-    } else if (logObject != null) {
-      // not all objects implement toString, unfortunately,
-      // and we don't want this to throw. Blob.toString throws,
-      // for example - let's just serializePretty and move on
-      appended = JSON.serializePretty(logObject);
-    }
-    return appended;
-  }
-
-  protected void log(String logString) {
-    this.log(logString, null);
-  }
-
   protected void processDelegatedFullRecalcRollup(List<Rollup__mdt> rollupInfo, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
     isRunningAsync = true; // the first rollup can immediately start rolling up, instead of dispatching to a queueable / another batchable
     Rollup roll = getRollup(rollupInfo, this.calcItemType, calcItems, oldCalcItems, null, this.invokePoint);
@@ -2472,7 +2331,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     Map<String, SObject> updatedLookupRecords = new Map<String, SObject>();
     Map<SObjectType, RollupRelationshipFieldFinder.Traversal> grandparentRollups = new Map<SObjectType, RollupRelationshipFieldFinder.Traversal>();
     for (Rollup rollup : rollups) {
-      this.log('starting rollup for: ', rollup);
+      RollupLogger.Instance.log('starting rollup for: ', rollup);
       // for each iteration, ensure we're not operating beyond the bounds of our query limits
       if (hasExceededCurrentRollupLimits(rollup.rollupControl)) {
         this.deferredRollups.add(rollup);
@@ -2577,7 +2436,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       failedRollupInfo.add(roll.metadata);
     }
     String exceptionString = 'rollup failed to re-queue for: ';
-    this.log(exceptionString, failedRollupInfo);
+    RollupLogger.Instance.log(exceptionString, failedRollupInfo);
     throw new AsyncException(exceptionString + JSON.serialize(failedRollupInfo));
   }
 
@@ -2733,7 +2592,12 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         }
       }
 
-      String countQuery = getQueryString(rollup.lookupObj, new List<String>{ 'Count()' }, String.valueOf(rollup.lookupFieldOnLookupObject), '=');
+      String countQuery = RollupQueryBuilder.Current.getQuery(
+        rollup.lookupObj,
+        new List<String>{ 'Count()' },
+        String.valueOf(rollup.lookupFieldOnLookupObject),
+        '='
+      );
       if (queryCountsToLookupIds.containsKey(countQuery)) {
         queryCountsToLookupIds.get(countQuery).addAll(uniqueIds);
       } else {
@@ -2777,14 +2641,14 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         this.winnowCalcItemsAndCheckReparenting(rollup, localCalcItems, oldLookupItems);
 
         // Check for changed values
-        this.log('lookup record prior to rolling up: ', lookupRecord);
+        RollupLogger.Instance.log('lookup record prior to rolling up: ', lookupRecord);
         Object priorVal = lookupRecord.get(rollup.opFieldOnLookupObject);
         Object newVal = this.getRollupVal(rollup, localCalcItems, priorVal, key, rollup.lookupFieldOnCalcItem);
         if (priorVal != newVal) {
           lookupRecord.put(rollup.opFieldOnLookupObject, newVal);
           recordsToUpdate.put(key, lookupRecord);
         }
-        this.log('lookup record after rolling up: ', lookupRecord);
+        RollupLogger.Instance.log('lookup record after rolling up: ', lookupRecord);
       }
     }
 
@@ -2917,8 +2781,8 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         Op deleteOp = opNameToOp.get(deleteOpName);
         Rollup oldLookupsRollup = new Rollup(roll, deleteOp, reparentedCalcItems);
 
-        this.log('reparenting operation: ', oldLookupsRollup);
-        this.log('Reparented item prior to reparenting rollup: ', lookupRecord);
+        RollupLogger.Instance.log('reparenting operation: ', oldLookupsRollup);
+        RollupLogger.Instance.log('Reparented item prior to reparenting rollup: ', lookupRecord);
 
         Object priorVal = lookupRecord.get(roll.opFieldOnLookupObject);
         Object newVal = this.getRollupVal(oldLookupsRollup, reparentedCalcItems, priorVal, key, roll.lookupFieldOnCalcItem);
@@ -2927,7 +2791,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
           lookupRecord.put(roll.opFieldOnLookupObject, newVal);
           recordsToUpdate.put(key, lookupRecord);
         }
-        this.log('Reparented item after reparenting rollup: ', lookupRecord);
+        RollupLogger.Instance.log('Reparented item after reparenting rollup: ', lookupRecord);
       }
     }
   }

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -250,7 +250,7 @@ public without sharing abstract class RollupCalculator {
   protected virtual Object calculateNewAggregateValue(Rollup.Op op, Set<Id> objIds, SObjectType sObjectType) {
     String operationName = op.name().contains('_') ? op.name().substringAfter('_') : op.name();
     String alias = operationName.toLowerCase() + 'Field';
-    String query = Rollup.getQueryString(
+    String query = RollupQueryBuilder.Current.getQuery(
       sObjectType,
       new List<String>{ operationName + '(' + this.opFieldOnCalcItem + ')' + alias },
       'Id',
@@ -272,7 +272,7 @@ public without sharing abstract class RollupCalculator {
       this.isRecursiveRecalc = true; // now we're cooking with gas
 
       List<SObject> allOtherItems = Database.query(
-        Rollup.getQueryString(
+        RollupQueryBuilder.Current.getQuery(
           sObjectType,
           new List<String>{ this.metadata.LookupFieldOnCalcItem__c, String.valueOf(this.opFieldOnCalcItem) },
           'Id',
@@ -361,7 +361,8 @@ public without sharing abstract class RollupCalculator {
         queryFields.add('COUNT(Id)');
       }
       String query =
-        Rollup.getQueryString(sObjectType, queryFields, 'Id', '!=', this.lookupKeyQuery) + (isGroupable ? (' GROUP BY ' + this.opFieldOnCalcItem) : '');
+        RollupQueryBuilder.Current.getQuery(sObjectType, queryFields, 'Id', '!=', this.lookupKeyQuery) +
+        (isGroupable ? (' GROUP BY ' + this.opFieldOnCalcItem) : '');
       List<SObject> results = Database.query(query);
       for (SObject res : results) {
         // have to use the String representation of the this.opFieldOnCalcItem to avoid:
@@ -657,14 +658,14 @@ public without sharing abstract class RollupCalculator {
     protected override Decimal getNumericChangedValue(SObject calcItem, Map<Id, SObject> oldCalcItems) {
       SObject oldCalcItem = oldCalcItems.containsKey(calcItem.Id) ? oldCalcItems.get(calcItem.Id) : calcItem;
 
-      Object newVal = calcItem.get(this.opFieldOnCalcItem);
+      // for a reparenting, the item counts towards the new record on an update
       if (this.isReparented(calcItem, oldCalcItem)) {
-        return (Decimal) newVal;
+        return 1;
       }
 
       Object priorCalcVal = oldCalcItem.get(this.opFieldOnCalcItem);
       // for updates, we have to decrement the count if the value has been cleared out
-      return newVal == null && priorCalcVal != null ? -1 : 0;
+      return calcItem.get(this.opFieldOnCalcItem) == null && priorCalcVal != null ? -1 : 0;
     }
   }
 
@@ -799,7 +800,7 @@ public without sharing abstract class RollupCalculator {
 
     private void sortAndConcat() {
       List<String> values = this.stringVal.split(this.concatDelimiter);
-      for (Integer index = values.size() -1; index >= 0; index--) {
+      for (Integer index = values.size() - 1; index >= 0; index--) {
         if (String.isBlank(values[index])) {
           values.remove(index);
         }
@@ -851,7 +852,7 @@ public without sharing abstract class RollupCalculator {
       // items are accounted for in concatDistinctIds (for proper exclusion)
       if (this.isLastItem) {
         Set<Id> objIds = this.concatDistinctIds;
-        String query = Rollup.getQueryString(
+        String query = RollupQueryBuilder.Current.getQuery(
           calcItem.getSObjectType(),
           new List<String>{ this.opFieldOnCalcItem.getDescribe().getName() },
           'Id',
@@ -922,7 +923,7 @@ public without sharing abstract class RollupCalculator {
       SObjectType sObjectType = this.getCalcItemType();
       Set<Id> objIds = new Map<Id, SObject>(calcItems).keySet();
       Boolean isArchivable = sObjectType == Task.SObjectType || sObjectType == Event.SObjectType;
-      String query = Rollup.getQueryString(sObjectType, new List<String>{ isArchivable ? 'Id' : 'Count()' }, 'Id', '!=', this.lookupKeyQuery);
+      String query = RollupQueryBuilder.Current.getQuery(sObjectType, new List<String>{ isArchivable ? 'Id' : 'Count()' }, 'Id', '!=', this.lookupKeyQuery);
       Integer countOfPreExistingItems = isArchivable ? Database.query(query).size() : Database.countQuery(query);
 
       Decimal oldSum = (Decimal) this.calculateNewAggregateValue(Rollup.Op.SUM, objIds, sObjectType);
@@ -988,7 +989,7 @@ public without sharing abstract class RollupCalculator {
       Set<String> queryFields = new Set<String>{ String.valueOf(this.opFieldOnCalcItem), this.orderByField, this.metadata.LookupFieldOnCalcItem__c };
       queryFields.addAll(RollupEvaluator.getWhereEval(this.metadata.CalcItemWhereClause__c, sObjectType).getQueryFields());
       // a full-recalc is always necessary because we don't retain the information about the order by field
-      String queryString = Rollup.getQueryString(sObjectType, new List<String>(queryFields), 'Id', '!=', this.lookupKeyQuery);
+      String queryString = RollupQueryBuilder.Current.getQuery(sObjectType, new List<String>(queryFields), 'Id', '!=', this.lookupKeyQuery);
 
       // we have to exclude the current items on delete, otherwise they'll be incorrectly considered
       if (this.op.name().contains('DELETE')) {

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -386,7 +386,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
     }
 
     private void logError(Exception ex) {
-      System.debug(LoggingLevel.ERROR, 'RollupEvaluator: ' + ex.getMessage() + '\n' + ex.getStackTraceString());
+      RollupLogger.Instance.log('an error occurred in RollupEvaluator: ', ex);
     }
   }
 

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -36,6 +36,6 @@ public class RollupFullBatchRecalculator extends Rollup {
   }
 
   public override void finish(Database.BatchableContext bc) {
-    this.log('RollupFullBatchRecalculator finished');
+    RollupLogger.Instance.log('RollupFullBatchRecalculator finished');
   }
 }

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,5 +1,5 @@
 public class RollupLogger extends Rollup {
-  public RollupLogger() {
+  private RollupLogger() {
     super(InvocationPoint.FROM_STATIC_LOGGER);
   }
 

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,0 +1,54 @@
+public class RollupLogger extends Rollup {
+  public RollupLogger() {
+    super(InvocationPoint.FROM_STATIC_LOGGER);
+  }
+
+  public static final RollupLogger Instance = new RollupLogger();
+
+  public void log(String logString) {
+    this.log(logString, null);
+  }
+
+  public void log(String logString, Object logObject) {
+    if (this.rollupControl?.IsRollupLoggingEnabled__c == true) {
+      String appended = this.getLogStringFromObject(logObject);
+      List<String> messages = new List<String>{ logString };
+      if (String.isNotBlank(appended)) {
+        messages.add(appended);
+      }
+      // not all Rollup-generated exceptions come with stacktraces - this is a known issue, where using "new DMLException().getStackTraceString()"
+      // works to re-create the stacktrace for all of the calling code
+      messages.add(new DMLException().getStackTraceString());
+      System.debug('Rollup: ' + String.join(messages, '\n') + '\n');
+    }
+  }
+
+  private String getLogStringFromObject(Object logObject) {
+    String appended = '';
+    if (logObject instanceof String) {
+      appended = (String) logObject;
+    } else if (logObject instanceof List<Rollup>) {
+      List<Rollup> rolls = (List<Rollup>) logObject;
+      for (Rollup roll : rolls) {
+        appended += this.getLogStringFromObject(roll) + '\n';
+      }
+      appended = appended.removeEnd('\n');
+    } else if (logObject instanceof Rollup) {
+      Rollup roll = (Rollup) logObject;
+      if (roll.isBatched && roll.rollups.isEmpty() == false) {
+        appended = this.getLogStringFromObject(roll.rollups);
+      } else {
+        appended = roll.toString();
+      }
+    } else if (logObject instanceof Exception) {
+      Exception ex = (Exception) logObject;
+      appended = ex.getMessage() + '\nInner stacktrace: ' + ex.getStackTraceString();
+    } else if (logObject != null) {
+      // not all objects implement toString, unfortunately,
+      // and we don't want this to throw. Blob.toString throws,
+      // for example - let's just serializePretty and move on
+      appended = JSON.serializePretty(logObject);
+    }
+    return appended;
+  }
+}

--- a/rollup/core/classes/RollupLogger.cls-meta.xml
+++ b/rollup/core/classes/RollupLogger.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/rollup/core/classes/RollupQueryBuilder.cls
+++ b/rollup/core/classes/RollupQueryBuilder.cls
@@ -1,0 +1,125 @@
+public without sharing class RollupQueryBuilder {
+  private RollupQueryBuilder() {
+  }
+
+  public static final RollupQueryBuilder Current = new RollupQueryBuilder();
+
+  /**
+   * @return String `queryString` - returns a query string with "objIds" expected as a bind variable
+   */
+  public String getQuery(
+    SObjectType sObjectType,
+    List<String> uniqueQueryFieldNames,
+    String lookupFieldOnLookupObject,
+    String equality,
+    String optionalWhereClause
+  ) {
+    DescribeSObjectResult sObjectToken = sObjectType.getDescribe();
+    Map<String, SObjectField> baseFields = sObjectToken.fields.getMap();
+    Set<String> lowerCaseFieldNames = new Set<String>();
+
+    for (Integer index = uniqueQueryFieldNames.size() - 1; index >= 0; index--) {
+      String uniqueFieldName = uniqueQueryFieldNames[index];
+      if (String.isBlank(uniqueFieldName)) {
+        uniqueQueryFieldNames.remove(index);
+        continue;
+      }
+
+      String lowerCaseField = uniqueFieldName.toLowerCase();
+      // it's possible for fields that differ only in casing to be passed in -
+      // but that throws an exception when passed to SOQL. Let's avoid that!
+      if (lowerCaseFieldNames.contains(lowerCaseField)) {
+        uniqueQueryFieldNames.remove(index);
+      } else {
+        lowerCaseFieldNames.add(lowerCaseField);
+      }
+
+      // ensure that the base relationship name field is transformed appropriately
+      if (baseFields.containsKey(uniqueFieldName + 'Id') || baseFields.containsKey(uniqueFieldName + '__c')) {
+        SObjectField baseField = baseFields.get(uniqueFieldName + 'Id') == null
+          ? baseFields.get(uniqueFieldName + '__c')
+          : baseFields.get(uniqueFieldName + 'Id');
+        DescribeFieldResult fieldToken = baseField.getDescribe();
+        if (fieldToken.getType() == DisplayType.REFERENCE && uniqueQueryFieldNames.contains(fieldToken.getName()) == false) {
+          uniqueQueryFieldNames[index] = fieldToken.getName();
+        }
+      } else if (
+        baseFields.containsKey(uniqueFieldName) &&
+        sObjectToken.getName() == uniqueFieldName.substringBefore('.') &&
+        uniqueQueryFieldNames.contains(uniqueFieldName) == false
+      ) {
+        uniqueQueryFieldNames[index] = uniqueFieldName;
+      }
+    }
+    // again noting the coupling for consumers of this method
+    // "objIds" is required to be present in the scope where the query is run
+    optionalWhereClause = this.adjustWhereClauseForPolymorphicFields(sObjectType, uniqueQueryFieldNames, optionalWhereClause);
+    String baseQuery =
+      'SELECT ' +
+      String.join(uniqueQueryFieldNames, ',') +
+      '\nFROM ' +
+      sObjectType +
+      '\nWHERE ' +
+      lookupFieldOnLookupObject +
+      ' ' +
+      equality +
+      ' :objIds';
+    if (String.isNotBlank(optionalWhereClause)) {
+      if (optionalWhereClause.startsWith('\nAND') || optionalWhereClause.startsWith('\nOR')) {
+        baseQuery += optionalWhereClause;
+      } else {
+        baseQuery += '\nAND ' + optionalWhereClause;
+      }
+    }
+    if (sObjectType == Task.SObjectType || sObjectType == Event.SObjectType) {
+      // handle archived rows
+      baseQuery += '\nAND IsDeleted = false ALL ROWS';
+    }
+    return baseQuery;
+  }
+
+  public String getQuery(SObjectType sObjectType, List<String> uniqueQueryFieldNames, String lookupFieldOnLookupObject, String equality) {
+    return this.getQuery(sObjectType, uniqueQueryFieldNames, lookupFieldOnLookupObject, equality, null);
+  }
+
+  private String adjustWhereClauseForPolymorphicFields(SObjectType sObjectType, List<String> uniqueQueryFieldNames, String optionalWhereClause) {
+    // you can't filter on *.Owner for polymorphic fields - or even select them, for that matter. Instead we have to massage the query to use
+    // TYPEOF instead
+    if (String.isBlank(optionalWhereClause) || this.hasPolymorphicOwnerClause(optionalWhereClause) == false) {
+      return optionalWhereClause;
+    }
+    RollupEvaluator.WhereFieldEvaluator whereEval = RollupEvaluator.getWhereEval(optionalWhereClause, sObjectType);
+    try {
+      for (String whereClause : whereEval.getWhereClauses()) {
+        if (this.hasPolymorphicOwnerClause(whereClause) == false) {
+          continue;
+        }
+        String fieldName = whereClause.split(' ')[0];
+        List<String> fieldParts = fieldName.split('\\.');
+        String whoOrWhat = fieldParts.remove(0);
+        String indexer = whoOrWhat + '.Type = \'';
+        String relationshipName = optionalWhereClause.substring(optionalWhereClause.indexOf(indexer) + indexer.length()).substringBeforeLast('\'');
+        String typeOfField = String.join(fieldParts, '.');
+
+        uniqueQueryFieldNames.add('TYPEOF ' + whoOrWhat + ' WHEN ' + relationshipName + ' THEN ' + typeOfField + ' END');
+
+        optionalWhereClause = optionalWhereClause.replace(indexer + relationshipName + '\'', '').trim();
+        optionalWhereClause = optionalWhereClause.replace(whereClause, '').trim();
+      }
+      // sanitize what's left of the where clause
+      while (optionalWhereClause.endsWith('AND')) {
+        optionalWhereClause = optionalWhereClause.substringBeforeLast('AND').trim();
+      }
+      while (optionalWhereClause.endsWith('OR')) {
+        optionalWhereClause = optionalWhereClause.substringBeforeLast('OR').trim();
+      }
+    } catch (Exception ex) {
+      RollupLogger.Instance.log('exception occurred while building query: ', ex);
+    }
+    return optionalWhereClause;
+  }
+
+  private Boolean hasPolymorphicOwnerClause(String whereClause) {
+    return whereClause.contains('.Owner');
+  }
+}

--- a/rollup/core/classes/RollupQueryBuilder.cls-meta.xml
+++ b/rollup/core/classes/RollupQueryBuilder.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/rollup/tests/RollupCalculatorTests.cls
+++ b/rollup/tests/RollupCalculatorTests.cls
@@ -439,9 +439,9 @@ private class RollupCalculatorTests {
       Opportunity.AccountId
     );
     Opportunity opp = new Opportunity(Id = '0066g00003VDGbF001', Amount = 2, AccountId = '0016g00003VDGbF001');
-    calc.performRollup(new List<Opportunity>{ opp }, new Map<Id, SObject>{ opp.Id => new Opportunity(AccountId = '0016g00003VDGbF002', Amount = 1) });
+    calc.performRollup(new List<Opportunity>{ opp }, new Map<Id, SObject>{ opp.Id => new Opportunity(AccountId = '0016g00003VDGbF002') });
 
-    System.assertEquals(opp.Amount, (Decimal) calc.getReturnValue(), 'New value should be returned on reparenting update!');
+    System.assertEquals(1, (Decimal) calc.getReturnValue(), 'If record is reparented, it should count towards count for new record!');
   }
 
   @isTest

--- a/rollup/tests/RollupQueryBuilderTests.cls
+++ b/rollup/tests/RollupQueryBuilderTests.cls
@@ -1,0 +1,54 @@
+@isTest
+private class RollupQueryBuilderTests {
+  @isTest
+  static void shouldQueryAllTasks() {
+    String queryString = RollupQueryBuilder.Current.getQuery(Task.SObjectType, new List<String>{ 'Id' }, 'WhatId', '=');
+
+    // validate the query
+    Set<String> objIds = new Set<String>();
+    Database.query(queryString);
+
+    System.assertEquals(true, queryString.contains('AND IsDeleted = false ALL ROWS'));
+  }
+
+  @isTest
+  static void shouldQueryAllEvents() {
+    String queryString = RollupQueryBuilder.Current.getQuery(Event.SObjectType, new List<String>{ 'Id' }, 'WhatId', '=');
+
+    Set<String> objIds = new Set<String>();
+    Database.query(queryString);
+
+    System.assertEquals(true, queryString.contains('AND IsDeleted = false ALL ROWS'));
+  }
+
+  @isTest
+  static void shouldProperlyQueryIfMultipleCasedVersionsOfSameFieldPassedIn() {
+    String queryString = RollupQueryBuilder.Current.getQuery(
+      Opportunity.SObjectType,
+      new List<String>{ 'Id', 'ID', 'id', 'iD', 'AccountId', 'AccountID', 'accountId', 'accountID' },
+      'AccountId',
+      '='
+    );
+
+    Set<String> objIds = new Set<String>();
+    Database.query(queryString);
+
+    System.assertEquals(true, queryString.contains('Id'));
+    System.assertEquals(true, queryString.contains('AccountId'));
+  }
+
+  @isTest
+  static void shouldNotBlowUpIfPassedInFieldsAreNullOrBlank() {
+    String queryString = RollupQueryBuilder.Current.getQuery(
+      Opportunity.SObjectType,
+      new List<String>{ '', null, ' ', 'Id'},
+      'AccountId',
+      '='
+    );
+
+    Set<String> objIds = new Set<String>();
+    Database.query(queryString);
+
+    System.assertEquals(true, queryString.contains('Id'));
+  }
+}

--- a/rollup/tests/RollupQueryBuilderTests.cls-meta.xml
+++ b/rollup/tests/RollupQueryBuilderTests.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/rollup/tests/RollupTests.cls
+++ b/rollup/tests/RollupTests.cls
@@ -2475,7 +2475,6 @@ private class RollupTests {
 
   @isTest
   static void shouldThrowValidationErrorOnUpdateFromFlowIfNoOldCalcItems() {
-    // testing for static log entries, as well
     Rollup.defaultControl = new RollupControl__mdt(IsRollupLoggingEnabled__c = true);
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{
       new ContactPointAddress(PreferenceRank = 1000, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
@@ -3596,7 +3595,7 @@ private class RollupTests {
   }
 
   @isTest
-  static void shouldCorrectlyReparentForCountDistinct() {
+  static void shouldCorrectlyReparentForStringsCountDistinct() {
     Account acc = [SELECT Id FROM Account];
 
     Rollup.defaultControl = new RollupControl__mdt(ShouldAbortRun__c = true);
@@ -3629,6 +3628,48 @@ private class RollupTests {
     System.assertEquals(2, updatedAcc.AnnualRevenue, 'COUNT DISTINCT AFTER_UPDATE should count only the distinct entries');
     Account updatedOldAcc = (Account) mock.Records[1];
     System.assertEquals(0, updatedOldAcc.AnnualRevenue, 'COUNT DISTINCT AFTER_UPDATE should be empty after reparenting');
+  }
+
+  @isTest
+  static void shouldCorrectlyReparentForStringCount() {
+    Account acc = [SELECT Id FROM Account];
+
+    Rollup.defaultControl = new RollupControl__mdt(ShouldAbortRun__c = true);
+    Account oldAcc = new Account(AnnualRevenue = 1, Name = 'Something');
+    insert oldAcc;
+    Rollup.defaultControl = null;
+
+    // the first two items will be false positives; records whose values haven't changed over the course of the update
+    // of interest to us will be the last record, whose ParentId we'll show as the oldAcc's in oldRecordsMap to trigger a
+    // reparenting
+    List<ContactPointAddress> testCpas = new List<ContactPointAddress>{
+      new ContactPointAddress(ParentId = acc.Id, Name = 'X', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)),
+      new ContactPointAddress(ParentId = acc.Id, Name = 'Y', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)),
+      new ContactPointAddress(ParentId = acc.Id, Name = 'Z', Id = RollupTestUtils.createId(ContactPointAddress.SObjectType))
+    };
+
+    DMLMock mock = loadMock(testCpas);
+    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
+
+    ContactPointAddress firstCpa = testCpas[0].clone(true, true);
+    ContactPointAddress secondCpa = testCpas[1].clone(true, true);
+    ContactPointAddress thirdCpa = testCpas[2].clone(true, true);
+    thirdCpa.ParentId = oldAcc.Id;
+
+    Rollup.oldRecordsMap = new Map<Id, ContactPointAddress>{ firstCpa.Id => firstCpa, secondCpa.Id => secondCpa, thirdCpa.Id => thirdCpa };
+
+    Test.startTest();
+    Rollup.countFromApex(ContactPointAddress.Name, ContactPointAddress.ParentId, Account.Id, Account.AnnualRevenue, Account.SObjectType).runCalc();
+    Test.stopTest();
+
+    System.assertEquals(2, mock.Records.size(), 'Records should have been populated COUNT AFTER_UPDATE reparenting STRING: ' + mock.Records);
+    for (Account updatedAcc : (List<Account>) mock.Records) {
+      if (updatedAcc.Id == acc.Id) {
+        System.assertEquals(1, updatedAcc.AnnualRevenue, 'COUNT AFTER_UPDATE should only count updated entries reparented to it');
+      } else if (updatedAcc.Id == oldAcc.Id) {
+        System.assertEquals(0, updatedAcc.AnnualRevenue, 'Old account should have had its annual revenue decremented');
+      }
+    }
   }
 
   @isTest
@@ -3666,29 +3707,6 @@ private class RollupTests {
     Account updatedOldAcc = (Account) mock.Records[1];
     System.assertEquals(oldAcc.Id, updatedOldAcc.Id);
     System.assertEquals(null, updatedOldAcc.AnnualRevenue, 'AVERAGE AFTER_UPDATE should take the diff between the current amount and the pre-existing one');
-  }
-
-  /** Queries */
-  @isTest
-  static void shouldQueryAllTasks() {
-    String queryString = Rollup.getQueryString(Task.SObjectType, new List<String>{ 'Id' }, 'WhatId', '=');
-
-    // validate the query
-    Set<String> objIds = new Set<String>();
-    Database.query(queryString);
-
-    System.assertEquals(true, queryString.contains('AND IsDeleted = false ALL ROWS'));
-  }
-
-  @isTest
-  static void shouldQueryAllEvents() {
-    String queryString = Rollup.getQueryString(Event.SObjectType, new List<String>{ 'Id' }, 'WhatId', '=');
-
-    // validate the query
-    Set<String> objIds = new Set<String>();
-    Database.query(queryString);
-
-    System.assertEquals(true, queryString.contains('AND IsDeleted = false ALL ROWS'));
   }
 
   /** Re-queueing */
@@ -3853,7 +3871,12 @@ private class RollupTests {
     insert cpas;
 
     DMLMock mock = new DMLMock();
-    Rollup.defaultControl = new RollupControl__mdt(BatchChunkSize__c = 1, MaxRollupRetries__c = 100, MaxNumberOfQueries__c = 1, IsRollupLoggingEnabled__c = true);
+    Rollup.defaultControl = new RollupControl__mdt(
+      BatchChunkSize__c = 1,
+      MaxRollupRetries__c = 100,
+      MaxNumberOfQueries__c = 1,
+      IsRollupLoggingEnabled__c = true
+    );
     // start as synchronous rollup to allow for one deferral
     Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = 'Synchronous Rollup');
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionNumber": "1.2.23.0",
-            "versionDescription": "Closed final scalability loophole with Rollup and query limits, added parent recalc flexipage button",
+            "versionNumber": "1.2.24.0",
+            "versionDescription": "Fixed issue with String-based COUNT rollups, more separation of concerns work",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest"
         }
     ],

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -31,6 +31,7 @@
         "apex-rollup@1.2.20-0": "04t6g000008nt5NAAQ",
         "apex-rollup@1.2.21-0": "04t6g000008nt6kAAA",
         "apex-rollup@1.2.22-0": "04t6g000008SgCUAA0",
-        "apex-rollup@1.2.23-0": "04t6g000008SgDcAAK"
+        "apex-rollup@1.2.23-0": "04t6g000008SgDcAAK",
+        "apex-rollup@1.2.24-0": "04t6g000008SgEQAA0"
     }
 }


### PR DESCRIPTION
* Broke out logging to separate rollup object
* Broke out queries to separate builder (possible due to refactoring getParedFieldName out of querying methods in v1.2.23)
* Fixed an issue with COUNT rollups and string-based fields on reparenting