### PR TITLE
V1.2.25 - Merge reparenting & Recursion updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Create fast, scalable custom rollups driven by Custom Metadata in your Salesforc
 
 ### Package deployment options
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SgEQAA0">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SgGCAA0">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SgEQAA0">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SgGCAA0">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ These are the fields on the `Rollup Control` custom metadata type:
 - `Max Rollup Retries` - (defaults to 100) - Only configurable on the Org Default record. Use in conjunction with `Max Query Rows`. This determines the maximum possible rollup jobs (either batched or queued) that can be spawned from a single overall rollup operation due to the prior one(s) exceeding the configured query limit.
 - `Batch Chunk Size` - (defaults to 2000) - The amount of records passed into each batchable job in the event that Rollup batches. Default is 2000, which is the vanilla Salesforce default for batch jobs.
 - `Is Rollup Logging Enabled` - (defaults to false) - Check this box in order to debug your rollups. Debug information is included in a few mission-critical pieces of Rollup to provide you with more information about where exactly an error might be occurring, should you encounter one.
+- `Is Merge Reparenting Enabled` - (defaults to true) - By default, if there is an `after delete` trigger context for Account / Case / Contact / Lead where Rollup is being used and one or more of those records is merged, Rollup goes and updates any children records from the old lookup to the new lookup automatically prior to recalculating rollup values. If you have pre-existing merge handling covered in your org by some other means, you should disable this checkbox and ensure that Rollup is only called _after_ your pre-existing merge handling has run.
 
 ### Flow / Process Builder Invocable
 

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -672,8 +672,6 @@ private class RollupIntegrationTests {
     System.assertEquals(true, eval.matches(opp), 'Should match recursively if values do not match');
   }
 
-  // TODO need invocable test
-  // for multiple rollups and full recalc too
   @isTest
   static void shouldCorrectlyRollupFromTriggerOnMerge() {
     // this test relies on AccountTrigger.trigger having AFTER DELETE set up

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -624,4 +624,41 @@ private class RollupIntegrationTests {
 
     System.assertEquals(true, eval.matches(opp), 'Should match recursively if values do not match');
   }
+
+  @isTest
+  static void shouldCorrectlyMaxFromTriggerOnMerge() {
+    // this test relies on AccountTrigger.trigger having AFTER DELETE set up
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        RollupFieldOnCalcItem__c = 'PreferenceRank',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'MAX'
+      )
+    };
+
+    // you can only merge contacts / accounts / leads / cases
+    Account parent = [SELECT Id FROM Account];
+    Account parentToMerge = new Account(Name = 'Second parent');
+    insert parentToMerge;
+
+    List<ContactPointAddress> rollupChildren = new List<ContactPointAddress>{
+      new ContactPointAddress(Name = 'Child one', ParentId = parent.Id, PreferenceRank = 1),
+      new ContactPointAddress(Name = 'Child two', ParentId = parentToMerge.Id, PreferenceRank = 2)
+    };
+
+    // we don't even need the parent account's annual revenue to be set; rather
+    // we need to validate that post merge, the rollup is recalculated correctly
+    insert rollupChildren;
+
+    Test.startTest();
+    Database.MergeResult res = Database.merge(parent, parentToMerge.Id, true);
+    Test.stopTest();
+
+    parent = [SELECT Id, AnnualRevenue FROM Account WHERE Id = :parent.Id];
+    System.assertEquals(2, parent.AnnualRevenue, 'Merge should have triggered rollup');
+  }
 }

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -625,8 +625,10 @@ private class RollupIntegrationTests {
     System.assertEquals(true, eval.matches(opp), 'Should match recursively if values do not match');
   }
 
+  // TODO need invocable test
+  // for multiple rollups and full recalc too
   @isTest
-  static void shouldCorrectlyMaxFromTriggerOnMerge() {
+  static void shouldCorrectlyRollupFromTriggerOnMerge() {
     // this test relies on AccountTrigger.trigger having AFTER DELETE set up
     Rollup.rollupMetadata = new List<Rollup__mdt>{
       new Rollup__mdt(
@@ -637,6 +639,15 @@ private class RollupIntegrationTests {
         LookupFieldOnLookupObject__c = 'Id',
         RollupFieldOnLookupObject__c = 'AnnualRevenue',
         RollupOperation__c = 'MAX'
+      ),
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        RollupFieldOnCalcItem__c = 'Name',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'Description',
+        RollupOperation__c = 'CONCAT'
       )
     };
 
@@ -658,7 +669,8 @@ private class RollupIntegrationTests {
     Database.MergeResult res = Database.merge(parent, parentToMerge.Id, true);
     Test.stopTest();
 
-    parent = [SELECT Id, AnnualRevenue FROM Account WHERE Id = :parent.Id];
+    parent = [SELECT Id, Description, AnnualRevenue FROM Account WHERE Id = :parent.Id];
     System.assertEquals(2, parent.AnnualRevenue, 'Merge should have triggered rollup');
+    System.assertEquals(rollupChildren[0].Name + ', ' + rollupChildren[1].Name, parent.Description, 'Second rollup should also have run');
   }
 }

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -325,7 +325,7 @@ private class RollupIntegrationTests {
   }
 
   @isTest
-  static void shouldRunGrandparentRollupsWhenIntermediateObjectsAreUpdated() {
+  static void shouldRunGrandparentRollupsWhenIntermediateObjectsAreUpdatedFromApex() {
     Account greatGrandparent = new Account(Name = 'Great-grandparent');
     Account secondGreatGrandparent = new Account(Name = 'Second great-grandparent');
     insert new List<Account>{ greatGrandparent, secondGreatGrandparent };
@@ -370,8 +370,55 @@ private class RollupIntegrationTests {
     Account updatedGreatGrandparent = [SELECT Name FROM Account WHERE Id = :greatGrandparent.Id];
     Account updatedGreatGrandparentTwo = [SELECT Name FROM Account WHERE Id = :secondGreatGrandparent.Id];
 
-    System.assertEquals(secondChild.Name, updatedGreatGrandparent.Name, 'Grandparent record should have retriggered greatgrandparent rollup!');
-    System.assertEquals(child.Name, updatedGreatGrandparentTwo.Name, 'Grandparent record should have retriggered greatgrandparent rollup again!');
+    System.assertEquals(secondChild.Name, updatedGreatGrandparent.Name, 'Grandparent record should have retriggered greatgrandparent rollup! - apex');
+    System.assertEquals(child.Name, updatedGreatGrandparentTwo.Name, 'Grandparent record should have retriggered greatgrandparent rollup again! - apex');
+  }
+
+  @isTest
+  static void shouldRunGrandparentRollupsWhenIntermediateObjectsAreUpdatedFromFlow() {
+    Account greatGrandparent = new Account(Name = 'Great-grandparent Flow');
+    Account secondGreatGrandparent = new Account(Name = 'Second great-grandparent Flow');
+    insert new List<Account>{ greatGrandparent, secondGreatGrandparent };
+
+    ParentApplication__c grandParent = new ParentApplication__c(Name = 'Grandparent Flow', Account__c = greatGrandparent.Id);
+    ParentApplication__c secondGrandparent = new ParentApplication__c(Name = 'Second grandparent Flow', Account__c = secondGreatGrandparent.Id);
+    List<ParentApplication__c> parentApps = new List<ParentApplication__c>{ grandParent, secondGrandparent };
+    insert parentApps;
+
+    Application__c parent = new Application__c(Name = 'Parent-level Flow', ParentApplication__c = grandParent.Id);
+    Application__c secondParent = new Application__c(Name = 'Second parent-level Flow', ParentApplication__c = secondGrandparent.Id);
+    insert new List<Application__c>{ parent, secondParent };
+
+    ApplicationLog__c child = new ApplicationLog__c(Application__c = secondParent.Id, Name = 'Test Rollup Grandchildren Reparenting Flow');
+    ApplicationLog__c secondChild = new ApplicationLog__c(Name = 'Reparenting deux Flow', Application__c = parent.Id);
+    insert new List<ApplicationLog__c>{ child, secondChild };
+
+    Rollup.shouldRun = true;
+    Rollup.FlowInput input = new Rollup.FlowInput();
+    input.recordsToRollup = parentApps;
+    input.calcItemTypeWhenRollupStartedFromParent = 'ApplicationLog__c';
+    input.rollupFieldOnCalcItem = 'Name';
+    input.lookupFieldOnCalcItem = 'Application__c';
+    input.rollupSObjectName = 'Account';
+    input.lookupFieldOnOpObject = 'Id';
+    input.rollupFieldOnOpObject = 'Name';
+    input.rollupOperation = 'CONCAT_DISTINCT';
+    input.rollupContext = 'UPDATE';
+    input.grandparentRelationshipFieldPath = 'Application__r.ParentApplication__r.Account__r.Name';
+    input.oldRecordsToRollup = new List<ParentApplication__c>{
+      new ParentApplication__c(Id = grandParent.Id, Account__c = secondGreatGrandparent.Id),
+      new ParentApplication__c(Id = secondGrandparent.Id, Account__c = greatGrandparent.Id)
+    };
+
+    Test.startTest();
+    Rollup.performRollup(new List<Rollup.FlowInput>{ input });
+    Test.stopTest();
+
+    Account updatedGreatGrandparent = [SELECT Name FROM Account WHERE Id = :greatGrandparent.Id];
+    Account updatedGreatGrandparentTwo = [SELECT Name FROM Account WHERE Id = :secondGreatGrandparent.Id];
+
+    System.assertEquals(secondChild.Name, updatedGreatGrandparent.Name, 'Grandparent record should have retriggered greatgrandparent rollup! - flow');
+    System.assertEquals(child.Name, updatedGreatGrandparentTwo.Name, 'Grandparent record should have retriggered greatgrandparent rollup again! - flow');
   }
 
   @isTest

--- a/extra-tests/triggers/AccountTrigger.trigger
+++ b/extra-tests/triggers/AccountTrigger.trigger
@@ -1,0 +1,4 @@
+trigger AccountTrigger on Account (after delete) {
+  // included specifically to test merges
+  Rollup.runFromTrigger();
+}

--- a/extra-tests/triggers/AccountTrigger.trigger-meta.xml
+++ b/extra-tests/triggers/AccountTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>51.0</apiVersion>
+  <status>Active</status>
+</ApexTrigger>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.2.24.0",
+  "version": "1.2.25.0",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -323,7 +323,9 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     // side effect in the below method - rollups can be removed from this.rollups if a control record ShouldAbortRun__c == true
     this.ingestRollupControlData();
 
-    this.isNoOp = this.rollups.isEmpty() && this.syncRollups.isEmpty();
+    if (this.isNoOp) {
+      this.isNoOp = this.rollups.isEmpty() && this.syncRollups.isEmpty();
+    }
     if (this.isNoOp || this.rollupControl.ShouldAbortRun__c || SETTINGS.IsEnabled__c == false) {
       return 'No process Id';
     }
@@ -351,9 +353,11 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     Boolean canEnqueue = Limits.getLimitQueueableJobs() > Limits.getQueueableJobs();
     Boolean isAsyncInnerClass = this instanceof RollupAsyncProcessor;
     Rollup roll;
+    // deferred rollups delay the full batch recalc
+    // till all the others have gone
     if (this.rollups.size() == 1 && this.rollups[0] instanceof RollupFullBatchRecalculator) {
       roll = this.rollups[0];
-    } else if(this instanceof RollupFullBatchRecalculator) {
+    } else if (this instanceof RollupFullBatchRecalculator) {
       roll = this;
     } else if (shouldRunAsBatch && System.isBatch() == false) {
       // safe to batch because the QueryLocator will only return one type of SObject
@@ -1725,10 +1729,9 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
   private static void flattenBatches(Rollup outerRollup, List<Rollup> rollups) {
     for (Rollup rollup : rollups) {
-      System.debug(rollup);
       if (rollup.rollups.isEmpty() == false) {
         for (Rollup innerRoll : rollup.rollups) {
-          innerRoll.isFullRecalc = rollup.isFullRecalc || innerRoll.isFullRecalc;
+          innerRoll.isFullRecalc = rollup.isFullRecalc;
         }
         // recurse through lists until there aren't any more nested rollups
         flattenBatches(outerRollup, rollup.rollups);

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -742,6 +742,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       if (flowInput.deferProcessing == true) {
         RollupLogger.Instance.log('deferring processing for rollup', rollups);
         CACHED_ROLLUPS.addAll(rollups);
+        rollups.clear();
       } else {
         RollupLogger.Instance.log('adding invocable rollup to list', rollups);
         rollups.addAll(rollups);
@@ -1524,7 +1525,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     }
 
     if (rollupMetadata.isEmpty() == false) {
-      rollups.add(getRollup(rollupMetadata, calcItemSObjectType, calcItems, oldCalcItems, eval, InvocationPoint.FROM_APEX));
+      rollups.addAll(getRollup(rollupMetadata, calcItemSObjectType, calcItems, oldCalcItems, eval, InvocationPoint.FROM_APEX).rollups);
     }
 
     flattenBatches(batchRollup, rollups);
@@ -1722,9 +1723,10 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
   private static void flattenBatches(Rollup outerRollup, List<Rollup> rollups) {
     for (Rollup rollup : rollups) {
+      System.debug(rollup);
       if (rollup.rollups.isEmpty() == false) {
         for (Rollup innerRoll : rollup.rollups) {
-          innerRoll.isFullRecalc = rollup.isFullRecalc;
+          innerRoll.isFullRecalc = rollup.isFullRecalc || innerRoll.isFullRecalc;
         }
         // recurse through lists until there aren't any more nested rollups
         flattenBatches(outerRollup, rollup.rollups);
@@ -2640,15 +2642,20 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     // because you can only return one list of SObjects from a batch job's QueryLocator
     SObjectType targetType;
     Map<String, Set<String>> queryCountsToLookupIds = new Map<String, Set<String>>();
-    for (Rollup rollup : this.rollups) {
+
+    for (Rollup roll : this.rollups) {
       if (targetType == null) {
-        targetType = rollup.lookupObj;
-      } else if (rollup.lookupObj != targetType) {
+        targetType = roll.lookupObj;
+      } else if (roll.lookupObj != targetType) {
         hasMoreThanOneTarget = true;
-      } else if (String.isNotBlank(rollup.metadata?.GrandparentRelationshipFieldPath__c)) {
+      }
+
+      if (String.isNotBlank(roll.metadata?.GrandparentRelationshipFieldPath__c)) {
         // getting the count for grandparent (or greater) relationships will be handled further
         // downstream; for our purposes, it isn't useful to try to get all of the records while
         // we're still in a sync context
+        continue;
+      } else if (roll.calcItems?.isEmpty() != false) {
         continue;
       }
 
@@ -2657,17 +2664,18 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       }
 
       Set<String> uniqueIds = new Set<String>();
-      for (SObject calcItem : rollup.calcItems) {
-        String lookupKey = (String) calcItem.get(rollup.lookupFieldOnCalcItem);
+
+      for (SObject calcItem : roll.calcItems) {
+        String lookupKey = (String) calcItem.get(roll.lookupFieldOnCalcItem);
         if (String.isNotBlank(lookupKey)) {
           uniqueIds.add(lookupKey);
         }
       }
 
       String countQuery = RollupQueryBuilder.Current.getQuery(
-        rollup.lookupObj,
+        roll.lookupObj,
         new List<String>{ 'Count()' },
-        String.valueOf(rollup.lookupFieldOnLookupObject),
+        String.valueOf(roll.lookupFieldOnLookupObject),
         '='
       );
       if (queryCountsToLookupIds.containsKey(countQuery)) {

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1509,7 +1509,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         rollupContext = '';
       }
       when AFTER_DELETE {
-        reparentAndGetMergedRecordIds(calcItems, rollupMetadata, mergedParentIds);
+        reparentAndGetMergedRecordIds(calcItems, rollupMetadata, mergedParentIds, batchRollup.rollupControl);
       }
       when else {
         shouldReturn = true;
@@ -2143,7 +2143,12 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     return ((SObject) Type.forName(sObjectName).newInstance());
   }
 
-  private static void reparentAndGetMergedRecordIds(List<SObject> calcItems, List<Rollup__mdt> rollupMetadata, Set<String> mergedParentIds) {
+  private static void reparentAndGetMergedRecordIds(
+    List<SObject> calcItems,
+    List<Rollup__mdt> rollupMetadata,
+    Set<String> mergedParentIds,
+    RollupControl__mdt control
+  ) {
     String mergeFieldIndicator = 'MasterRecordId';
     // titled objIds because it's used as a bind variable in SOQL below
     Set<String> objIds = new Set<String>();
@@ -2158,7 +2163,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       }
     }
 
-    if (objIds.isEmpty()) {
+    if (objIds.isEmpty() || control.IsMergeReparentingEnabled__c == false) {
       return;
     }
 

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -54,8 +54,8 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
   // non-final instance variables
   protected Boolean isFullRecalc = false;
+  protected Boolean isNoOp;
   private Boolean isCDCUpdate = false;
-  private Boolean isNoOp;
   private Map<SObjectType, Set<String>> lookupObjectToUniqueFieldNames;
   private List<SObject> lookupItems;
   private RollupRelationshipFieldFinder.Traversal traversal;
@@ -352,7 +352,9 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     Boolean canEnqueue = Limits.getLimitQueueableJobs() > Limits.getQueueableJobs();
     Boolean isAsyncInnerClass = this instanceof RollupAsyncProcessor;
     Rollup roll;
-    if (shouldRunAsBatch && System.isBatch() == false) {
+    if (this.rollups.size() == 1 && this.rollups[0] instanceof RollupFullBatchRecalculator) {
+      roll = this.rollups[0];
+    } else if (shouldRunAsBatch && System.isBatch() == false) {
       // safe to batch because the QueryLocator will only return one type of SObject
       // we have to re-initialize the rollup because it's the Queueable inner class
       // at this point, and without re-initialization we get "System.UnexpectedException: Error processing messages"
@@ -2395,7 +2397,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     for (Rollup rollup : rollups) {
       RollupLogger.Instance.log('starting rollup for: ', rollup);
       // for each iteration, ensure we're not operating beyond the bounds of our query limits
-      if (hasExceededCurrentRollupLimits(rollup.rollupControl)) {
+      if (hasExceededCurrentRollupLimits(rollup.rollupControl) || rollup instanceof RollupFullBatchRecalculator) {
         this.deferredRollups.add(rollup);
         continue;
       }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -325,7 +325,6 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
     this.isNoOp = this.rollups.isEmpty() && this.syncRollups.isEmpty();
     if (this.isNoOp || this.rollupControl.ShouldAbortRun__c || SETTINGS.IsEnabled__c == false) {
-      RollupLogger.Instance.log('aborting run, no-op');
       return 'No process Id';
     }
 
@@ -553,7 +552,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
     String queryString = RollupQueryBuilder.Current.getQuery(childType, new List<String>(queryFields), 'Id', '!=');
 
-    return startFullRecalc(matchingMetadata, amountOfCalcItems, queryString, objIds, recordIds, childType, null, localInvokePoint);
+    return buildFullRecalcRollup(matchingMetadata, amountOfCalcItems, queryString, objIds, recordIds, childType, null, localInvokePoint).beginAsyncRollup();
   }
 
   @AuraEnabled
@@ -573,7 +572,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
     QueryWrapper wrapper = new QueryWrapper(metadata.LookupObject__c, metadata.LookupFieldOnLookupObject__c);
     wrapper.setQuery(metadata.CalcItemWhereClause__c);
-    return performFullRecalculationInner(metadata, wrapper, InvocationPoint.FROM_LWC);
+    return getFullRecalcRollup(metadata, wrapper, InvocationPoint.FROM_LWC).beginAsyncRollup();
   }
 
   global class FlowInput {
@@ -702,13 +701,12 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
       flowInput.rollupOperation = flowInput.rollupOperation.toUpperCase();
       String rollupContext = getFlowRollupContext(flowInput);
+      // flow collections are not strongly typed, so we grab from the first record
+      SObjectType sObjectType = flowInput.recordsToRollup[0].getSObjectType();
 
       // this will throw back up to the Flow engine if the inputs don't pass validation
       enforceValidationRules(flowInput);
-      enforceFlowSpecificRules(flowInput);
-
-      // flow collections are not strongly typed, so we grab from the first record
-      SObjectType sObjectType = flowInput.recordsToRollup[0].getSObjectType();
+      enforceFlowSpecificRules(flowInput, sObjectType);
 
       Rollup__mdt rollupMeta = new Rollup__mdt(
         RollupFieldOnCalcItem__c = flowInput.rollupFieldOnCalcItem,
@@ -727,31 +725,26 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         ConcatDelimiter__c = flowInput.concatDelimiter,
         UltimateParentLookup__c = flowInput.ultimateParentLookup,
         RollupToUltimateParent__c = flowInput.rollupToUltimateParent,
-        CalcItem__c = flowInput.isRollupStartedFromParent ? flowInput.calcItemTypeWhenRollupStartedFromParent : String.valueOf(sObjectType)
+        CalcItem__c = flowInput.isRollupStartedFromParent || String.isNotBlank(flowInput.calcItemTypeWhenRollupStartedFromParent)
+          ? flowInput.calcItemTypeWhenRollupStartedFromParent
+          : String.valueOf(sObjectType),
+        IsRollupStartedFromParent__c = flowInput.isRollupStartedFromParent
       );
 
-      if (flowInput.isRollupStartedFromParent) {
-        QueryWrapper wrapper = getParentWhereClause(
-          flowInput.recordsToRollup,
-          flowInput.lookupFieldOnOpObject,
-          flowInput.rollupSObjectName,
-          flowInput.lookupFieldOnCalcItem,
-          flowInput.grandparentRelationshipFieldPath,
-          flowInput.calcItemWhereClause
-        );
-        performFullRecalculationInner(rollupMeta, wrapper, fromInvocable);
-        continue;
+      List<Rollup__mdt> metas = new List<Rollup__mdt>{ rollupMeta };
+      Map<Id, SObject> oldFlowRecords = getOldFlowRecords(flowInput, sObjectType);
+      processCustomMetadata(rollups, metas, flowInput.recordsToRollup, oldFlowRecords, new Set<String>(), rollupContext);
+
+      if (metas.isEmpty() == false) {
+        rollups.add(getRollup(new List<Rollup__mdt>{ rollupMeta }, sObjectType, flowInput.recordsToRollup, oldFlowRecords, null, fromInvocable));
       }
 
-      Map<Id, SObject> oldFlowRecords = getOldFlowRecords(flowInput, sObjectType);
-
-      Rollup roll = getRollup(new List<Rollup__mdt>{ rollupMeta }, sObjectType, flowInput.recordsToRollup, oldFlowRecords, null, fromInvocable);
       if (flowInput.deferProcessing == true) {
-        RollupLogger.Instance.log('deferring processing for rollup', roll);
-        CACHED_ROLLUPS.add(roll);
+        RollupLogger.Instance.log('deferring processing for rollup', rollups);
+        CACHED_ROLLUPS.addAll(rollups);
       } else {
-        RollupLogger.Instance.log('adding invocable rollup to list', roll);
-        rollups.add(roll);
+        RollupLogger.Instance.log('adding invocable rollup to list', rollups);
+        rollups.addAll(rollups);
       }
     }
 
@@ -1488,8 +1481,9 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   }
 
   global static Rollup runFromApex(List<Rollup__mdt> rollupMetadata, Evaluator eval, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
+    Rollup batchRollup = new RollupAsyncProcessor(InvocationPoint.FROM_APEX);
     if (shouldRunFromTrigger() == false) {
-      return new RollupAsyncProcessor(InvocationPoint.FROM_APEX);
+      return batchRollup;
     }
 
     String rollupContext;
@@ -1515,64 +1509,26 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
       }
     }
 
+    if (shouldReturn) {
+      return batchRollup;
+    }
+
+    List<Rollup> rollups = new List<Rollup>();
+    processCustomMetadata(rollups, rollupMetadata, calcItems, oldCalcItems, mergedParentIds, rollupContext);
+
     SObjectType calcItemSObjectType = calcItems.getSObjectType();
-    for (Integer index = rollupMetadata.size() - 1; index >= 0; index--) {
-      Rollup__mdt rollupInfo = rollupMetadata[index];
-      if (String.isBlank(rollupInfo.CalcItem__c)) {
-        rollupInfo.CalcItem__c = String.valueOf(calcItemSObjectType);
-      }
-      Boolean isIntermediateRollupForGrandparent =
-        rollupInfo.CalcItem__c != String.valueOf(calcItemSObjectType) &&
-        String.isNotBlank(rollupInfo.GrandparentRelationshipFieldPath__c) &&
-        calcItems.isEmpty() == false &&
-        rollupInfo.IsRollupStartedFromParent__c == false &&
-        rollupInfo.LookupObject__c != String.valueOf(calcItemSObjectType);
-
-      if (rollupInfo.IsRollupStartedFromParent__c || isIntermediateRollupForGrandparent) {
-        QueryWrapper queryWrapper = isIntermediateRollupForGrandparent == false
-          ? getParentWhereClause(
-              calcItems,
-              rollupInfo.LookupFieldOnLookupObject__c,
-              rollupInfo.LookupObject__c,
-              rollupInfo.LookupFieldOnCalcItem__c,
-              rollupInfo.GrandparentRelationshipFieldPath__c,
-              rollupInfo.CalcItemWhereClause__c
-            )
-          : getIntermediateGrandparentQueryWrapper(rollupInfo.GrandparentRelationshipFieldPath__c, calcItems, oldCalcItems);
-        if (rollupInfo.IsRollupStartedFromParent__c || isIntermediateRollupForGrandparent && (queryWrapper.hasQuery || isCDC)) {
-          rollupMetadata.remove(index);
-          performFullRecalculationInner(rollupInfo, queryWrapper, InvocationPoint.FROM_APEX);
-        }
-      } else if (mergedParentIds.isEmpty() == false) {
-        QueryWrapper wrapper = new QueryWrapper('', rollupInfo.LookupFieldOnCalcItem__c);
-        for (String mergedParentId : mergedParentIds) {
-          wrapper.addRecordId(mergedParentId);
-        }
-        rollupMetadata.remove(index);
-        performFullRecalculationInner(rollupInfo, wrapper, InvocationPoint.FROM_APEX);
-      }
-
-      // if the same items get run through different rollup operations in the same transaction (rare, but not impossible ...)
-      // we need to reset the CMDT to the correct base operation prior to appending the new context
-      rollupInfo.RollupOperation__c =
-        rollupContext +
-        (rollupInfo.RollupOperation__c.contains('UPDATE_') || rollupInfo.RollupOperation__c.contains('DELETE_')
-          ? rollupInfo.RollupOperation__c.substringAfter('_')
-          : rollupInfo.RollupOperation__c);
-    }
-    shouldReturn = rollupMetadata.isEmpty();
-
-    if (shouldReturn == false) {
-      if (CACHED_APEX_OPERATIONS.containsKey(calcItemSObjectType)) {
-        CACHED_APEX_OPERATIONS.get(calcItemSObjectType).add(apexContext);
-      } else {
-        CACHED_APEX_OPERATIONS.put(calcItemSObjectType, new Set<TriggerOperation>{ apexContext });
-      }
+    if (CACHED_APEX_OPERATIONS.containsKey(calcItemSObjectType)) {
+      CACHED_APEX_OPERATIONS.get(calcItemSObjectType).add(apexContext);
+    } else {
+      CACHED_APEX_OPERATIONS.put(calcItemSObjectType, new Set<TriggerOperation>{ apexContext });
     }
 
-    return shouldReturn
-      ? new RollupAsyncProcessor(InvocationPoint.FROM_APEX)
-      : getRollup(rollupMetadata, calcItemSObjectType, calcItems, oldCalcItems, eval, InvocationPoint.FROM_APEX);
+    if (rollupMetadata.isEmpty() == false) {
+      rollups.add(getRollup(rollupMetadata, calcItemSObjectType, calcItems, oldCalcItems, eval, InvocationPoint.FROM_APEX));
+    }
+
+    flattenBatches(batchRollup, rollups);
+    return batchRollup;
   }
 
   /** end global-facing section, begin public/private static helpers */
@@ -1657,7 +1613,63 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     return hasExceededLimits && isDeferralAllowed;
   }
 
-  private static String performFullRecalculationInner(Rollup__mdt meta, QueryWrapper queryWrapper, InvocationPoint invokePoint) {
+  private static void processCustomMetadata(
+    List<Rollup> rollups,
+    List<Rollup__mdt> metas,
+    List<SObject> calcItems,
+    Map<Id, SObject> oldCalcItems,
+    Set<String> mergedParentIds,
+    String rollupContext
+  ) {
+    SObjectType calcItemSObjectType = calcItems.getSObjectType();
+    for (Integer index = metas.size() - 1; index >= 0; index--) {
+      Rollup__mdt meta = metas[index];
+      Boolean isIntermediateRollupForGrandparent =
+        meta.CalcItem__c != String.valueOf(calcItemSObjectType) &&
+        String.isNotBlank(meta.GrandparentRelationshipFieldPath__c) &&
+        calcItems.isEmpty() == false &&
+        meta.IsRollupStartedFromParent__c == false &&
+        meta.LookupObject__c != String.valueOf(calcItemSObjectType);
+
+      if (String.isBlank(meta.CalcItem__c)) {
+        meta.CalcItem__c = String.valueOf(calcItemSObjectType);
+      }
+
+      if (meta.IsRollupStartedFromParent__c || isIntermediateRollupForGrandparent) {
+        QueryWrapper queryWrapper = isIntermediateRollupForGrandparent == false
+          ? getParentWhereClause(
+              calcItems,
+              meta.LookupFieldOnLookupObject__c,
+              meta.LookupObject__c,
+              meta.LookupFieldOnCalcItem__c,
+              meta.GrandparentRelationshipFieldPath__c,
+              meta.CalcItemWhereClause__c
+            )
+          : getIntermediateGrandparentQueryWrapper(meta.GrandparentRelationshipFieldPath__c, calcItems, oldCalcItems);
+        if (meta.IsRollupStartedFromParent__c || isIntermediateRollupForGrandparent && (queryWrapper.hasQuery || isCDC)) {
+          metas.remove(index);
+          rollups.add(getFullRecalcRollup(meta, queryWrapper, InvocationPoint.FROM_APEX));
+        }
+      } else if (mergedParentIds.isEmpty() == false) {
+        QueryWrapper wrapper = new QueryWrapper('', meta.LookupFieldOnCalcItem__c);
+        for (String mergedParentId : mergedParentIds) {
+          wrapper.addRecordId(mergedParentId);
+        }
+        metas.remove(index);
+        rollups.add(getFullRecalcRollup(meta, wrapper, InvocationPoint.FROM_APEX));
+      }
+
+      // if the same items get run through different rollup operations in the same transaction (rare, but not impossible ...)
+      // we need to reset the CMDT to the correct base operation prior to appending the new context
+      meta.RollupOperation__c =
+        rollupContext +
+        (meta.RollupOperation__c.contains('UPDATE_') || meta.RollupOperation__c.contains('DELETE_')
+          ? meta.RollupOperation__c.substringAfter('_')
+          : meta.RollupOperation__c);
+    }
+  }
+
+  private static Rollup getFullRecalcRollup(Rollup__mdt meta, QueryWrapper queryWrapper, InvocationPoint invokePoint) {
     // just how many items are we talking, here? If it's less than the query limit, we can proceed
     // otherwise, kick off a batch to fetch the calc items and then chain into the regular code path
     SObjectType childType = getSObjectFromName(meta.CalcItem__c).getSObjectType();
@@ -1670,7 +1682,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     );
 
     Set<String> objIds = new Set<String>(); // get everything that doesn't have a null Id - a pretty trick
-    Set<Id> recordIds = queryWrapper.recordIds; // also used below, bound to the "queryString" variable
+    Set<Id> recordIds = queryWrapper.recordIds;
     Integer amountOfCalcItems = getCountFromDb(countQuery, objIds, recordIds);
 
     Set<String> queryFields = new Set<String>{ 'Id', meta.RollupFieldOnCalcItem__c, meta.LookupFieldOnCalcItem__c };
@@ -1678,10 +1690,10 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     queryFields.addAll(whereEval.getQueryFields());
     String queryString = RollupQueryBuilder.Current.getQuery(childType, new List<String>(queryFields), 'Id', '!=', queryWrapper.getQuery());
 
-    return startFullRecalc(new List<Rollup__mdt>{ meta }, amountOfCalcItems, queryString, objIds, recordIds, childType, whereEval, invokePoint);
+    return buildFullRecalcRollup(new List<Rollup__mdt>{ meta }, amountOfCalcItems, queryString, objIds, recordIds, childType, whereEval, invokePoint);
   }
 
-  private static String startFullRecalc(
+  private static Rollup buildFullRecalcRollup(
     List<Rollup__mdt> matchingMeta,
     Integer amountOfCalcItems,
     String queryString,
@@ -1691,21 +1703,14 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     Evaluator eval,
     InvocationPoint invokePoint
   ) {
-    // RollupLogger used to reference the default RollupControl__mdt.MaxLookupRowsBeforeBatching__c, as well as BatchChunkSize__c
-    RollupLogger rollupLogger = RollupLogger.Instance;
-    rollupLogger.log('Starting full recalc');
-    Boolean shouldQueue = amountOfCalcItems != SENTINEL_COUNT_VALUE && amountOfCalcItems < rollupLogger.rollupControl.MaxLookupRowsBeforeBatching__c;
+    Boolean shouldQueue = amountOfCalcItems != SENTINEL_COUNT_VALUE && amountOfCalcItems < RollupLogger.Instance.rollupControl.MaxLookupRowsBeforeBatching__c;
     if (shouldQueue) {
       List<SObject> calculationItems = Database.query(queryString);
       Rollup thisRollup = getRollup(matchingMeta, calcItemType, calculationItems, new Map<Id, SObject>(calculationItems), eval, invokePoint);
       thisRollup.isFullRecalc = true;
-      return thisRollup.runCalc();
+      return thisRollup;
     } else {
-      // batch to get calc items and then batch to rollup
-      return Database.executeBatch(
-        new RollupFullBatchRecalculator(queryString, invokePoint, matchingMeta, calcItemType, recordIds),
-        rollupLogger.rollupControl.BatchChunkSize__c.intValue()
-      );
+      return new RollupFullBatchRecalculator(queryString, invokePoint, matchingMeta, calcItemType, recordIds);
     }
   }
 
@@ -1718,6 +1723,9 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
   private static void flattenBatches(Rollup outerRollup, List<Rollup> rollups) {
     for (Rollup rollup : rollups) {
       if (rollup.rollups.isEmpty() == false) {
+        for (Rollup innerRoll : rollup.rollups) {
+          innerRoll.isFullRecalc = rollup.isFullRecalc;
+        }
         // recurse through lists until there aren't any more nested rollups
         flattenBatches(outerRollup, rollup.rollups);
       } else {
@@ -1753,11 +1761,11 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     }
   }
 
-  private static void enforceFlowSpecificRules(FlowInput flowInput) {
+  private static void enforceFlowSpecificRules(FlowInput flowInput, SObjectType sObjectType) {
     try {
       if (flowInput.rollupContext == 'UPDATE' && flowInput.oldRecordsToRollup?.isEmpty() == true) {
         throw new IllegalArgumentException('Prior records to rollup collection required for rollup context: ' + flowInput.rollupContext);
-      } else if (flowInput.recordsToRollup?.isEmpty() == false) {
+      } else if (String.isBlank(flowInput.grandparentRelationshipFieldPath)) {
         SObject firstRecord = flowInput.recordsToRollup[0];
         SObject lookupItem = getSObjectFromName(
           flowInput.isRollupStartedFromParent ? flowInput.calcItemTypeWhenRollupStartedFromParent : flowInput.rollupSObjectName
@@ -1817,8 +1825,10 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     public void addRecordId(String recordId) {
       if (String.isNotBlank(recordId)) {
         this.hasQuery = true;
-        this.recordIds.add(recordId);
-        this.stringifiedRecordIds.add('\'' + recordId + '\'');
+        if (this.recordIds.contains(recordId) == false) {
+          this.recordIds.add(recordId);
+          this.stringifiedRecordIds.add('\'' + recordId + '\'');
+        }
       }
     }
 
@@ -1984,9 +1994,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     }
     /**
      * We have rollup operations to perform. That's great!
-     * BUT Field Definition CMDT records are stored like such: `Account.NumberOfEmployees`
-     * The generic "put" operation for SObjects (necessary later) doesn't support these "full length" field names
-     * Let's pare them down and get ready to rollup!
+     * Let's get ready to rollup!
      */
     Rollup batchRollup = new RollupAsyncProcessor(rollupInvokePoint);
     DescribeSObjectResult describeForSObject = sObjectType.getDescribe();
@@ -2167,7 +2175,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         );
 
         for (SObject childToReparent : recordsToReparent) {
-          childToReparent.put(meta.LookupFieldOnCalcItem__c, mergedIdToCurrentParentId.get((Id)childToReparent.get(meta.LookupFieldOnCalcItem__c)));
+          childToReparent.put(meta.LookupFieldOnCalcItem__c, mergedIdToCurrentParentId.get((Id) childToReparent.get(meta.LookupFieldOnCalcItem__c)));
           recordsToUpdate.add(childToReparent);
         }
       }
@@ -2579,7 +2587,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     RollupControl__mdt orgDefaults = this.rollupControl;
     for (Integer index = this.rollups.size() - 1; index >= 0; index--) {
       Rollup rollup = this.rollups[index];
-      rollup.isFullRecalc = this.isFullRecalc;
+      rollup.isFullRecalc = rollup.isFullRecalc || this.isFullRecalc;
 
       Boolean shouldRunSyncDeferred = this.getShouldRunSyncDeferred(rollup);
       Boolean couldRunSync =

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -353,6 +353,8 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     Rollup roll;
     if (this.rollups.size() == 1 && this.rollups[0] instanceof RollupFullBatchRecalculator) {
       roll = this.rollups[0];
+    } else if(this instanceof RollupFullBatchRecalculator) {
+      roll = this;
     } else if (shouldRunAsBatch && System.isBatch() == false) {
       // safe to batch because the QueryLocator will only return one type of SObject
       // we have to re-initialize the rollup because it's the Queueable inner class
@@ -552,7 +554,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
     String queryString = RollupQueryBuilder.Current.getQuery(childType, new List<String>(queryFields), 'Id', '!=');
 
-    return buildFullRecalcRollup(matchingMetadata, amountOfCalcItems, queryString, objIds, recordIds, childType, null, localInvokePoint).beginAsyncRollup();
+    return buildFullRecalcRollup(matchingMetadata, amountOfCalcItems, queryString, objIds, recordIds, childType, null, localInvokePoint).runCalc();
   }
 
   @AuraEnabled
@@ -572,7 +574,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
     QueryWrapper wrapper = new QueryWrapper(metadata.LookupObject__c, metadata.LookupFieldOnLookupObject__c);
     wrapper.setQuery(metadata.CalcItemWhereClause__c);
-    return getFullRecalcRollup(metadata, wrapper, InvocationPoint.FROM_LWC).beginAsyncRollup();
+    return getFullRecalcRollup(metadata, wrapper, InvocationPoint.FROM_LWC).runCalc();
   }
 
   global class FlowInput {

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -551,7 +551,6 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
     String queryString = RollupQueryBuilder.Current.getQuery(childType, new List<String>(queryFields), 'Id', '!=');
 
-    // eval always null via this route, despite having been used to get the relationship fields
     return startFullRecalc(matchingMetadata, amountOfCalcItems, queryString, objIds, recordIds, childType, null, localInvokePoint);
   }
 
@@ -1486,13 +1485,14 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     apexContext = null;
   }
 
-  private static Rollup runFromApex(List<Rollup__mdt> rollupMetadata, Evaluator eval, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
+  global static Rollup runFromApex(List<Rollup__mdt> rollupMetadata, Evaluator eval, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
     if (shouldRunFromTrigger() == false) {
       return new RollupAsyncProcessor(InvocationPoint.FROM_APEX);
     }
 
     String rollupContext;
     Boolean shouldReturn = false;
+    Set<String> mergedParentIds = new Set<String>();
 
     switch on apexContext {
       when AFTER_UPDATE {
@@ -1505,13 +1505,17 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         /** for AFTER_INSERT, the base operation name will always be used */
         rollupContext = '';
       }
+      when AFTER_DELETE {
+        reparentAndGetMergedRecordIds(calcItems, rollupMetadata, mergedParentIds);
+      }
       when else {
         shouldReturn = true;
       }
     }
 
     SObjectType calcItemSObjectType = calcItems.getSObjectType();
-    for (Rollup__mdt rollupInfo : rollupMetadata) {
+    for (Integer index = rollupMetadata.size() - 1; index >= 0; index--) {
+      Rollup__mdt rollupInfo = rollupMetadata[index];
       if (String.isBlank(rollupInfo.CalcItem__c)) {
         rollupInfo.CalcItem__c = String.valueOf(calcItemSObjectType);
       }
@@ -1519,10 +1523,10 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         rollupInfo.CalcItem__c != String.valueOf(calcItemSObjectType) &&
         String.isNotBlank(rollupInfo.GrandparentRelationshipFieldPath__c) &&
         calcItems.isEmpty() == false &&
-        rollupInfo.IsRollupStartedFromParent__c == false;
+        rollupInfo.IsRollupStartedFromParent__c == false &&
+        rollupInfo.LookupObject__c != String.valueOf(calcItemSObjectType);
 
       if (rollupInfo.IsRollupStartedFromParent__c || isIntermediateRollupForGrandparent) {
-        shouldReturn = true;
         QueryWrapper queryWrapper = isIntermediateRollupForGrandparent == false
           ? getParentWhereClause(
               calcItems,
@@ -1534,8 +1538,16 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
             )
           : getIntermediateGrandparentQueryWrapper(rollupInfo.GrandparentRelationshipFieldPath__c, calcItems, oldCalcItems);
         if (rollupInfo.IsRollupStartedFromParent__c || isIntermediateRollupForGrandparent && (queryWrapper.hasQuery || isCDC)) {
+          rollupMetadata.remove(index);
           performFullRecalculationInner(rollupInfo, queryWrapper, InvocationPoint.FROM_APEX);
         }
+      } else if (mergedParentIds.isEmpty() == false) {
+        QueryWrapper wrapper = new QueryWrapper('', rollupInfo.LookupFieldOnCalcItem__c);
+        for (String mergedParentId : mergedParentIds) {
+          wrapper.addRecordId(mergedParentId);
+        }
+        rollupMetadata.remove(index);
+        performFullRecalculationInner(rollupInfo, wrapper, InvocationPoint.FROM_APEX);
       }
 
       // if the same items get run through different rollup operations in the same transaction (rare, but not impossible ...)
@@ -1546,6 +1558,7 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
           ? rollupInfo.RollupOperation__c.substringAfter('_')
           : rollupInfo.RollupOperation__c);
     }
+    shouldReturn = rollupMetadata.isEmpty();
 
     if (shouldReturn == false) {
       if (CACHED_APEX_OPERATIONS.containsKey(calcItemSObjectType)) {
@@ -1928,6 +1941,8 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
         if (getPartOfGrandparentChain(meta.GrandparentRelationshipFieldPath__c, sObjectType) != null) {
           continue;
         }
+      } else if (Trigger.operationType == TriggerOperation.AFTER_DELETE && sObjectName == meta.LookupObject__c) {
+        continue;
       } else if (meta.CalcItem__c != sObjectName && meta.IsRollupStartedFromParent__c == false) {
         rollupMetadatas.remove(index);
       } else if (meta.IsRollupStartedFromParent__c && sObjectName != meta.LookupObject__c) {
@@ -2071,14 +2086,14 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
     if (Trigger.operationType != null && isCDC == false) {
       apexContext = Trigger.operationType;
     }
-    // there are only four allowed trigger operations that qualify
-    if (
-      shouldRun &&
-      apexContext != TriggerOperation.AFTER_INSERT &&
-      apexContext != TriggerOperation.AFTER_UPDATE &&
-      apexContext != TriggerOperation.BEFORE_DELETE &&
-      apexContext != TriggerOperation.AFTER_UNDELETE
-    ) {
+    Set<TriggerOperation> validTriggerOps = new Set<TriggerOperation>{
+      TriggerOperation.AFTER_INSERT,
+      TriggerOperation.AFTER_UPDATE,
+      TriggerOperation.BEFORE_DELETE,
+      TriggerOperation.AFTER_DELETE,
+      TriggerOperation.AFTER_UNDELETE
+    };
+    if (shouldRun && validTriggerOps.contains(apexContext) == false) {
       shouldRun = false;
     }
     // an undelete behaviors **strictly** the same as an insert
@@ -2109,6 +2124,53 @@ global without sharing virtual class Rollup implements Database.Batchable<SObjec
 
   private static SObject getSObjectFromName(String sObjectName) {
     return ((SObject) Type.forName(sObjectName).newInstance());
+  }
+
+  private static void reparentAndGetMergedRecordIds(List<SObject> calcItems, List<Rollup__mdt> rollupMetadata, Set<String> mergedParentIds) {
+    String mergeFieldIndicator = 'MasterRecordId';
+    // titled objIds because it's used as a bind variable in SOQL below
+    Set<String> objIds = new Set<String>();
+    Map<Id, Id> mergedIdToCurrentParentId = new Map<Id, Id>();
+    for (SObject record : calcItems) {
+      Map<String, Object> populatedFields = record.getPopulatedFieldsAsMap();
+      if (populatedFields.containsKey(mergeFieldIndicator) && populatedFields.get(mergeFieldIndicator) != null) {
+        String mergedFieldValue = String.valueOf(populatedFields.get(mergeFieldIndicator));
+        objIds.add(record.Id);
+        mergedIdToCurrentParentId.put(record.Id, Id.valueOf(mergedFieldValue));
+        mergedParentIds.add(mergedFieldValue);
+      }
+    }
+
+    if (objIds.isEmpty()) {
+      return;
+    }
+
+    // only M/D relationships specifically set to reparent do so automatically
+    // for everything else - there's rollup
+    List<SObject> recordsToUpdate = new List<SObject>();
+    Set<SObjectType> updatedChildTypes = new Set<SObjectType>();
+    for (Rollup__mdt meta : rollupMetadata) {
+      if (meta.LookupObject__c != String.valueOf(calcItems.getSObjectType())) {
+        continue;
+      }
+
+      SObjectType calcItemSObject = getSObjectFromName(meta.CalcItem__c).getSObjectType();
+
+      // SOQL in a for loop - with the caveat that it's once per child object of any given parent
+      if (updatedChildTypes.contains(calcItemSObject) == false) {
+        updatedChildTypes.add(calcItemSObject);
+
+        List<SObject> recordsToReparent = Database.query(
+          RollupQueryBuilder.Current.getQuery(calcItemSObject, new List<String>{ 'Id', meta.LookupFieldOnCalcItem__c }, meta.LookupFieldOnCalcItem__c, '=')
+        );
+
+        for (SObject childToReparent : recordsToReparent) {
+          childToReparent.put(meta.LookupFieldOnCalcItem__c, mergedIdToCurrentParentId.get((Id)childToReparent.get(meta.LookupFieldOnCalcItem__c)));
+          recordsToUpdate.add(childToReparent);
+        }
+      }
+    }
+    DML.doUpdate(recordsToUpdate);
   }
 
   private static Rollup loadRollups(

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -407,6 +407,8 @@ public without sharing abstract class RollupCalculator {
 
       if (this.isReparented(calcItem, oldCalcItem)) {
         return newVal;
+      } else if (this.eval?.matches(calcItem) == true && this.eval?.matches(oldCalcItem) == false) {
+        return newVal;
       }
 
       Decimal oldVal = this.getNumericValue(oldCalcItem);
@@ -663,9 +665,14 @@ public without sharing abstract class RollupCalculator {
         return 1;
       }
 
-      Object priorCalcVal = oldCalcItem.get(this.opFieldOnCalcItem);
       // for updates, we have to decrement the count if the value has been cleared out
-      return calcItem.get(this.opFieldOnCalcItem) == null && priorCalcVal != null ? -1 : 0;
+      Decimal retVal = 0;
+      if (calcItem.get(this.opFieldOnCalcItem) == null && oldCalcItem.get(this.opFieldOnCalcItem) != null) {
+        retVal = -1;
+      } else if (this.eval?.matches(oldCalcItem) == false && this.eval?.matches(calcItem) == true) {
+        retVal = 1;
+      }
+      return retVal;
     }
   }
 

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -119,9 +119,11 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       Boolean matches = this.changedFieldNames.isEmpty() && this.oldRecordsMap == null;
       for (String fieldName : this.changedFieldNames) {
         // need to trim because list can be comma-separated with leading/trailing spaces
-        if (calcSObject?.get(fieldName.trim()) != oldRecord?.get(fieldName.trim())) {
-          matches = true;
-          break;
+        if (calcSObject.getPopulatedFieldsAsMap().containsKey(fieldName)) {
+          if (calcSObject == oldRecord || calcSObject?.get(fieldName.trim()) != oldRecord?.get(fieldName.trim())) {
+            matches = true;
+            break;
+          }
         }
       }
       return matches;

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -11,6 +11,7 @@ public class RollupFullBatchRecalculator extends Rollup {
     Set<Id> recordIds
   ) {
     super(invokePoint);
+    this.isNoOp = false;
     this.calcItemType = calcItemType;
     this.queryString = queryString;
     this.rollupInfo = rollupInfo;

--- a/rollup/core/classes/RollupQueryBuilder.cls
+++ b/rollup/core/classes/RollupQueryBuilder.cls
@@ -91,7 +91,7 @@ public without sharing class RollupQueryBuilder {
     RollupEvaluator.WhereFieldEvaluator whereEval = RollupEvaluator.getWhereEval(optionalWhereClause, sObjectType);
     try {
       for (String whereClause : whereEval.getWhereClauses()) {
-        if (this.hasPolymorphicOwnerClause(whereClause) == false) {
+        if (this.hasPolymorphicOwnerClause(whereClause) == false || uniqueQueryFieldNames.contains('Count()')) {
           continue;
         }
         String fieldName = whereClause.split(' ')[0];

--- a/rollup/core/classes/RollupRecursionItem.cls
+++ b/rollup/core/classes/RollupRecursionItem.cls
@@ -1,8 +1,9 @@
 public without sharing class RollupRecursionItem {
-  public final String lookupKey;
-  public final Object rollupValue;
   public final Id Id;
 
+  private final String lookupKey;
+  private final Object rollupValue;
+  private final List<Object> additionalValues = new List<Object>();
   private final Hasher hasher;
 
   public RollupRecursionItem(SObject item, Rollup__mdt metadata) {
@@ -13,6 +14,17 @@ public without sharing class RollupRecursionItem {
       .add(this.lookupKey)
       .add(this.rollupValue)
       .add(this.Id);
+    Map<String, Object> fieldsToValues = item?.getPopulatedFieldsAsMap();
+    if (fieldsToValues != null && String.isNotBlank(metadata.CalcItemWhereClause__c)) {
+      List<String> whereFields = RollupEvaluator.getWhereEval(metadata.CalcItemWhereClause__c, item?.getSObjectType()).getQueryFields();
+      for (String whereField : whereFields) {
+        if (fieldsToValues.containsKey(whereField)) {
+          Object whereVal = fieldsToValues.get(whereField);
+          this.additionalValues.add(whereVal);
+          this.hasher.add(whereVal);
+        }
+      }
+    }
   }
 
   // need to define both "equals" and "hashCode" so that a Set<RollupRecursionItem> can use "contains"
@@ -20,7 +32,7 @@ public without sharing class RollupRecursionItem {
   public Boolean equals(Object thatItem) {
     if (thatItem instanceof RollupRecursionItem) {
       RollupRecursionItem that = (RollupRecursionItem) thatItem;
-      return this.lookupKey == that.lookupKey && this.rollupValue == that.rollupValue && this.Id == that.Id;
+      return this.lookupKey == that.lookupKey && this.rollupValue == that.rollupValue && this.Id == that.Id && this.additionalValues == that.additionalValues;
     }
 
     return false;

--- a/rollup/core/customMetadata/RollupControl.Org_Defaults.md-meta.xml
+++ b/rollup/core/customMetadata/RollupControl.Org_Defaults.md-meta.xml
@@ -7,6 +7,10 @@
         <value xsi:type="xsd:double">2000.0</value>
     </values>
     <values>
+        <field>IsMergeReparentingEnabled__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
         <field>IsRollupLoggingEnabled__c</field>
         <value xsi:type="xsd:boolean">false</value>
     </values>

--- a/rollup/core/layouts/RollupControl__mdt-Rollup Control Layout.layout-meta.xml
+++ b/rollup/core/layouts/RollupControl__mdt-Rollup Control Layout.layout-meta.xml
@@ -18,6 +18,10 @@
                 <behavior>Edit</behavior>
                 <field>TriggerOrInvocableName__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>IsMergeReparentingEnabled__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/rollup/core/objects/RollupControl__mdt/fields/IsMergeReparentingEnabled__c.field-meta.xml
+++ b/rollup/core/objects/RollupControl__mdt/fields/IsMergeReparentingEnabled__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>IsMergeReparentingEnabled__c</fullName>
+    <defaultValue>true</defaultValue>
+    <description>If checked, Rollup will automatically reparent children records when a parent record is merged. If you have pre-existing merge handling, please uncheck this option!</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>If checked, Rollup will automatically reparent children records when a parent record is merged. If you have pre-existing merge handling, please uncheck this option!</inlineHelpText>
+    <label>Is Merge Reparenting Enabled</label>
+    <type>Checkbox</type>
+</CustomField>

--- a/rollup/core/profiles/Admin.profile-meta.xml
+++ b/rollup/core/profiles/Admin.profile-meta.xml
@@ -77,6 +77,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>RollupControl__mdt.IsMergeReparentingEnabled__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>RollupControl__mdt.MaxLookupRowsBeforeBatching__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/rollup/tests/RollupCalculatorTests.cls
+++ b/rollup/tests/RollupCalculatorTests.cls
@@ -499,6 +499,26 @@ private class RollupCalculatorTests {
     System.assertEquals(0, calc.getReturnValue());
   }
 
+  @isTest
+  static void shouldReturnCountIfRollupValueUnchangedButEvalStatusHas() {
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      0,
+      Rollup.Op.UPDATE_COUNT,
+      Opportunity.Amount,
+      Account.AnnualRevenue,
+      new Rollup__mdt(CalcItem__c = 'Opportunity'),
+      '0011g00003VDGbF002',
+      Opportunity.AccountId
+    );
+    Opportunity opp = new Opportunity(Id = '0066g00003VDGbF001', Amount = 2, AccountId = '0016g00003VDGbF001');
+    Opportunity oldOpp = opp.clone(true, true);
+    oldOpp.Amount = 1;
+    calc.setEvaluator(new RollupEvaluator.WhereFieldEvaluator('Amount != ' + oldOpp.Amount, Opportunity.SObjectType));
+
+    calc.performRollup(new List<Opportunity>{ opp }, new Map<Id, SObject>{ oldOpp.Id => oldOpp });
+    System.assertEquals(1, calc.getReturnValue(), 'Count should be returned if item was previously excluded but now isn\t!');
+  }
+
   // SUM tests
 
   @isTest
@@ -518,6 +538,26 @@ private class RollupCalculatorTests {
     calc.performRollup(new List<Opportunity>{ opp }, new Map<Id, SObject>());
 
     System.assertEquals(null, calc.getReturnValue());
+  }
+
+  @isTest
+  static void shouldReturnSumIfRollupValueUnchangedButEvalStatusHas() {
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      0,
+      Rollup.Op.UPDATE_SUM,
+      Opportunity.Amount,
+      Account.AnnualRevenue,
+      new Rollup__mdt(CalcItem__c = 'Opportunity'),
+      '0011g00003VDGbF002',
+      Opportunity.AccountId
+    );
+    Opportunity opp = new Opportunity(Id = '0066g00003VDGbF001', Amount = 2, AccountId = '0016g00003VDGbF001');
+    Opportunity oldOpp = opp.clone(true, true);
+    oldOpp.Amount = 1;
+    calc.setEvaluator(new RollupEvaluator.WhereFieldEvaluator('Amount != ' + oldOpp.Amount, Opportunity.SObjectType));
+
+    calc.performRollup(new List<Opportunity>{ opp }, new Map<Id, SObject>{ oldOpp.Id => oldOpp });
+    System.assertEquals(2, calc.getReturnValue(), 'Sum should be returned if item was previously excluded but now isn\t!');
   }
 
   // CONCAT tests

--- a/rollup/tests/RollupEvaluatorTests.cls
+++ b/rollup/tests/RollupEvaluatorTests.cls
@@ -347,7 +347,7 @@ private class RollupEvaluatorTests {
     Rollup.Evaluator eval = RollupEvaluator.getEvaluator(
       null,
       rollupMetadata,
-      new Map<Id, SObject>{ oldOpp.Id => oldOpp, secondOpp.Id => secondOpp },
+      new Map<Id, SObject>{ oldOpp.Id => oldOpp, secondOpp.Id => new Opportunity(Id = secondOpp.Id, StageName = secondOpp.StageName, Amount = 15) },
       Opportunity.SObjectType
     );
     System.assertEquals(true, eval.matches(opp), 'Should match since StageName has changed and amount > 20');
@@ -400,7 +400,8 @@ private class RollupEvaluatorTests {
     Rollup.Evaluator eval = RollupEvaluator.getEvaluator(
       new RollupEvaluator.AlwaysTrueEvaluator(),
       rollupMetadata,
-      new Map<Id, SObject>{ oldOpp.Id => oldOpp, secondOpp.Id => secondOpp },
+      // second opp can't be passed by reference since we do a referential equality check in the changed field eval
+      new Map<Id, SObject>{ oldOpp.Id => oldOpp, secondOpp.Id => new Opportunity(Id = secondOpp.Id, Amount = secondOpp.Amount, Name = 'Something else') },
       Opportunity.SObjectType
     );
 
@@ -446,7 +447,7 @@ private class RollupEvaluatorTests {
     Rollup.Evaluator eval = RollupEvaluator.getEvaluator(
       new RollupEvaluator.AlwaysTrueEvaluator(),
       rollupMetadata,
-      new Map<Id, SObject>{ oldOpp.Id => oldOpp, secondOpp.Id => secondOpp },
+      new Map<Id, SObject>{ oldOpp.Id => oldOpp, secondOpp.Id => new Opportunity(Id = secondOpp.Id, StageName = secondOpp.StageName, Amount = secondOpp.Amount, Name = 'Something else' ) },
       Opportunity.SObjectType
     );
 

--- a/rollup/tests/RollupRecursionItemTests.cls
+++ b/rollup/tests/RollupRecursionItemTests.cls
@@ -1,6 +1,5 @@
 @isTest
 private class RollupRecursionItemTests {
-
   @isTest
   static void shouldReportFalseForNonRollupRecursionItemEquals() {
     RollupRecursionItem recursionItem = new RollupRecursionItem(null, new Rollup__mdt());
@@ -54,6 +53,19 @@ private class RollupRecursionItemTests {
 
   @isTest
   static void shouldNotReportTrueIfSamePropsButDifferentCalcItemWhereFields() {
-    System.assert(false, 'Fix me!');
+    Account acc = new Account(Name = 'Hi', Id = RollupTestUtils.createId(Account.SObjectType), Description = 'Some description');
+    Rollup__mdt meta = new Rollup__mdt(
+      RollupFieldOnCalcItem__c = 'Name',
+      LookupFieldOnCalcItem__c = 'Id',
+      CalcItemWhereClause__c = 'Description != \'' + acc.Description + '\''
+    );
+
+    RollupRecursionItem item = new RollupRecursionItem(acc, meta);
+
+    Account clonedAccount = acc.clone(true, true);
+    clonedAccount.Description = 'Some other description';
+    RollupRecursionItem secondItem = new RollupRecursionItem(clonedAccount, meta);
+
+    System.assertNotEquals(item, secondItem);
   }
 }

--- a/rollup/tests/RollupRecursionItemTests.cls
+++ b/rollup/tests/RollupRecursionItemTests.cls
@@ -51,4 +51,9 @@ private class RollupRecursionItemTests {
 
     System.assertNotEquals(true, recursionItems.contains(nonMatchingItem));
   }
+
+  @isTest
+  static void shouldNotReportTrueIfSamePropsButDifferentCalcItemWhereFields() {
+    System.assert(false, 'Fix me!');
+  }
 }

--- a/rollup/tests/RollupTests.cls
+++ b/rollup/tests/RollupTests.cls
@@ -2933,7 +2933,7 @@ private class RollupTests {
     flowInputs[0].calcItemChangedFields = 'Name, IsDefault';
     flowInputs[0].oldRecordsToRollup = new List<ContactPointAddress>{
       new ContactPointAddress(ParentId = cpas[0].ParentId, Id = cpas[0].Id, PreferenceRank = 250, Name = cpas[0].Name),
-      new ContactPointAddress(ParentId = cpas[1].ParentId, Id = cpas[1].Id, Name = 'Name that does not match', PreferenceRank = 200)
+      new ContactPointAddress(ParentId = cpas[1].ParentId, Id = cpas[1].Id, PreferenceRank = 200, Name = 'Name that does not match')
     };
 
     Test.startTest();

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,9 +5,10 @@
             "package": "apex-rollup",
             "path": "rollup",
             "versionNumber": "1.2.25.0",
-            "versionDescription": "Adding merge functionality for parent records, record-triggered flow bugfixes",
+            "versionDescription": "Correcting issues with recursion detection & merging of parent-level records support",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest"
-        }
+        },
+        {"path": "extra-tests"}
     ],
     "namespace": "",
     "sfdcLoginUrl": "https://login.salesforce.com",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -7,8 +7,7 @@
             "versionNumber": "1.2.25.0",
             "versionDescription": "Correcting issues with recursion detection & merging of parent-level records support",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest"
-        },
-        {"path": "extra-tests"}
+        }
     ],
     "namespace": "",
     "sfdcLoginUrl": "https://login.salesforce.com",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionNumber": "1.2.24.0",
-            "versionDescription": "Fixed issue with String-based COUNT rollups, more separation of concerns work",
+            "versionNumber": "1.2.25.0",
+            "versionDescription": "Adding merge functionality for parent records, record-triggered flow bugfixes",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest"
         }
     ],

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -32,6 +32,7 @@
         "apex-rollup@1.2.21-0": "04t6g000008nt6kAAA",
         "apex-rollup@1.2.22-0": "04t6g000008SgCUAA0",
         "apex-rollup@1.2.23-0": "04t6g000008SgDcAAK",
-        "apex-rollup@1.2.24-0": "04t6g000008SgEQAA0"
+        "apex-rollup@1.2.24-0": "04t6g000008SgEQAA0",
+        "apex-rollup@1.2.25-0": "04t6g000008SgGCAA0"
     }
 }


### PR DESCRIPTION
* Fixes #112 by adding configurable merge reparenting. This only affects Cases / Contacts / Accounts / Leads as these are the standard Salesforce objects where merging is supported. This also adds the requirement for `after delete` in Apex triggers; there is no corresponding equivalent for invocables since neither Flow nor PB support after delete operations (yet). Raised the visibility of the `Rollup.runFromApex` to global to assist with plugging the gap this leaves for people using flow-based rollups who also want to opt into the correct behavior for merge-based reparenting. This functionality is now gated behind the `RollupControl__mdt.IsMergeReparentingEnabled__c` checkbox field, which comes enabled by default on the `Org_Defaults` rollup control record. See the README section entitled **Parent Level Merges** for more information!
* Fixed an issue with recursion detection where calc items differing only by their where clause values could incorrectly get flagged as not having changed while in a recursive trigger/flow scenario
* Fixed several `RollupEvaluator` bugs - mostly surrounding how a calculation item qualifies during an update if the prior version of the item would have been excluded due to the Calc Item Where Clause, but the new item would not be
* Consolidated rollup behavior between invocable/apex-based invocations for two crucial segments - grandparent rollups and rollups triggered from the parent objects. There were previously several subtle differences in the logic for these two sections, and in both cases this was hiding an issue (now fixed) where a full recalculation triggered by either sort of event would prevent other necessary rollups from running at the same time. This issue has now been resolved, and comes with the added benefit of plugging the "escape hatch" code path that had become increasingly prevalent when it came to full recalcs.