### PR TITLE
V1.2.38 - Rollup Goes On a Diet

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Create fast, scalable custom rollups driven by Custom Metadata in your Salesforc
 
 ### Package deployment options
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sgy3AAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SgyDAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sgy3AAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SgyDAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Create fast, scalable custom rollups driven by Custom Metadata in your Salesforc
 
 ### Package deployment options
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SgyDAAS">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SgySAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SgyDAAS">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SgySAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Create fast, scalable custom rollups driven by Custom Metadata in your Salesforc
 
 ### Package deployment options
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SguzAAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sgy3AAC">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SguzAAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sgy3AAC">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/InvocableDrivenTests.cls
+++ b/extra-tests/classes/InvocableDrivenTests.cls
@@ -49,7 +49,7 @@ private class InvocableDrivenTests {
     System.assertEquals(today.addDays(-2), reparentAccount.DateField__c);
     System.assertEquals(3, reparentAccount.NumberOfEmployees, 'Second account should properly reflect reparented record for number of employees');
     System.assertEquals(one.Description + ', ' + three.Description, reparentAccount.Description, 'Second account should have only reparented case description');
-    System.assertEquals(one.Subject, reparentAccount.Name, 'Second account name field should reflect last subject');
     System.assertEquals(2, reparentAccount.AnnualRevenue, 'Second account sum field should include updated amount');
+    System.assertEquals(one.Subject, reparentAccount.Name, 'Second account name field should reflect last subject');
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.2.37.0",
+  "version": "1.2.38.0",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/plugins/CustomObjectRollupLogger/README.md
+++ b/plugins/CustomObjectRollupLogger/README.md
@@ -1,11 +1,11 @@
 # Custom Object Rollup Logger
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SgufAAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SgxPAAS">
   <img alt="Deploy to Salesforce"
        src="../../media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SgufAAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SgxPAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="../../media/deploy-package-to-sandbox.png">
 </a>

--- a/plugins/CustomObjectRollupLogger/classes/RollupCustomObjectLogger.cls
+++ b/plugins/CustomObjectRollupLogger/classes/RollupCustomObjectLogger.cls
@@ -1,15 +1,22 @@
 public class RollupCustomObjectLogger extends RollupLogger {
   private final List<RollupLogEvent__e> rollupLogEvents = new List<RollupLogEvent__e>();
-  private final Integer MAX_LOG_STRING_LENGTH = RollupLogEvent__e.Message__c.getDescribe().getLength();
+  private final Database.DMLOptions truncatedAllowedOptions;
+
+  public RollupCustomObjectLogger() {
+    super();
+    this.truncatedAllowedOptions = new Database.DMLOptions();
+    this.truncatedAllowedOptions.AllowFieldTruncation = true;
+  }
 
   public override void log(String logString, LoggingLevel logLevel) {
-    String potentiallyTruncatedString = logString.length() > MAX_LOG_STRING_LENGTH ? logString.substring(0, MAX_LOG_STRING_LENGTH) : logString;
-    this.rollupLogEvents.add(new RollupLogEvent__e(
+    RollupLogEvent__e logEvent = new RollupLogEvent__e(
       LoggingLevel__c = logLevel.name(),
       LoggedBy__c = UserInfo.getUserId(),
-      Message__c = potentiallyTruncatedString,
+      Message__c = logString,
       TransactionId__c = Request.getCurrent().getRequestId()
-    ));
+    );
+    logEvent.setOptions(this.truncatedAllowedOptions);
+    this.rollupLogEvents.add(logEvent);
   }
 
   public override void log(String logString, Object logObject, LoggingLevel logLevel) {

--- a/plugins/CustomObjectRollupLogger/classes/RollupCustomObjectLogger.cls
+++ b/plugins/CustomObjectRollupLogger/classes/RollupCustomObjectLogger.cls
@@ -1,11 +1,13 @@
 public class RollupCustomObjectLogger extends RollupLogger {
   private final List<RollupLogEvent__e> rollupLogEvents = new List<RollupLogEvent__e>();
+  private final Integer MAX_LOG_STRING_LENGTH = RollupLogEvent__e.Message__c.getDescribe().getLength();
 
   public override void log(String logString, LoggingLevel logLevel) {
+    String potentiallyTruncatedString = logString.length() > MAX_LOG_STRING_LENGTH ? logString.substring(0, MAX_LOG_STRING_LENGTH) : logString;
     this.rollupLogEvents.add(new RollupLogEvent__e(
       LoggingLevel__c = logLevel.name(),
       LoggedBy__c = UserInfo.getUserId(),
-      Message__c = logString,
+      Message__c = potentiallyTruncatedString,
       TransactionId__c = Request.getCurrent().getRequestId()
     ));
   }

--- a/plugins/CustomObjectRollupLogger/classes/RollupCustomObjectLoggerTests.cls
+++ b/plugins/CustomObjectRollupLogger/classes/RollupCustomObjectLoggerTests.cls
@@ -11,12 +11,13 @@ private class RollupCustomObjectLoggerTests {
     Test.stopTest();
 
     List<RollupLog__c> rollupLogs = [
-      SELECT Id, NumberOfLogEntries__c, TransactionId__c, (SELECT Message__c, LoggingLevel__c FROM RollupLogEntry__r)
+      SELECT Id, NumberOfLogEntries__c, TransactionId__c, ErrorWouldHaveBeenThrown__c, (SELECT Message__c, LoggingLevel__c FROM RollupLogEntry__r)
       FROM RollupLog__c
     ];
     System.assertEquals(1, rollupLogs.size(), 'Parent-level rollup log should have been created');
     RollupLog__c firstEntry = rollupLogs[0];
     System.assertNotEquals(null, firstEntry.TransactionId__c, 'Transaction Id should have been assigned');
+    System.assertEquals(true, firstEntry.ErrorWouldHaveBeenThrown__c, 'ERROR level log message was created, this field should be flagged');
 
     // Rollup Log Entries
     System.assertEquals(2, firstEntry.RollupLogEntry__r.size());

--- a/plugins/CustomObjectRollupLogger/classes/RollupLogEventHandler.cls
+++ b/plugins/CustomObjectRollupLogger/classes/RollupLogEventHandler.cls
@@ -3,7 +3,11 @@ public class RollupLogEventHandler {
     Map<String, RollupLog__c> transactionIdToLogs = new Map<String, RollupLog__c>();
 
     for (RollupLogEvent__e logEvent : logEvents) {
-      RollupLog__c rollupLog = new RollupLog__c(TransactionId__c = logEvent.TransactionId__c, LoggedBy__c = Id.valueOf(logEvent.LoggedBy__c));
+      RollupLog__c rollupLog = new RollupLog__c(
+        ErrorWouldHaveBeenThrown__c = logEvent.LoggingLevel__c == LoggingLevel.ERROR.name(),
+        LoggedBy__c = Id.valueOf(logEvent.LoggedBy__c),
+        TransactionId__c = logEvent.TransactionId__c
+      );
       transactionIdToLogs.put(logEvent.TransactionId__c, rollupLog);
     }
 

--- a/plugins/CustomObjectRollupLogger/layouts/RollupLog__c-Rollup Log Layout.layout-meta.xml
+++ b/plugins/CustomObjectRollupLogger/layouts/RollupLog__c-Rollup Log Layout.layout-meta.xml
@@ -21,6 +21,10 @@
                 <behavior>Readonly</behavior>
                 <field>NumberOfLogEntries__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>ErrorWouldHaveBeenThrown__c</field>
+            </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>
     </layoutSections>
@@ -43,6 +47,10 @@
             <layoutItems>
                 <behavior>Readonly</behavior>
                 <field>LastModifiedById</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>TransactionId__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>

--- a/plugins/CustomObjectRollupLogger/objects/RollupLog__c/RollupLog__c.object-meta.xml
+++ b/plugins/CustomObjectRollupLogger/objects/RollupLog__c/RollupLog__c.object-meta.xml
@@ -161,7 +161,7 @@
         <type>AutoNumber</type>
     </nameField>
     <pluralLabel>Rollup Logs</pluralLabel>
-    <searchLayouts/>
+    <searchLayouts></searchLayouts>
     <sharingModel>ReadWrite</sharingModel>
     <visibility>Public</visibility>
 </CustomObject>

--- a/plugins/CustomObjectRollupLogger/objects/RollupLog__c/fields/ErrorWouldHaveBeenThrown__c.field-meta.xml
+++ b/plugins/CustomObjectRollupLogger/objects/RollupLog__c/fields/ErrorWouldHaveBeenThrown__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ErrorWouldHaveBeenThrown__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>If Rollup logs an otherwise fatal exception (with LoggingLevel.ERROR), this field is checked off</description>
+    <externalId>false</externalId>
+    <inlineHelpText>If Rollup logs an otherwise fatal exception (with LoggingLevel.ERROR), this field is checked off</inlineHelpText>
+    <label>Error Would Have Been Thrown</label>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/plugins/CustomObjectRollupLogger/objects/RollupLog__c/fields/TransactionId__c.field-meta.xml
+++ b/plugins/CustomObjectRollupLogger/objects/RollupLog__c/fields/TransactionId__c.field-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>TransactionId__c</fullName>
     <caseSensitive>false</caseSensitive>

--- a/plugins/CustomObjectRollupLogger/permissionsets/RollupLogViewer.permissionset-meta.xml
+++ b/plugins/CustomObjectRollupLogger/permissionsets/RollupLogViewer.permissionset-meta.xml
@@ -3,6 +3,11 @@
     <description>Grants permission to Rollup Log information</description>
     <fieldPermissions>
         <editable>false</editable>
+        <field>RollupLog__c.ErrorWouldHaveBeenThrown__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>RollupLogEntry__c.Message__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/plugins/CustomObjectRollupLogger/profiles/Admin.profile-meta.xml
+++ b/plugins/CustomObjectRollupLogger/profiles/Admin.profile-meta.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Profile xmlns="http://soap.sforce.com/2006/04/metadata">
     <fieldPermissions>
+        <editable>false</editable>
+        <field>RollupLog__c.ErrorWouldHaveBeenThrown__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>RollupLog__c.LoggedBy__c</field>
         <readable>true</readable>

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -18,31 +18,29 @@ global without sharing virtual class Rollup {
   @testVisible
   private static RollupControl__mdt specificControl;
   @testVisible
-  private static Integer maxQueryRowOverride;
-  @testVisible
-  private static final List<RollupAsyncProcessor> CACHED_ROLLUPS = new List<RollupAsyncProcessor>();
+  private static final List<Rollup> CACHED_ROLLUPS = new List<Rollup>();
 
+  private static final Set<String> REPARENTED_KEYS = new Set<String>();
   private static Map<SObjectType, Set<TriggerOperation>> CACHED_APEX_OPERATIONS = new Map<SObjectType, Set<TriggerOperation>>();
   private static Boolean isCDC = false;
   private static Boolean isDeferralAllowed = true;
   private static final String CONTROL_ORG_DEFAULTS = 'Org_Defaults';
-  private static final Set<String> ALWAYS_FULL_RECALC_OPS = new Set<String>{
-    Op.FIRST.name(),
-    Op.LAST.name(),
-    Op.AVERAGE.name(),
-    Op.CONCAT_DISTINCT.name(),
-    Op.COUNT_DISTINCT.name()
-  };
 
+  protected final Set<Id> matchingCalcItemIds;
   protected final RollupControl__mdt rollupControl;
   protected final InvocationPoint invokePoint;
   protected final Boolean isBatched;
   protected final List<RollupAsyncProcessor> rollups = new List<RollupAsyncProcessor>();
 
   // non-final instance variables
+  protected List<SObject> calcItems;
+  protected Map<Id, SObject> oldCalcItems;
+  protected Rollup__mdt metadata;
   protected Boolean isFullRecalc = false;
   protected Boolean isNoOp;
   protected Boolean isCDCUpdate = false;
+  protected RollupAsyncProcessor fullRecalcProcessor;
+  protected Integer queryCount;
 
   /**
    * receiving an interface/subclass from a property get/set (from the book "The Art Of Unit Testing") is an old technique;
@@ -122,7 +120,10 @@ global without sharing virtual class Rollup {
   }
 
   private class FilterResults {
-    public List<SObject> matchingItems { get; set; }
+    public FilterResults() {
+      this.matchingItemIds = new Set<Id>();
+    }
+    public Set<Id> matchingItemIds { get; private set; }
     public Evaluator eval { get; set; }
   }
 
@@ -164,9 +165,18 @@ global without sharing virtual class Rollup {
   protected Rollup(InvocationPoint invokePoint) {
     this.invokePoint = invokePoint;
     this.rollupControl = getSingleControlOrDefault(RollupControl__mdt.DeveloperName, CONTROL_ORG_DEFAULTS, defaultControl);
+    this.isBatched = true;
+    // a batch only becomes valid if other Rollups are added to it
+    this.isNoOp = true;
   }
 
-  protected List<RollupAsyncProcessor> getCachedRollups() {
+  protected Rollup(InvocationPoint invokePoint, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
+    this(invokePoint);
+    this.calcItems = calcItems;
+    this.oldCalcItems = oldCalcItems;
+  }
+
+  protected List<Rollup> getCachedRollups() {
     return CACHED_ROLLUPS;
   }
 
@@ -182,7 +192,7 @@ global without sharing virtual class Rollup {
     isDeferralAllowed = value;
   }
 
-  protected RollupAsyncProcessor getAsyncRollup(
+  protected Rollup getAsyncRollup(
     List<Rollup__mdt> rollupOperations,
     SObjectType sObjectType,
     List<SObject> calcItems,
@@ -199,6 +209,10 @@ global without sharing virtual class Rollup {
 
   public virtual String runCalc() {
     return 'Not implemented';
+  }
+
+  protected virtual String getHashedContents() {
+    return this.toString();
   }
 
   /**
@@ -228,6 +242,7 @@ global without sharing virtual class Rollup {
     public Set<String> queryFields = new Set<String>();
     public List<Rollup__mdt> metadata = new List<Rollup__mdt>();
     public String whereClause = '';
+    public Integer recordCount = RollupQueryBuilder.SENTINEL_COUNT_VALUE;
   }
 
   @AuraEnabled
@@ -257,12 +272,13 @@ global without sharing virtual class Rollup {
 
       SObjectType childType = getSObjectFromName(matchingMeta.CalcItem__c).getSObjectType();
       Set<String> whereFields = getQueryFieldsFromMetadata(matchingMeta, RollupEvaluator.getWhereEval(matchingMeta.CalcItemWhereClause__c, childType));
+      RollupMetadata metaWrapper;
       if (childToMetaWrapper.containsKey(childType)) {
-        RollupMetadata metaWrapper = childToMetaWrapper.get(childType);
+        metaWrapper = childToMetaWrapper.get(childType);
         metaWrapper.queryFields.addAll(whereFields);
         metaWrapper.metadata.add(matchingMeta);
       } else {
-        RollupMetadata metaWrapper = new RollupMetadata();
+        metaWrapper = new RollupMetadata();
         metaWrapper.queryFields = wherefields;
         metaWrapper.metadata.add(matchingMeta);
         metaWrapper.whereClause = potentialWhereClause;
@@ -275,16 +291,19 @@ global without sharing virtual class Rollup {
         if (currentCount == RollupQueryBuilder.SENTINEL_COUNT_VALUE) {
           amountOfCalcItems = currentCount;
         } else {
+          metaWrapper.recordCount = currentCount;
           amountOfCalcItems += currentCount;
         }
       }
     }
 
-    List<RollupAsyncProcessor> processors = new List<RollupAsyncProcessor>();
+    List<Rollup> processors = new List<Rollup>();
     for (SObjectType childType : childToMetaWrapper.keySet()) {
       RollupMetadata metaWrapper = childToMetaWrapper.get(childType);
       String queryString = RollupQueryBuilder.Current.getQuery(childType, new List<String>(metaWrapper.queryFields), 'Id', '!=', metaWrapper.whereClause);
-      processors.add(buildFullRecalcRollup(metaWrapper.metadata, amountOfCalcItems, queryString, objIds, recordIds, childType, null, localInvokePoint));
+      Rollup fullRecalcRoll = buildFullRecalcRollup(metaWrapper.metadata, amountOfCalcItems, queryString, objIds, recordIds, childType, null, localInvokePoint);
+      fullRecalcRoll.queryCount = metaWrapper.recordCount;
+      processors.add(fullRecalcRoll);
     }
 
     return batch(processors);
@@ -416,7 +435,7 @@ global without sharing virtual class Rollup {
   )
   global static List<FlowOutput> performRollup(List<FlowInput> flowInputs) {
     List<FlowOutput> flowOutputs = new List<FlowOutput>();
-    List<RollupAsyncProcessor> localRollups = new List<RollupAsyncProcessor>();
+    List<Rollup> localRollups = new List<Rollup>();
     InvocationPoint fromInvocable = InvocationPoint.FROM_INVOCABLE;
 
     for (FlowInput flowInput : flowInputs) {
@@ -466,22 +485,16 @@ global without sharing virtual class Rollup {
       processCustomMetadata(localRollups, metas, flowInput.recordsToRollup, oldFlowRecords, new Set<String>(), rollupContext, fromInvocable);
 
       if (metas.isEmpty() == false) {
-        RollupAsyncProcessor batchedRollup = getRollup(
-          new List<Rollup__mdt>{ rollupMeta },
-          sObjectType,
-          flowInput.recordsToRollup,
-          oldFlowRecords,
-          null,
-          fromInvocable
-        );
+        Rollup batchedRollup = getRollup(new List<Rollup__mdt>{ rollupMeta }, sObjectType, flowInput.recordsToRollup, oldFlowRecords, null, fromInvocable);
+        batchedRollup.metadata = rollupMeta;
         String logMessage = 'adding invocable rollup to list';
         if (flowInput.deferProcessing) {
           logMessage = 'deferring processing for rollup';
-          CACHED_ROLLUPS.addAll(batchedRollup.rollups);
+          CACHED_ROLLUPS.add(batchedRollup);
         } else {
-          localRollups.addAll(batchedRollup.rollups);
+          localRollups.add(batchedRollup);
         }
-        RollupLogger.Instance.log(logMessage, batchedRollup.rollups, LoggingLevel.DEBUG);
+        RollupLogger.Instance.log(logMessage, batchedRollup, LoggingLevel.DEBUG);
       }
     }
 
@@ -497,7 +510,7 @@ global without sharing virtual class Rollup {
       }
     }
     RollupLogger.Instance.save();
-    RollupAsyncProcessor.flatten(CACHED_ROLLUPS);
+    flatten(CACHED_ROLLUPS);
 
     return flowOutputs;
   }
@@ -1102,34 +1115,6 @@ global without sharing virtual class Rollup {
     );
   }
 
-  private static Rollup operateFromApex(
-    SObjectField operationFieldOnCalcItem,
-    SObjectField lookupFieldOnCalcItem,
-    SObjectField lookupFieldOnOperationObject,
-    SObjectField operationFieldOnOperationObject,
-    SObjectType lookupSObjectType,
-    Op rollupOperation,
-    Object defaultRecalculationValue,
-    String orderByFirstLast,
-    Evaluator eval
-  ) {
-    Rollup__mdt meta = new Rollup__mdt(
-      RollupFieldOnCalcItem__c = operationFieldOnCalcItem.getDescribe().getName(),
-      LookupObject__c = String.valueOf(lookupSObjectType),
-      LookupFieldOnCalcItem__c = lookupFieldOnCalcItem.getDescribe().getName(),
-      LookupFieldOnLookupObject__c = lookupFieldOnOperationObject.getDescribe().getName(),
-      RollupFieldOnLookupObject__c = operationFieldOnOperationObject.getDescribe().getName(),
-      RollupOperation__c = rollupOperation.name(),
-      OrderByFirstLast__c = orderByFirstLast
-    );
-    if (defaultRecalculationValue instanceof Decimal) {
-      meta.FullRecalculationDefaultNumberValue__c = (Decimal) defaultRecalculationValue;
-    } else if (defaultRecalculationValue instanceof String) {
-      meta.FullRecalculationDefaultStringValue__c = (String) defaultRecalculationValue;
-    }
-    return runFromApex(new List<Rollup__mdt>{ meta }, eval, getTriggerRecords(), getOldTriggerRecordsMap());
-  }
-
   global static void runFromCDCTrigger() {
     isCDC = true;
     // CDC always uses Trigger.new
@@ -1219,9 +1204,9 @@ global without sharing virtual class Rollup {
   }
 
   global static Rollup runFromApex(List<Rollup__mdt> rollupMetadata, Evaluator eval, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
-    Rollup batchRollup = new RollupAsyncProcessor(InvocationPoint.FROM_APEX);
+    Rollup rollupConductor = new RollupAsyncProcessor(InvocationPoint.FROM_APEX, calcItems, oldCalcItems);
     if (shouldRunFromTrigger() == false) {
-      return batchRollup;
+      return rollupConductor;
     }
 
     String rollupContext;
@@ -1240,7 +1225,7 @@ global without sharing virtual class Rollup {
         rollupContext = '';
       }
       when AFTER_DELETE {
-        reparentAndGetMergedRecordIds(calcItems, rollupMetadata, mergedParentIds, batchRollup.rollupControl);
+        reparentAndGetMergedRecordIds(calcItems, rollupMetadata, mergedParentIds, rollupConductor.rollupControl);
       }
       when else {
         shouldReturn = true;
@@ -1248,7 +1233,7 @@ global without sharing virtual class Rollup {
     }
 
     if (shouldReturn) {
-      return batchRollup;
+      return rollupConductor;
     }
 
     List<Rollup> localRollups = new List<Rollup>();
@@ -1258,18 +1243,18 @@ global without sharing virtual class Rollup {
     populateCachedApexOperations(calcItemSObjectType, apexContext);
 
     if (rollupMetadata.isEmpty() == false) {
-      localRollups.addAll(getRollup(rollupMetadata, calcItemSObjectType, calcItems, oldCalcItems, eval, InvocationPoint.FROM_APEX).rollups);
+      localRollups.add(getRollup(rollupMetadata, calcItemSObjectType, calcItems, oldCalcItems, eval, InvocationPoint.FROM_APEX));
     }
 
-    flattenBatches(batchRollup, localRollups);
-    return batchRollup;
+    flattenBatches(rollupConductor, localRollups);
+    return rollupConductor;
   }
 
   /** end global-facing section, begin public/private static helpers */
 
   public static void processStoredFlowRollups() {
     RollupLogger.Instance.log('processing deferred flow rollups', LoggingLevel.DEBUG);
-    List<RollupAsyncProcessor> rollupsToProcess = new List<RollupAsyncProcessor>(CACHED_ROLLUPS);
+    List<Rollup> rollupsToProcess = new List<Rollup>(CACHED_ROLLUPS);
     CACHED_ROLLUPS.clear();
     batch(rollupsToProcess, InvocationPoint.FROM_INVOCABLE);
   }
@@ -1351,6 +1336,103 @@ global without sharing virtual class Rollup {
   public static String getBaseOperationName(String fullOpName) {
     Set<String> operationsWithUnderscores = new Set<String>{ Op.COUNT_DISTINCT.name(), Op.CONCAT_DISTINCT.name() };
     return operationsWithUnderscores.contains(fullOpName) == false && fullOpName.contains('_') ? fullOpName.substringAfter('_') : fullOpName;
+  }
+
+  private static Rollup operateFromApex(
+    SObjectField operationFieldOnCalcItem,
+    SObjectField lookupFieldOnCalcItem,
+    SObjectField lookupFieldOnOperationObject,
+    SObjectField operationFieldOnOperationObject,
+    SObjectType lookupSObjectType,
+    Op rollupOperation,
+    Object defaultRecalculationValue,
+    String orderByFirstLast,
+    Evaluator eval
+  ) {
+    Rollup__mdt meta = new Rollup__mdt(
+      RollupFieldOnCalcItem__c = operationFieldOnCalcItem.getDescribe().getName(),
+      LookupObject__c = String.valueOf(lookupSObjectType),
+      LookupFieldOnCalcItem__c = lookupFieldOnCalcItem.getDescribe().getName(),
+      LookupFieldOnLookupObject__c = lookupFieldOnOperationObject.getDescribe().getName(),
+      RollupFieldOnLookupObject__c = operationFieldOnOperationObject.getDescribe().getName(),
+      RollupOperation__c = rollupOperation.name(),
+      OrderByFirstLast__c = orderByFirstLast
+    );
+    if (defaultRecalculationValue instanceof Decimal) {
+      meta.FullRecalculationDefaultNumberValue__c = (Decimal) defaultRecalculationValue;
+    } else if (defaultRecalculationValue instanceof String) {
+      meta.FullRecalculationDefaultStringValue__c = (String) defaultRecalculationValue;
+    }
+    return runFromApex(new List<Rollup__mdt>{ meta }, eval, getTriggerRecords(), getOldTriggerRecordsMap());
+  }
+
+  private static void flatten(List<Rollup> stackedRollups) {
+    Map<String, Rollup> rollupOperationToRollup = new Map<String, Rollup>();
+    Integer counter = 0;
+    Map<String, List<String>> operationToProcessedRecords = new Map<String, List<String>>();
+    for (Rollup stackedRollup : stackedRollups) {
+      // If the hashed contents aren't the same, we can't collapse
+      // the two rollup operations, and instead have to juggle the updated values for the parent in memory
+      String rollupKey = stackedRollup.getHashedContents();
+      Boolean shouldAddSameRollupOperation = false;
+
+      if (rollupOperationToRollup.containsKey(rollupKey)) {
+        Rollup matchingRollup = rollupOperationToRollup.get(rollupKey);
+        for (Integer index = stackedRollup.calcItems.size() - 1; index >= 0; index--) {
+          SObject calcItem = stackedRollup.calcItems[index];
+          if (matchingRollup.calcItems.contains(calcItem) == false && operationToProcessedRecords.containsKey(rollupKey) == false) {
+            doBookkeepingOnCachedItems(matchingRollup, stackedRollup, operationToProcessedRecords, calcItem, rollupKey, index);
+          } else if (
+            matchingRollup.calcItems.contains(calcItem) == false &&
+            operationToProcessedRecords.containsKey(rollupKey) &&
+            operationToProcessedRecords.get(rollupKey).contains(calcItem.Id) == false
+          ) {
+            doBookkeepingOnCachedItems(matchingRollup, stackedRollup, operationToProcessedRecords, calcItem, rollupKey, index);
+          }
+        }
+
+        if (stackedRollup.calcItems.isEmpty() == false) {
+          shouldAddSameRollupOperation = true;
+        }
+      } else {
+        rollupOperationToRollup.put(rollupKey, stackedRollup);
+      }
+      if (shouldAddSameRollupOperation) {
+        counter++;
+        rollupOperationToRollup.put(rollupKey + counter, stackedRollup);
+      }
+    }
+    stackedRollups.clear();
+    stackedRollups.addAll(rollupOperationToRollup.values());
+  }
+
+  private static void doBookkeepingOnCachedItems(
+    Rollup matchingRollup,
+    Rollup stackedRollup,
+    Map<String, List<String>> operationToProcessedRecords,
+    SObject calcItem,
+    String rollupKey,
+    Integer index
+  ) {
+    List<String> processedRecords = operationToProcessedRecords.containsKey(rollupKey)
+      ? operationToProcessedRecords.get(rollupKey)
+      : new List<String>{ calcItem.Id };
+    operationToProcessedRecords.put(rollupKey, processedRecords);
+    Map<Id, SObject> idToCalcItem = new Map<Id, SObject>(matchingRollup.calcItems);
+    idToCalcItem.put(calcItem.Id, calcItem);
+    matchingRollup.calcItems.clear();
+    matchingRollup.calcItems.addAll(idToCalcItem.values());
+    stackedRollup.calcItems.remove(index);
+
+    if (stackedRollup.oldCalcItems.isEmpty() == false && stackedRollup.oldCalcItems.containsKey(calcItem.Id) == false) {
+      matchingRollup.oldCalcItems.put(calcItem.Id, stackedRollup.oldCalcItems.get(calcItem.Id));
+    }
+    for (Rollup innerRollup : matchingRollup.rollups) {
+      if (innerRollup.matchingCalcItemIds?.isEmpty() == false) {
+        innerRollup.matchingCalcItemIds.addAll(idToCalcItem.keySet());
+        innerRollup.matchingCalcItemIds.addAll(matchingRollup.oldCalcItems.keySet());
+      }
+    }
   }
 
   private static void processCustomMetadata(
@@ -1456,12 +1538,15 @@ global without sharing virtual class Rollup {
   ) {
     List<SObject> typedCalcItems = calcItems.clone();
     typedCalcItems.clear();
+    String potentialDeleteOpName = 'DELETE_' + getBaseOperationName(meta.RollupOperation__c);
 
     for (SObject calcItem : calcItems) {
       if (meta.IsRollupStartedFromParent__c == false && String.isBlank(meta.GrandparentRelationshipFieldPath__c) && oldCalcItems.containsKey(calcItem.Id)) {
         SObject oldCalcItem = oldCalcItems.get(calcItem.Id);
-        if (calcItem.get(meta.LookupFieldOnCalcItem__c) != oldCalcItem.get(meta.LookupFieldOnCalcItem__c)) {
+        String key = potentialDeleteOpName + oldCalcItem.Id + JSON.serialize(meta);
+        if (calcItem.get(meta.LookupFieldOnCalcItem__c) != oldCalcItem.get(meta.LookupFieldOnCalcItem__c) && REPARENTED_KEYS.contains(key) == false) {
           typedCalcItems.add(oldCalcItem);
+          REPARENTED_KEYS.add(key);
         }
       }
     }
@@ -1469,10 +1554,18 @@ global without sharing virtual class Rollup {
     // we only need to perform the delete if we've arrived here
     // via a route where there were oldCalcItems AND one or more of their lookup keys changed
     if (typedCalcItems.isEmpty() == false) {
-      String potentialDeleteOpName = 'DELETE_' + getBaseOperationName(meta.RollupOperation__c);
       Rollup__mdt clonedMeta = meta.clone();
       clonedMeta.RollupOperation__c = potentialDeleteOpName;
-      rollups.add(getRollup(new List<Rollup__mdt>{ clonedMeta }, typedCalcItems.getSObjectType(), typedCalcItems, new Map<Id, SObject>(), null, invokePoint));
+      Rollup deleteProcessor = getRollup(
+        new List<Rollup__mdt>{ clonedMeta },
+        typedCalcItems.getSObjectType(),
+        typedCalcItems,
+        new Map<Id, SObject>(),
+        null,
+        invokePoint
+      );
+      RollupLogger.Instance.log('adding delete operation for:', deleteProcessor, LoggingLevel.DEBUG);
+      rollups.add(deleteProcessor);
     }
   }
 
@@ -1490,7 +1583,7 @@ global without sharing virtual class Rollup {
     return '\nORDER BY ' + String.join(orderByFields, ',');
   }
 
-  private static RollupAsyncProcessor getFullRecalcRollup(Rollup__mdt meta, QueryWrapper queryWrapper, InvocationPoint invokePoint) {
+  private static Rollup getFullRecalcRollup(Rollup__mdt meta, QueryWrapper queryWrapper, InvocationPoint invokePoint) {
     // just how many items are we talking, here? If it's less than the query limit, we can proceed
     // otherwise, kick off a batch to fetch the calc items and then chain into the regular code path
     SObjectType childType = getSObjectFromName(meta.CalcItem__c).getSObjectType();
@@ -1511,10 +1604,12 @@ global without sharing virtual class Rollup {
     queryFields.addAll(RollupEvaluator.getWhereEval(meta.CalcItemWhereClause__c, childType).getQueryFields());
     String queryString = RollupQueryBuilder.Current.getQuery(childType, new List<String>(queryFields), 'Id', '!=', queryWrapper.getQuery());
 
-    return buildFullRecalcRollup(new List<Rollup__mdt>{ meta }, amountOfCalcItems, queryString, objIds, recordIds, childType, whereEval, invokePoint);
+    Rollup fullRecalc = buildFullRecalcRollup(new List<Rollup__mdt>{ meta }, amountOfCalcItems, queryString, objIds, recordIds, childType, whereEval, invokePoint);
+    fullRecalc.queryCount = amountOfCalcItems;
+    return fullRecalc;
   }
 
-  private static RollupAsyncProcessor buildFullRecalcRollup(
+  private static Rollup buildFullRecalcRollup(
     List<Rollup__mdt> matchingMeta,
     Integer amountOfCalcItems,
     String queryString,
@@ -1527,13 +1622,13 @@ global without sharing virtual class Rollup {
     for (Rollup__mdt meta : matchingMeta) {
       meta.IsFullRecordSet__c = true;
     }
-    RollupAsyncProcessor instance = new RollupAsyncProcessor(invokePoint);
+    Rollup instance = new Rollup(invokePoint);
     Boolean shouldQueue =
       amountOfCalcItems != RollupQueryBuilder.SENTINEL_COUNT_VALUE &&
       amountOfCalcItems < instance.rollupControl.MaxLookupRowsBeforeBatching__c;
     if (shouldQueue) {
       List<SObject> calculationItems = Database.query(queryString);
-      RollupAsyncProcessor thisRollup = getRollup(matchingMeta, calcItemType, calculationItems, new Map<Id, SObject>(calculationItems), eval, invokePoint);
+      Rollup thisRollup = getRollup(matchingMeta, calcItemType, calculationItems, new Map<Id, SObject>(calculationItems), eval, invokePoint);
       thisRollup.isFullRecalc = true;
       return thisRollup;
     } else {
@@ -1543,21 +1638,30 @@ global without sharing virtual class Rollup {
   }
 
   private static String batch(List<Rollup> rollups, InvocationPoint invokePoint) {
-    Rollup batchRollup = new RollupAsyncProcessor(invokePoint);
-    flattenBatches(batchRollup, rollups);
-    return batchRollup.runCalc();
+    if (rollups.isEmpty()) {
+      return new Rollup(invokePoint).runCalc();
+    }
+    Rollup batchedRollup = new RollupAsyncProcessor(invokePoint, rollups[0].calcItems, rollups[0].oldCalcItems);
+    flattenBatches(batchedRollup, rollups);
+    return batchedRollup.runCalc();
   }
 
   private static void flattenBatches(Rollup outerRollup, List<Rollup> rollups) {
     for (Rollup rollup : rollups) {
       if (rollup.rollups.isEmpty() == false) {
         for (Rollup innerRoll : rollup.rollups) {
+          if (rollup.calcItems?.isEmpty() == false) {
+            innerRoll.calcItems = rollup.calcItems;
+          }
+          if (rollup.oldCalcItems?.isEmpty() == false) {
+            innerRoll.oldCalcItems = rollup.oldCalcItems;
+          }
           innerRoll.isFullRecalc = rollup.isFullRecalc;
         }
         // recurse through lists until there aren't any more nested rollups
         flattenBatches(outerRollup, rollup.rollups);
       } else {
-        loadRollups(rollup, outerRollup);
+        loadRollups((RollupAsyncProcessor) rollup, outerRollup);
       }
     }
   }
@@ -1825,7 +1929,7 @@ global without sharing virtual class Rollup {
     return null;
   }
 
-  private static RollupAsyncProcessor getRollup(
+  private static Rollup getRollup(
     List<Rollup__mdt> rollupOperations,
     SObjectType sObjectType,
     List<SObject> calcItems,
@@ -1833,8 +1937,9 @@ global without sharing virtual class Rollup {
     Evaluator eval,
     InvocationPoint rollupInvokePoint
   ) {
+    Rollup rollupConductor = new RollupAsyncProcessor(rollupInvokePoint, calcItems, oldCalcItems);
     if (rollupOperations.isEmpty() || calcItems.isEmpty()) {
-      return new RollupAsyncProcessor(rollupInvokePoint);
+      return rollupConductor;
     }
     if (sObjectType == null) {
       sObjectType = calcItems[0].getSObjectType();
@@ -1843,7 +1948,6 @@ global without sharing virtual class Rollup {
      * We have rollup operations to perform. That's great!
      * Let's get ready to rollup!
      */
-    RollupAsyncProcessor batchRollup = new RollupAsyncProcessor(rollupInvokePoint);
     DescribeSObjectResult describeForSObject = sObjectType.getDescribe();
     Map<String, SObjectField> fieldNameToField = describeForSObject.fields.getMap();
 
@@ -1865,7 +1969,7 @@ global without sharing virtual class Rollup {
       rollupMetadata.LookupFieldOnLookupObject__c = lookupFieldOnOpObject.getDescribe().getName();
       rollupMetadata.RollupFieldOnLookupObject__c = rollupFieldOnOpObject.getDescribe().getName();
 
-      if (rollupMetadata.IsFullRecordSet__c != true && ALWAYS_FULL_RECALC_OPS.contains(getBaseOperationName(rollupMetadata.RollupOperation__c))) {
+      if (rollupMetadata.IsFullRecordSet__c != true && isFullRecalcOp(getBaseOperationName(rollupMetadata.RollupOperation__c))) {
         rollupMetadata.IsFullRecordSet__c = true;
       }
 
@@ -1889,16 +1993,15 @@ global without sharing virtual class Rollup {
         lookupSObjectType,
         sObjectType, // calc item SObjectType
         rollupOp,
-        filterResults.matchingItems,
-        oldCalcItems,
-        batchRollup,
+        filterResults.matchingItemIds,
+        rollupConductor,
         filterResults.eval,
         localControl,
         rollupInvokePoint,
         rollupMetadata
       );
     }
-    return batchRollup;
+    return rollupConductor;
   }
 
   private static SObjectField getSObjectFieldByName(DescribeSObjectResult objectDescribe, String desiredField) {
@@ -1911,6 +2014,14 @@ global without sharing virtual class Rollup {
     }
 
     return null;
+  }
+
+  private static Boolean isFullRecalcOp(String baseOperationName) {
+    return baseOperationName == Op.FIRST.name() ||
+      baseOperationName == Op.LAST.name() ||
+      baseOperationName == Op.AVERAGE.name() ||
+      baseOperationName == Op.CONCAT_DISTINCT.name() ||
+      baseOperationName == Op.COUNT_DISTINCT.name();
   }
 
   private static String getRollupControlKey(
@@ -2052,16 +2163,15 @@ global without sharing virtual class Rollup {
     SObjectType lookupSObjectType,
     SObjectType calcItemSObjectType,
     Op rollupOp,
-    List<SObject> calcItems,
-    Map<Id, SObject> oldCalcItems,
-    Rollup batchRollup,
+    Set<Id> matchingCalcItemIds,
+    Rollup rollupConductor,
     Evaluator eval,
     RollupControl__mdt rollupControl,
     InvocationPoint invokePoint,
     Rollup__mdt rollupMetadata
   ) {
-    Rollup rollup = RollupAsyncProcessor.getProcessor(
-      calcItems,
+    RollupAsyncProcessor processor = RollupAsyncProcessor.getProcessor(
+      matchingCalcItemIds,
       rollupFieldOnCalcItem,
       lookupFieldOnCalcItem,
       lookupFieldOnOpObject,
@@ -2069,23 +2179,19 @@ global without sharing virtual class Rollup {
       lookupSObjectType,
       calcItemSObjectType,
       rollupOp,
-      oldCalcItems,
       eval,
       invokePoint,
       rollupControl,
       rollupMetadata
     );
-    return loadRollups(rollup, batchRollup);
+    return loadRollups(processor, rollupConductor);
   }
 
-  private static Rollup loadRollups(Rollup rollup, Rollup batchRollup) {
-    RollupAsyncProcessor processor = (RollupAsyncProcessor) rollup;
-    if (batchRollup != null && rollup != null && rollup.isNoOp == false) {
-      batchRollup.rollups.add(processor);
-    } else if (rollup != null && rollup.isNoOp == false) {
-      rollup.rollups.add(processor);
+  private static Rollup loadRollups(RollupAsyncProcessor processor, Rollup rollupConductor) {
+    if (rollupConductor != null && processor != null && processor.isNoOp == false) {
+      rollupConductor.rollups.add(processor);
     }
-    return batchRollup != null ? batchRollup : rollup;
+    return rollupConductor;
   }
 
   private static RollupControl__mdt getSingleControlOrDefault(SObjectField whereField, Object whereValue, RollupControl__mdt testOverrideData) {
@@ -2138,14 +2244,7 @@ global without sharing virtual class Rollup {
 
   private static FilterResults filter(List<SObject> calcItems, Map<Id, SObject> oldCalcItems, Evaluator eval, Rollup__mdt metadata, SObjectType calcItemType) {
     FilterResults results = new FilterResults();
-    List<SObject> matchingItems = calcItems == null ? new List<SObject>() : calcItems.clone();
-    results.matchingItems = matchingItems;
-    if (matchingItems.isEmpty()) {
-      return results;
-    }
-    matchingItems.clear(); // retains the strong-typing on the list for downstream calls to List.getSbjectType()
     calcItems = replaceCalcItemsForPolymorphicWhereClause(calcItems, metadata);
-
     results.eval = RollupEvaluator.getEvaluator(eval, metadata, oldCalcItems, calcItemType);
 
     // while we iterate through calcItems, the only possible mutation to that array is through "replaceCalcItemsForPolymorphicWhereClause"
@@ -2156,13 +2255,12 @@ global without sharing virtual class Rollup {
       // if the where clause would exclude something, but we're in an update
       // and the old value wouldn't have been excluded, pass it on through
       // to be handled further downstream
-      SObject potentialOldItem = oldCalcItems?.isEmpty() == false && oldCalcItems.containsKey(item.Id) ? oldCalcItems.get(item.Id) : item;
-      if (results.eval.matches(item) || results.eval.matches(potentialOldItem)) {
-        matchingItems.add(item);
-        // metadata shouldn't be null, but it's good to check; unfortunately, if(null) throws so we
-        // have to do this EXTRA explicit check
+      if (results.eval.matches(item)) {
+        results.matchingItemIds.add(item.Id);
+      } else if (oldCalcItems != null && oldCalcItems.containsKey(item.Id) && results.eval.matches(oldCalcItems.get(item.Id))) {
+        results.matchingItemIds.add(item.Id);
       } else if (metadata?.IsFullRecordSet__c == true) {
-        matchingItems.add(item);
+        results.matchingItemIds.add(item.Id);
       }
     }
     return results;

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1688,9 +1688,7 @@ global without sharing virtual class Rollup {
 
     if (String.isNotBlank(errorMessage)) {
       Exception ex = new IllegalArgumentException(errorMessage);
-      RollupLogger.Instance.log('an error occurred while validating flow inputs', ex, LoggingLevel.ERROR);
-      RollupLogger.Instance.save();
-      throw ex;
+      logAndThrowFlowException(ex, 'an error occurred while validating flow inputs');
     }
   }
 
@@ -1713,10 +1711,14 @@ global without sharing virtual class Rollup {
         (flowInput.isRollupStartedFromParent ? firstRecord : lookupItem).get(flowInput.lookupFieldOnOpObject);
       }
     } catch (Exception ex) {
-      RollupLogger.Instance.log('an error occurred while validating flow-specific rules', ex, LoggingLevel.ERROR);
-      RollupLogger.Instance.save();
-      throw ex;
+      logAndThrowFlowException(ex, 'an error occurred while validating flow-specific rules');
     }
+  }
+
+  private static void logAndThrowFlowException(Exception ex, String logString) {
+    RollupLogger.Instance.log(logString, ex, LoggingLevel.ERROR);
+    RollupLogger.Instance.save();
+    throw ex;
   }
 
   private static QueryWrapper getIntermediateGrandparentQueryWrapper(String grandparentFieldPath, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -160,8 +160,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       'Is No Op' => String.valueOf(this.isNoOp)
     };
 
-    // TODO - potentially change this from toString to an argument-accepting method
-    // so that calcItems/oldCalcItems are only logged below the DEBUG logging level enum
     this.addToMap(props, 'Calc Items', this.calcItems);
     this.addToMap(props, 'Old Calc Items', this.oldCalcItems);
     this.addToMap(props, 'Rollup Metadata', this.metadata);
@@ -275,7 +273,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       roll = this;
     } else {
       // the end of the line
-      this.throwWithRollupData(this.rollups);
+      this.logFatalRollups(this.rollups);
     }
 
     return roll;
@@ -576,16 +574,15 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
         this.getAsyncRollup().beginAsyncRollup();
       } else if (this.deferredRollups.isEmpty() == false) {
-        this.throwWithRollupData(this.deferredRollups);
+        this.logFatalRollups(this.deferredRollups);
       }
     }
   }
 
-  private void throwWithRollupData(List<Rollup> rolls) {
+  private void logFatalRollups(List<Rollup> rolls) {
     String exceptionString = 'rollup failed to re-queue for: ';
     RollupLogger.Instance.log(exceptionString, rolls, LoggingLevel.ERROR);
     RollupLogger.Instance.save();
-    throw new AsyncException(exceptionString + rolls);
   }
 
   private void setupCalcItemData(Rollup roll) {

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -10,16 +10,12 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   private final List<RollupAsyncProcessor> deferredRollups = new List<RollupAsyncProcessor>();
   private final List<RollupAsyncProcessor> syncRollups = new List<RollupAsyncProcessor>();
 
-  protected final List<SObject> calcItems;
-  protected final Map<Id, SObject> oldCalcItems;
-  protected final Rollup__mdt metadata;
   protected final SObjectType calcItemType;
 
   private RollupRelationshipFieldFinder.Traversal traversal;
   private Map<SObjectType, Set<String>> lookupObjectToUniqueFieldNames;
   private Map<SObjectType, Set<String>> calcObjectToUniqueFieldNames;
   private List<SObject> lookupItems;
-  private RollupAsyncProcessor fullRecalcProcessor;
   private Map<String, List<SObject>> cachedFullRecalcs;
 
   private static final RollupSettings__c SETTINGS = RollupSettings__c.getInstance();
@@ -39,48 +35,17 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
   }
 
-  public static void flatten(List<RollupAsyncProcessor> stackedRollups) {
-    Map<String, RollupAsyncProcessor> rollupOperationToRollup = new Map<String, RollupAsyncProcessor>();
-    Integer counter = 0;
-    Map<String, List<String>> operationToProcessedRecords = new Map<String, List<String>>();
-    for (RollupAsyncProcessor stackedRollup : stackedRollups) {
-      // If the hashed contents are the same, we can't collapse
-      // the two rollup operations, and instead have to juggle the updated values for the parent in memory
-      String rollupKey = stackedRollup.getHashedContents();
-      Boolean shouldAddSameRollupOperation = false;
-
-      if (rollupOperationToRollup.containsKey(rollupKey)) {
-        RollupAsyncProcessor matchingRollup = rollupOperationToRollup.get(rollupKey);
-        for (Integer index = stackedRollup.calcItems.size() - 1; index >= 0; index--) {
-          SObject calcItem = stackedRollup.calcItems[index];
-          if (matchingRollup.calcItems.contains(calcItem) == false && operationToProcessedRecords.containsKey(rollupKey) == false) {
-            doBookkeepingOnCachedItems(matchingRollup, stackedRollup, operationToProcessedRecords, calcItem, rollupKey, index);
-          } else if (
-            matchingRollup.calcItems.contains(calcItem) == false &&
-            operationToProcessedRecords.containsKey(rollupKey) &&
-            operationToProcessedRecords.get(rollupKey).contains(calcItem.Id) == false
-          ) {
-            doBookkeepingOnCachedItems(matchingRollup, stackedRollup, operationToProcessedRecords, calcItem, rollupKey, index);
-          }
-        }
-
-        if (stackedRollup.calcItems.isEmpty() == false) {
-          shouldAddSameRollupOperation = true;
-        }
-      } else {
-        rollupOperationToRollup.put(rollupKey, stackedRollup);
-      }
-      if (shouldAddSameRollupOperation) {
-        counter++;
-        rollupOperationToRollup.put(rollupKey + counter, stackedRollup);
-      }
+  private class CalcItemData {
+    public CalcItemData(List<SObject> items, Map<Id, SObject> oldItems) {
+      this.items = items.clone();
+      this.oldItems = oldItems.clone();
     }
-    stackedRollups.clear();
-    stackedRollups.addAll(rollupOperationToRollup.values());
+    public final List<SObject> items;
+    public final Map<Id, SObject> oldItems;
   }
 
   public static RollupAsyncProcessor getProcessor(
-    List<SObject> calcItems,
+    Set<Id> matchingCalcItemIds,
     SObjectField opFieldOnCalcItem,
     SObjectField lookupFieldOnCalcItem,
     SObjectField lookupFieldOnLookupObject,
@@ -88,14 +53,13 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     SObjectType lookupObj,
     SObjectType calcItem,
     Op operation,
-    Map<Id, SObject> oldCalcItems,
     Evaluator eval,
     InvocationPoint rollupInvokePoint,
     RollupControl__mdt rollupControl,
     Rollup__mdt metadata
   ) {
     return new QueueableProcessor(
-      calcItems,
+      matchingCalcItemIds,
       opFieldOnCalcItem,
       lookupFieldOnCalcItem,
       lookupFieldOnLookupObject,
@@ -103,7 +67,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       lookupObj,
       calcItem,
       operation,
-      oldCalcItems,
       eval,
       rollupInvokePoint,
       rollupControl,
@@ -113,41 +76,23 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
   public RollupAsyncProcessor(InvocationPoint invokePoint) {
     super(invokePoint);
-    this.isBatched = true;
-    // a batch only becomes valid if other Rollups are added to it
-    this.isNoOp = true;
   }
 
-  public RollupAsyncProcessor(RollupAsyncProcessor innerRollup, Op op, List<SObject> calcItems) {
-    this(
-      calcItems,
-      innerRollup.opFieldOnCalcItem,
-      innerRollup.lookupFieldOnCalcItem,
-      innerRollup.lookupFieldOnLookupObject,
-      innerRollup.opFieldOnLookupObject,
-      innerRollup.lookupObj,
-      innerRollup.calcItemType,
-      op,
-      innerRollup.oldCalcItems,
-      null, // eval gets assigned below
-      innerRollup.invokePoint,
-      innerRollup.rollupControl,
-      innerRollup.metadata
-    );
+  public RollupAsyncProcessor(InvocationPoint invokePoint, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
+    super(invokePoint, calcItems, oldCalcItems);
+  }
+
+  public RollupAsyncProcessor(RollupAsyncProcessor innerRollup) {
+    super(innerRollup.invokePoint, innerRollup.calcItems, innerRollup.oldCalcItems);
 
     this.rollups.addAll(innerRollup.rollups);
     this.isNoOp = this.rollups.isEmpty() && innerRollup.metadata?.IsFullRecordSet__c == false;
     this.isFullRecalc = innerRollup.isFullRecalc;
     this.isCDCUpdate = innerRollup.isCDCUpdate;
-    this.eval = innerRollup.eval;
-  }
-
-  public RollupAsyncProcessor(RollupAsyncProcessor innerRollup) {
-    this(innerRollup, innerRollup.op, innerRollup.calcItems);
   }
 
   public RollupAsyncProcessor(
-    List<SObject> calcItems,
+    Set<Id> matchingCalcItemIds,
     SObjectField opFieldOnCalcItem,
     SObjectField lookupFieldOnCalcItem,
     SObjectField lookupFieldOnLookupObject,
@@ -155,14 +100,13 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     SObjectType lookupObj,
     SObjectType calcItemType,
     Op op,
-    Map<Id, SObject> oldCalcItems,
     Evaluator eval,
     InvocationPoint invokePoint,
     RollupControl__mdt rollupControl,
     Rollup__mdt rollupMetadata
   ) {
     super();
-    this.calcItems = calcItems;
+    this.matchingCalcItemIds = matchingCalcItemIds;
     this.opFieldOnCalcItem = opFieldOnCalcItem;
     this.lookupFieldOnCalcItem = lookupFieldOnCalcItem;
     this.lookupFieldOnLookupObject = lookupFieldOnLookupObject;
@@ -170,7 +114,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     this.lookupObj = lookupObj;
     this.calcItemType = calcItemType;
     this.op = op;
-    this.oldCalcItems = oldCalcItems;
     this.invokePoint = invokePoint;
     this.rollupControl = rollupControl;
     this.metadata = rollupMetadata;
@@ -180,7 +123,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       this.eval = eval;
     }
 
-    this.isNoOp = this.calcItems?.isEmpty() == true && this.metadata?.IsFullRecordSet__c == false;
+    this.isNoOp = this.matchingCalcItemIds?.isEmpty() == true && this.metadata?.IsFullRecordSet__c == false;
   }
 
   public Integer compareTo(Object otherRollup) {
@@ -211,14 +154,19 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
   public override String toString() {
     Map<String, String> props = new Map<String, String>{
+      'Type' => this.getTypeName(),
       'Invocation Point' => this.invokePoint.name(),
-      'Calc Items' => JSON.serializePretty(this.calcItems),
-      'Old Calc Items' => JSON.serializePretty(this.oldCalcItems),
-      'Rollup Metadata' => JSON.serializePretty(this.metadata),
-      'Rollup Control' => JSON.serializePretty(this.rollupControl),
       'Is Full Recalc' => String.valueOf(this.isFullRecalc),
       'Is No Op' => String.valueOf(this.isNoOp)
     };
+
+    // TODO - potentially change this from toString to an argument-accepting method
+    // so that calcItems/oldCalcItems are only logged below the DEBUG logging level enum
+    this.addToMap(props, 'Calc Items', this.calcItems);
+    this.addToMap(props, 'Old Calc Items', this.oldCalcItems);
+    this.addToMap(props, 'Rollup Metadata', this.metadata);
+    this.addToMap(props, 'Rollup Control', this.rollupControl);
+
     String baseString = '';
     for (String key : props.keySet()) {
       baseString += key + ': ' + props.get(key) + '\n';
@@ -300,6 +248,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     return rollupProcessId;
   }
 
+  protected virtual String getTypeName() {
+    return 'RollupAsyncProcessor';
+  }
+
   protected RollupAsyncProcessor getAsyncRollup() {
     // swap off on which async process is running to achieve infinite scaling
     isRunningAsync = true;
@@ -331,7 +283,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
   private class QueueableProcessor extends RollupAsyncProcessor implements System.Queueable {
     private QueueableProcessor(
-      List<SObject> calcItems,
+      Set<Id> matchingCalcItemIds,
       SObjectField opFieldOnCalcItem,
       SObjectField lookupFieldOnCalcItem,
       SObjectField lookupFieldOnLookupObject,
@@ -339,14 +291,13 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       SObjectType lookupObj,
       SObjectType calcItem,
       Op operation,
-      Map<Id, SObject> oldCalcItems,
       Evaluator eval,
       InvocationPoint rollupInvokePoint,
       RollupControl__mdt rollupControl,
       Rollup__mdt metadata
     ) {
       super(
-        calcItems,
+        matchingCalcItemIds,
         opFieldOnCalcItem,
         lookupFieldOnCalcItem,
         lookupFieldOnLookupObject,
@@ -354,7 +305,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         lookupObj,
         calcItem,
         operation,
-        oldCalcItems,
         eval,
         rollupInvokePoint,
         rollupControl,
@@ -368,6 +318,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
     private QueueableProcessor(RollupAsyncProcessor roll) {
       super(roll);
+    }
+
+    protected override String getTypeName() {
+      return 'QueueableProcessor';
     }
 
     protected override String beginAsyncRollup() {
@@ -426,7 +380,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
   protected void processDelegatedFullRecalcRollup(List<Rollup__mdt> rollupInfo, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
     isRunningAsync = true; // the first rollup can immediately start rolling up, instead of dispatching to a queueable / another batchable
-    RollupAsyncProcessor roll = this.getAsyncRollup(rollupInfo, this.calcItemType, calcItems, oldCalcItems, null, this.invokePoint);
+    Rollup roll = this.getAsyncRollup(rollupInfo, this.calcItemType, calcItems, oldCalcItems, null, this.invokePoint);
     roll.isFullRecalc = true;
     roll.fullRecalcProcessor = this;
     roll.runCalc();
@@ -491,9 +445,12 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     Map<String, SObject> updatedLookupRecords = new Map<String, SObject>();
     Map<SObjectType, RollupRelationshipFieldFinder.Traversal> grandparentRollups = new Map<SObjectType, RollupRelationshipFieldFinder.Traversal>();
     for (RollupAsyncProcessor roll : rollups) {
+      CalcItemData data = new CalcItemData(this.calcItems, this.oldCalcItems);
+      this.setupCalcItemData(roll);
       RollupLogger.Instance.log('starting rollup for: ', roll, LoggingLevel.DEBUG);
       // for each iteration, ensure we're not operating beyond the bounds of our query limits
       if (hasExceededCurrentRollupLimits(roll.rollupControl) || roll instanceof RollupFullBatchRecalculator) {
+        RollupLogger.Instance.log('Deferring current rollup, past limits', LoggingLevel.DEBUG);
         this.deferredRollups.add(roll);
         continue;
       }
@@ -519,6 +476,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       for (SObject updatedRecord : updatedParentRecords) {
         updatedLookupRecords.put(updatedRecord.Id, updatedRecord);
       }
+      this.resetCalcItemData(data);
     }
 
     this.splitUpdates(updatedLookupRecords);
@@ -528,13 +486,19 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     this.processDeferredRollups();
   }
 
-  private String getHashedContents() {
+  protected override String getHashedContents() {
     // the only thing that necessarily makes a rollup unique is the sum total of the metadata behind it
     // as well as the calc items driving that calculation.
-    // you could have multiple rollups with different calc item where clauses all rolling up to the same field
+    // you could have multiple rollups with different Calc Item Where Clauses all rolling up to the same field
     // even worse - in situations where multiple DML operations are enqueued in the same transaction
     // the same calc items by Id might differ slightly by field value.
     return String.valueOf(this.metadata);
+  }
+
+  private void addToMap(Map<String, String> props, String key, Object ref) {
+    if (ref != null) {
+      props.put(key, JSON.serializePretty(ref));
+    }
   }
 
   private void handleMultipleDMLRollupsEnqueuedInTheSameTransaction(List<Rollup> rolls) {
@@ -620,7 +584,28 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   private void throwWithRollupData(List<Rollup> rolls) {
     String exceptionString = 'rollup failed to re-queue for: ';
     RollupLogger.Instance.log(exceptionString, rolls, LoggingLevel.ERROR);
+    RollupLogger.Instance.save();
     throw new AsyncException(exceptionString + rolls);
+  }
+
+  private void setupCalcItemData(Rollup roll) {
+    // if a rollup has calc items set, we take their calcItem dependencies as the source of truth
+    if (roll.calcItems?.isEmpty() == false) {
+      this.calcItems = roll.calcItems;
+      this.oldCalcItems = roll.oldCalcItems != null ? roll.oldCalcItems : new Map<Id, SObject>();
+    } else if (this.calcItems?.isEmpty() == false) {
+      roll.calcItems = this.calcItems;
+      roll.oldCalcItems = this.oldCalcItems;
+    }
+  }
+
+  private void resetCalcItemData(CalcItemData data) {
+    if (data.items?.isEmpty() == false) {
+      this.calcItems = data.items;
+    }
+    if (data.oldItems?.isEmpty() == false) {
+      this.oldCalcItems = data.oldItems;
+    }
   }
 
   private void getFieldNamesForRollups(List<RollupAsyncProcessor> rollups) {
@@ -660,15 +645,18 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
             rollup.metadata,
             uniqueQueryFieldNames,
             rollup.lookupObj,
-            rollup.oldCalcItems
+            this.oldCalcItems
           )
-          .getParents(rollup.calcItems);
+          .getParents(this.calcItems);
       } else if (rollup.traversal?.getIsFinished() == false) {
         rollup.traversal.recommence();
       }
       return rollup.traversal.getIsFinished() ? rollup.traversal.getParentLookupToRecords() : lookupFieldToCalcItems;
     }
-    for (SObject calcItem : rollup.calcItems) {
+    for (SObject calcItem : this.calcItems) {
+      if (rollup.matchingCalcItemIds.contains(calcItem.Id) == false) {
+        continue;
+      }
       String key = (String) calcItem.get(rollup.lookupFieldOnCalcItem);
       if (lookupFieldToCalcItems.containsKey(key) == false) {
         lookupFieldToCalcItems.put(key, new Rollup.CalcItemBag(new List<SObject>{ calcItem }));
@@ -678,7 +666,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
       // if the lookup key differs from what it was on the old calc item,
       // include that value as well so that we can fix reparented records' rollup values
-      SObject potentialOldCalcItem = rollup.oldCalcItems?.get(calcItem.Id);
+      SObject potentialOldCalcItem = this.oldCalcItems?.get(calcItem.Id);
       if (potentialOldCalcItem != null) {
         String oldKey = (String) potentialOldCalcItem.get(rollup.lookupFieldOnCalcItem);
 
@@ -771,6 +759,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     SObjectType targetType;
     Map<String, Set<String>> queryCountsToLookupIds = new Map<String, Set<String>>();
 
+    Integer totalCountOfRecords = 0;
     for (RollupAsyncProcessor roll : this.rollups) {
       if (targetType == null) {
         targetType = roll.lookupObj;
@@ -778,12 +767,8 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         hasMoreThanOneTarget = true;
       }
 
-      if (String.isNotBlank(roll.metadata?.GrandparentRelationshipFieldPath__c)) {
-        // getting the count for grandparent (or greater) relationships will be handled further
-        // downstream; for our purposes, it isn't useful to try to get all of the records while
-        // we're still in a sync context
-        continue;
-      } else if (roll.calcItems?.isEmpty() != false) {
+      if (roll.queryCount != null) {
+        totalCountOfRecords += roll.queryCount;
         continue;
       }
 
@@ -791,9 +776,19 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         break;
       }
 
+      if (String.isNotBlank(roll.metadata?.GrandparentRelationshipFieldPath__c)) {
+        // getting the count for grandparent (or greater) relationships will be handled further
+        // downstream; for our purposes, it isn't useful to try to get all of the records while
+        // we're still in a sync context
+        continue;
+      } else if (roll.calcItems?.isEmpty() == true) {
+        continue;
+      }
+
       Set<String> uniqueIds = new Set<String>();
 
-      for (SObject calcItem : roll.calcItems) {
+      List<SObject> items = roll.calcItems?.isEmpty() == false ? roll.calcItems : this.calcItems;
+      for (SObject calcItem : items) {
         String lookupKey = (String) calcItem.get(roll.lookupFieldOnCalcItem);
         if (String.isNotBlank(lookupKey)) {
           uniqueIds.add(lookupKey);
@@ -813,7 +808,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       }
     }
 
-    Integer totalCountOfRecords = 0;
     if (hasMoreThanOneTarget == false) {
       for (String countQuery : queryCountsToLookupIds.keySet()) {
         Set<String> objIds = queryCountsToLookupIds.get(countQuery);
@@ -836,7 +830,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   ) {
     Map<String, SObject> recordsToUpdate = new Map<String, SObject>();
     Map<String, List<SObject>> oldLookupItems = new Map<String, List<SObject>>();
-    Set<SObject> unprocessedCalcItems = new Set<SObject>();
+    Set<Id> unprocessedCalcItems = new Set<Id>();
     RollupSObjectUpdater updater = new RollupSObjectUpdater(rollup.opFieldOnLookupObject);
     if (this.fullRecalcProcessor != null) {
       rollup.fullRecalcProcessor = this.fullRecalcProcessor;
@@ -860,7 +854,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         localCalcItems.addAll(bag.additional);
 
         if (hasExceededCurrentRollupLimits(this.rollupControl)) {
-          unprocessedCalcItems.addAll(localCalcItems);
+          unprocessedCalcItems = new Map<Id, SObject>(localCalcItems).keySet();
           lookupItems.remove(index);
           continue;
         }
@@ -885,19 +879,21 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     return recordsToUpdate.values();
   }
 
-  private void deferCalculationsWhenApproachingLimits(RollupAsyncProcessor roll, Set<SObject> unprocessedCalcItems) {
+  private void deferCalculationsWhenApproachingLimits(RollupAsyncProcessor roll, Set<Id> unprocessedCalcItems) {
     // remove the calc items that were successfully processed -
     // they're the ones that aren't in the unprocessed Set
-    for (Integer index = roll.calcItems.size() - 1; index >= 0; index--) {
-      SObject calcItem = roll.calcItems[index];
-      if (unprocessedCalcItems.contains(calcItem) == false) {
-        roll.calcItems.remove(index);
+    List<SObject> mutableItems = this.calcItems.clone();
+    for (Integer index = mutableItems.size() - 1; index >= 0; index--) {
+      SObject calcItem = mutableItems[index];
+      if (unprocessedCalcItems.contains(calcItem.Id) == false) {
+        mutableItems.remove(index);
       }
     }
     // if all of the calc items have been processed, we're golden - no need to proceed
     // otherwise, the newly trimmed-down Rollup will get picked up downstream for
     // reprocessing!
-    if (roll.calcItems.isEmpty() == false) {
+    if (mutableItems.isEmpty() == false) {
+      roll.calcItems = mutableItems;
       this.deferredRollups.add(roll);
     }
   }
@@ -908,8 +904,8 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       if (
         roll.metadata?.IsFullRecordSet__c == true &&
         (roll.eval.matches(calcItem) == false &&
-        (roll.oldCalcItems.containsKey(calcItem.Id) == false ||
-        roll.eval.matches(roll.oldCalcItems.get(calcItem.Id)) == false))
+        (this.oldCalcItems.containsKey(calcItem.Id) == false ||
+        roll.eval.matches(this.oldCalcItems.get(calcItem.Id)) == false))
       ) {
         // technically it should only be possible for a calc item that doesn't match
         // to still exist if it is a Full Record Set operation; this gives people the chance
@@ -918,7 +914,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         continue;
       }
       // Check for reparented records
-      SObject oldCalcItem = roll.oldCalcItems.get(calcItem.Id);
+      SObject oldCalcItem = this.oldCalcItems?.get(calcItem.Id);
 
       if (oldCalcItem == null) {
         continue;
@@ -959,13 +955,13 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   private SObject reassignOldCalcItemIfValueChanged(String lookupId, SObject oldCalcItem, RollupAsyncProcessor rollup) {
-    if (String.isBlank(lookupId)) {
+    if (String.isBlank(lookupId) || this.oldCalcItems == null) {
       return oldCalcItem;
     }
     // truly terrible, but before we pass the old item through the reparenting code path, we need to validate that it's only
     // the lookup field that has changed; otherwise, if the opFieldOnCalcItem has changed too, substitute the item whose value
     // previously corresponded to the parent record
-    for (SObject otherOldCalcItem : rollup.oldCalcItems.values()) {
+    for (SObject otherOldCalcItem : this.oldCalcItems.values()) {
       if (otherOldCalcItem.get(rollup.lookupFieldOnCalcItem) == lookupId) {
         if (otherOldCalcItem.get(rollup.opFieldOnCalcItem) != oldCalcItem.get(rollup.opFieldOnCalcItem)) {
           return otherOldCalcItem;
@@ -988,7 +984,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     );
     rollupCalc.setEvaluator(roll.eval);
     rollupCalc.setCDCUpdate(this.isCDCUpdate);
-    rollupCalc.performRollup(calcItems, roll.oldCalcItems);
+    rollupCalc.performRollup(calcItems, this.oldCalcItems);
     return rollupCalc.getReturnValue();
   }
 
@@ -1011,7 +1007,23 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         String currentOp = getBaseOperationName(roll.op.name());
         String deleteOpName = 'DELETE_' + currentOp;
         Op deleteOp = opNameToOp.get(deleteOpName);
-        RollupAsyncProcessor oldLookupsRollup = new RollupAsyncProcessor(roll, deleteOp, reparentedCalcItems);
+
+        // by default this returns a "batched" (set) of rollups; we
+        // just want the first (and only) inner rollup to perform the pseudo-delete
+        RollupAsyncProcessor oldLookupsRollup = getProcessor(
+            new Set<Id>(),
+            roll.opFieldOnCalcItem,
+            roll.lookupFieldOnCalcItem,
+            roll.lookupFieldOnLookupObject,
+            roll.opFieldOnLookupObject,
+            roll.lookupObj,
+            roll.calcItemType,
+            deleteOp,
+            null,
+            this.invokePoint,
+            this.rollupControl,
+            roll.metadata
+          );
 
         RollupLogger.Instance.log('reparenting operation: ', oldLookupsRollup, LoggingLevel.DEBUG);
         RollupLogger.Instance.log('Reparented item prior to reparenting rollup: ', lookupRecord, LoggingLevel.DEBUG);
@@ -1025,29 +1037,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         }
         RollupLogger.Instance.log('Reparented item after reparenting rollup: ', lookupRecord, LoggingLevel.DEBUG);
       }
-    }
-  }
-
-  private static void doBookkeepingOnCachedItems(
-    RollupAsyncProcessor matchingRollup,
-    RollupAsyncProcessor stackedRollup,
-    Map<String, List<String>> operationToProcessedRecords,
-    SObject calcItem,
-    String rollupKey,
-    Integer index
-  ) {
-    List<String> processedRecords = operationToProcessedRecords.containsKey(rollupKey)
-      ? operationToProcessedRecords.get(rollupKey)
-      : new List<String>{ calcItem.Id };
-    operationToProcessedRecords.put(rollupKey, processedRecords);
-    Map<Id, SObject> idToCalcItem = new Map<Id, SObject>(matchingRollup.calcItems);
-    idToCalcItem.put(calcItem.Id, calcItem);
-    matchingRollup.calcItems.clear();
-    matchingRollup.calcItems.addAll(idToCalcItem.values());
-    stackedRollup.calcItems.remove(index);
-
-    if (stackedRollup.oldCalcItems.isEmpty() == false && stackedRollup.oldCalcItems.containsKey(calcItem.Id) == false) {
-      matchingRollup.oldCalcItems.put(calcItem.Id, stackedRollup.oldCalcItems.get(calcItem.Id));
     }
   }
 }

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -44,6 +44,10 @@ public class RollupFullBatchRecalculator extends RollupAsyncProcessor implements
     RollupLogger.Instance.save();
   }
 
+  protected override String getTypeName() {
+    return 'RollupFullBatchRecalculator';
+  }
+
   protected override void retrieveAdditionalCalcItems(Map<String, Rollup.CalcItemBag> lookupToCalcItems, RollupAsyncProcessor rollup) {
     Map<String, Rollup.CalcItemBag> local = new Map<String, Rollup.CalcItemBag>();
     for (String lookupKey : lookupToCalcItems.keySet()) {

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -28,6 +28,7 @@ public class RollupFullBatchRecalculator extends RollupAsyncProcessor implements
   }
 
   public override void execute(Database.BatchableContext bc, List<SObject> calcItems) {
+    RollupLogger.Instance.log('starting full batch recalc run', this, LoggingLevel.DEBUG);
     /**
      * this batch class is a glorified "for loop" for the calc items, dispatching
      * them to the overall Rollup framework while breaking us out of the query limits

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -86,6 +86,7 @@ public virtual class RollupLogger extends Rollup implements ILogger {
       try {
         loggerInstance = (ILogger) Type.forName(SELF.rollupControl.RollupLoggerName__c).newInstance();
       } catch (Exception ex) {
+        SELF.log('cast to Rollup.ILogger failed with message: ' + ex.getMessage() + ', falling back to default logger', SELF, LoggingLevel.WARN);
         loggerInstance = SELF;
       }
     } else {

--- a/rollup/core/classes/RollupQueryBuilder.cls
+++ b/rollup/core/classes/RollupQueryBuilder.cls
@@ -113,7 +113,7 @@ public without sharing class RollupQueryBuilder {
         optionalWhereClause = optionalWhereClause.replace(whereClause, '').trim();
       }
     } catch (Exception ex) {
-      RollupLogger.Instance.log('exception occurred while building query: ', ex, LoggingLevel.ERROR);
+      RollupLogger.Instance.log('exception occurred while building query: ', ex, LoggingLevel.WARN);
     }
     return optionalWhereClause;
   }

--- a/rollup/tests/RollupStandardIntegrationTests.cls
+++ b/rollup/tests/RollupStandardIntegrationTests.cls
@@ -2,9 +2,10 @@
 private class RollupStandardIntegrationTests {
   @TestSetup
   static void setup() {
+    upsert new RollupSettings__c(IsEnabled__c = true);
+    // gets nulled out at the end of the setup context
     Rollup.defaultControl = new RollupControl__mdt(ShouldAbortRun__c = true);
     insert new Account(Name = 'RollupStandardIntegrationTests');
-    upsert new RollupSettings__c(IsEnabled__c = true);
   }
 
   @isTest
@@ -99,7 +100,8 @@ private class RollupStandardIntegrationTests {
   @isTest
   static void shouldNotFailForTruncatedTextFields() {
     Account acc = [SELECT Id FROM Account];
-    Contact con = new Contact(AccountId = acc.Id, Description = '0'.repeat(256), LastName = 'Truncate', Email = 'rollup@gmail.com');
+    Integer maxAccountNameLength = Account.Name.getDescribe().getLength();
+    Contact con = new Contact(AccountId = acc.Id, Description = '0'.repeat(maxAccountNameLength + 1), LastName = 'Truncate', Email = 'rollup@gmail.com');
     insert con;
 
     Rollup__mdt meta = new Rollup__mdt(
@@ -117,7 +119,7 @@ private class RollupStandardIntegrationTests {
     Test.stopTest();
 
     acc = [SELECT Name FROM Account];
-    System.assertEquals(255, acc.Name.length(), acc.Name);
+    System.assertEquals(maxAccountNameLength, acc.Name.length(), acc.Name);
   }
 
   @isTest
@@ -652,12 +654,8 @@ private class RollupStandardIntegrationTests {
     update cpas;
 
     Test.startTest();
-    List<Rollup.FlowOutput> flowOutputs = Rollup.performRollup(flowInputs);
+    Rollup.performRollup(flowInputs);
     Test.stopTest();
-
-    System.assertEquals(1, flowOutputs.size(), 'Flow outputs were not provided');
-    System.assertEquals('SUCCESS', flowOutputs[0].message);
-    System.assertEquals(true, flowOutputs[0].isSuccess);
 
     acc = [SELECT Id, AnnualRevenue FROM Account WHERE Id = :acc.Id];
     System.assertEquals(1500, acc.AnnualRevenue, 'SUM REFRESH from flow should fully recalc');

--- a/rollup/tests/RollupTests.cls
+++ b/rollup/tests/RollupTests.cls
@@ -3386,13 +3386,11 @@ private class RollupTests {
   /** Re-queueing */
   @isTest
   static void shouldRequeueRollupsWhenQueryLimitsExceeded() {
-    DMLMock mock = loadAccountIdMock(new List<ContactPointAddress>{ new ContactPointAddress(Id = RollupTestUtils.createId(ContactPointAddress.SObjectType), PreferenceRank = 1) });
-    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    Rollup.defaultControl = new RollupControl__mdt(
-      MaxRollupRetries__c = 1,
-      IsRollupLoggingEnabled__c = true,
-      MaxNumberOfQueries__c = 1
+    DMLMock mock = loadAccountIdMock(
+      new List<ContactPointAddress>{ new ContactPointAddress(Id = RollupTestUtils.createId(ContactPointAddress.SObjectType), PreferenceRank = 1) }
     );
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.defaultControl = new RollupControl__mdt(MaxRollupRetries__c = 1, IsRollupLoggingEnabled__c = true, MaxNumberOfQueries__c = 1);
     Rollup.specificControl = new RollupControl__mdt(
       ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.SYNCHRONOUS,
       MaxLookupRowsBeforeBatching__c = 1,

--- a/rollup/tests/RollupTests.cls
+++ b/rollup/tests/RollupTests.cls
@@ -3408,29 +3408,6 @@ private class RollupTests {
     System.assertEquals('Completed', [SELECT Status FROM AsyncApexJob WHERE JobType = 'Queueable' LIMIT 1]?.Status, [SELECT Status, JobType FROM AsyncApexJob]);
   }
 
-  @isTest
-  static void shouldThrowIfDeferralNotPossible() {
-    DMLMock mock = loadAccountIdMock(new List<ContactPointAddress>{ new ContactPointAddress(PreferenceRank = 1) });
-    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    Rollup.defaultControl = new RollupControl__mdt(MaxRollupRetries__c = 0, IsRollupLoggingEnabled__c = true);
-    Rollup.specificControl = new RollupControl__mdt(
-      ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.SYNCHRONOUS,
-      MaxLookupRowsBeforeBatching__c = -1,
-      BatchChunkSize__c = 0
-    );
-
-    try {
-      Test.startTest();
-      Rollup.countFromApex(ContactPointAddress.PreferenceRank, ContactPointAddress.ParentId, Account.Id, Account.AnnualRevenue, Account.SObjectType).runCalc();
-      Test.stopTest();
-      // a throw should occur within startTest()/stopTest() - the assertion below is uncatchable
-      System.assert(false, 'shouldThrowIfDeferralNotPossible should not make it here');
-    } catch (Exception ex) {
-      System.assertEquals(true, ex.getMessage().contains('rollup failed to re-queue for'), ex.getMessage());
-      System.assertNotEquals(true, ex.getMessage().contains('shouldThrowIfDeferralNotPossible should not make it here'));
-    }
-  }
-
   /** Grandparent rollups */
   @isTest
   static void shouldAllowGrandparentRollups() {
@@ -3519,6 +3496,11 @@ private class RollupTests {
     Rollup.DML = mock;
     Rollup.shouldRun = true;
     Rollup.records = [SELECT Id, AboutMe FROM User WHERE Id = :acc.OwnerId];
+    Rollup.defaultControl = new RollupControl__mdt(
+      ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.QUEUEABLE,
+      BatchChunkSize__c = 100,
+      IsRollupLoggingEnabled__c = true
+    );
     Rollup.rollupMetadata = new List<Rollup__mdt>{
       new Rollup__mdt(
         CalcItem__c = 'ContactPointAddress',

--- a/scripts/deploy-sfdx-project.json
+++ b/scripts/deploy-sfdx-project.json
@@ -8,5 +8,5 @@
   ],
   "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "51.0"
+  "sourceApiVersion": "52.0"
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -87,6 +87,6 @@
         "apex-rollup@1.2.35-0": "04t6g000008SguGAAS",
         "apex-rollup@1.2.36-0": "04t6g000008SguaAAC",
         "apex-rollup@1.2.37-0": "04t6g000008SguzAAC",
-        "apex-rollup@1.2.38-0": "04t6g000008SgyDAAS"
+        "apex-rollup@1.2.38-0": "04t6g000008SgySAAS"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -20,7 +20,7 @@
                 }
             ],
             "versionNumber": "0.0.3.0",
-            "versionDescription": "Prevent string overflow on log messages",
+            "versionDescription": "Prevent string overflow on log messages, added ErrorWouldHaveBeenThrown__c field on RollupLog__c",
             "default": false
         },
         {
@@ -51,7 +51,7 @@
         "Apex Rollup - Custom Logger": "0Ho6g000000Gn8ZCAS",
         "Apex Rollup - Custom Logger@0.0.1-0": "04t6g000008SgtwAAC",
         "Apex Rollup - Custom Logger@0.0.2-0": "04t6g000008SgufAAC",
-        "Apex Rollup - Custom Logger@0.0.3-0": "04t6g000008SgxPAAS",
+        "Apex Rollup - Custom Logger@0.0.3-0": "04t6g000008SgyNAAS",
         "Apex Rollup - Nebula Logger": "0Ho6g000000Gn8PCAS",
         "Apex Rollup - Nebula Logger@0.0.1-0": "04t6g000008SgolAAC",
         "Nebula Logger - Unlocked Package@4.5.2-0-plugin-framework-enhancements": "04t5Y0000027FNaQAM",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -87,6 +87,6 @@
         "apex-rollup@1.2.35-0": "04t6g000008SguGAAS",
         "apex-rollup@1.2.36-0": "04t6g000008SguaAAC",
         "apex-rollup@1.2.37-0": "04t6g000008SguzAAC",
-        "apex-rollup@1.2.38-0": "04t6g000008Sgy3AAC"
+        "apex-rollup@1.2.38-0": "04t6g000008SgyDAAS"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,7 +5,7 @@
             "package": "apex-rollup",
             "path": "rollup",
             "versionNumber": "1.2.38.0",
-            "versionDescription": "Including extra code coverage during package version creation",
+            "versionDescription": "Including extra code coverage during package version creation, REFRESH updates",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
                 "path": "extra-tests"
@@ -16,7 +16,7 @@
             "path": "plugins/CustomObjectRollupLogger",
             "dependencies": [
                 {
-                    "package": "apex-rollup@1.2.37-0"
+                    "package": "apex-rollup@1.2.38-0"
                 }
             ],
             "versionNumber": "0.0.3.0",
@@ -87,6 +87,6 @@
         "apex-rollup@1.2.35-0": "04t6g000008SguGAAS",
         "apex-rollup@1.2.36-0": "04t6g000008SguaAAC",
         "apex-rollup@1.2.37-0": "04t6g000008SguzAAC",
-        "apex-rollup@1.2.38-0": "04t6g000008SgvxAAC"
+        "apex-rollup@1.2.38-0": "04t6g000008Sgy3AAC"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -19,8 +19,8 @@
                     "package": "apex-rollup@1.2.37-0"
                 }
             ],
-            "versionNumber": "0.0.2.0",
-            "versionDescription": "Introducing basic logging plugin",
+            "versionNumber": "0.0.3.0",
+            "versionDescription": "Prevent string overflow on log messages",
             "default": false
         },
         {
@@ -28,7 +28,7 @@
             "path": "plugins/NebulaLogger",
             "dependencies": [
                 {
-                    "package": "apex-rollup@1.2.37-0"
+                    "package": "apex-rollup@1.2.38-0"
                 },
                 {
                     "package": "Nebula Logger - Unlocked Package@4.5.2-0-plugin-framework-enhancements"
@@ -51,6 +51,7 @@
         "Apex Rollup - Custom Logger": "0Ho6g000000Gn8ZCAS",
         "Apex Rollup - Custom Logger@0.0.1-0": "04t6g000008SgtwAAC",
         "Apex Rollup - Custom Logger@0.0.2-0": "04t6g000008SgufAAC",
+        "Apex Rollup - Custom Logger@0.0.3-0": "04t6g000008SgxPAAS",
         "Apex Rollup - Nebula Logger": "0Ho6g000000Gn8PCAS",
         "Apex Rollup - Nebula Logger@0.0.1-0": "04t6g000008SgolAAC",
         "Nebula Logger - Unlocked Package@4.5.2-0-plugin-framework-enhancements": "04t5Y0000027FNaQAM",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,9 +4,12 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionNumber": "1.2.37.0",
-            "versionDescription": "Fixing deferred rollup logic and adding more logging surrounding deferrals",
-            "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest"
+            "versionNumber": "1.2.38.0",
+            "versionDescription": "Including extra code coverage during package version creation",
+            "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
+            "unpackagedMetadata": {
+                "path": "extra-tests"
+            }
         },
         {
             "package": "Apex Rollup - Custom Logger",
@@ -36,7 +39,8 @@
             "default": false
         },
         {
-            "path": "extra-tests"
+            "path": "extra-tests",
+            "default": false
         }
     ],
     "namespace": "",
@@ -81,6 +85,7 @@
         "apex-rollup@1.2.34-0": "04t6g000008SglrAAC",
         "apex-rollup@1.2.35-0": "04t6g000008SguGAAS",
         "apex-rollup@1.2.36-0": "04t6g000008SguaAAC",
-        "apex-rollup@1.2.37-0": "04t6g000008SguzAAC"
+        "apex-rollup@1.2.37-0": "04t6g000008SguzAAC",
+        "apex-rollup@1.2.38-0": "04t6g000008SgvxAAC"
     }
 }


### PR DESCRIPTION
* Fixes #146 by going further down the rollup orchestrator/conductor path - the 'outer' rollup (previously referred to as the batchRollup - deprecating that term so that it's clear when a rollup is batched versus queued versus run sync) now 'conducts' the inner rollups by storing the calcItems and oldCalcItems map. This should drastically reduce memory consumption by basically eliminating how many List<SObject> copies are being passed around in memory; whereas previously, the more CMDT/Rollup invocations you used, the more Lists were stored, now the outer rollup condenses that information into one place.
* Avoids a possible string overflow exception when using the Custom Rollup Logger
* Restores the packaging script to its former glory, including a more consistent update to the `README` when the package version is updated!