### PR TITLE
Added multi-currency support

### DIFF
--- a/README.md
+++ b/README.md
@@ -948,7 +948,7 @@ You can use the included `Rollup Logger Plugin Parameter` CMDT record `Logging D
 
 ### Multi-Currency Orgs
 
-Untested. I would expect that MAX/SUM/MIN/AVERAGE operations would have undefined behavior (or, rather, incorrect conversions) if mixed currencies are present on the children items. This would be a good first issue for somebody looking to contribute!
+As of [v1.2.43](https://github.com/jamessimone/apex-rollup/releases/tag/v1.2.43), multi-currency orgs are now supported. Similar to how Salesforce's roll-up summary fields handle multi-currency, `Rollup` automatically converts currency values on child records to the parent record's currency when calculating the rollup value.  Currently, MIN, MAX and SUM operations are supported. // TODO - AVERAGE, FIRST and LAST are WIP
 
 ## Commit History
 

--- a/README.md
+++ b/README.md
@@ -948,7 +948,7 @@ You can use the included `Rollup Logger Plugin Parameter` CMDT record `Logging D
 
 ### Multi-Currency Orgs
 
-As of [v1.2.43](https://github.com/jamessimone/apex-rollup/releases/tag/v1.2.43), multi-currency orgs are now supported. Similar to how Salesforce's roll-up summary fields handle multi-currency, `Rollup` automatically converts currency values on child records to the parent record's currency when calculating the rollup value.  Currently, MIN, MAX and SUM operations are supported. // TODO - AVERAGE, FIRST and LAST are WIP
+As of [v1.2.43](https://github.com/jamessimone/apex-rollup/releases/tag/v1.2.43), multi-currency orgs are now supported for the operations: MIN, MAX, SUM, AVERAGE, FIRST and LAST. `Rollup` automatically converts currency values on child records to the parent record's currency when calculating the rollup value, similar to how Salesforce's roll-up summary fields handle multi-currency,.
 
 ## Commit History
 

--- a/config/data/CurrencyTypes.json
+++ b/config/data/CurrencyTypes.json
@@ -3,6 +3,17 @@
     {
       "attributes": {
         "type": "CurrencyType",
+        "referenceId": "ref0"
+      },
+      "IsoCode": "USD",
+      "DecimalPlaces": 2,
+      "ConversionRate": 1,
+      "IsActive":true,
+      "IsCorporate": true
+    },
+    {
+      "attributes": {
+        "type": "CurrencyType",
         "referenceId": "ref1"
       },
       "IsoCode": "EUR",

--- a/config/data/CurrencyTypes.json
+++ b/config/data/CurrencyTypes.json
@@ -1,0 +1,26 @@
+{
+  "records": [
+    {
+      "attributes": {
+        "type": "CurrencyType",
+        "referenceId": "ref1"
+      },
+      "IsoCode": "EUR",
+      "DecimalPlaces": 2,
+      "ConversionRate": 1.5,
+      "IsActive":true,
+      "IsCorporate": false
+    },
+    {
+      "attributes": {
+        "type": "CurrencyType",
+        "referenceId": "ref2"
+      },
+      "IsoCode": "JPY",
+      "DecimalPlaces": 4,
+      "ConversionRate": 0.0095,
+      "IsActive":true,
+      "IsCorporate": false
+    }
+  ]
+}

--- a/config/data/CurrencyTypes.json
+++ b/config/data/CurrencyTypes.json
@@ -7,7 +7,7 @@
       },
       "IsoCode": "EUR",
       "DecimalPlaces": 2,
-      "ConversionRate": 1.5,
+      "ConversionRate": 1.37,
       "IsActive":true,
       "IsCorporate": false
     },

--- a/config/data/CurrencyTypes.json
+++ b/config/data/CurrencyTypes.json
@@ -7,7 +7,7 @@
       },
       "IsoCode": "EUR",
       "DecimalPlaces": 2,
-      "ConversionRate": 1.37,
+      "ConversionRate": 0.85,
       "IsActive":true,
       "IsCorporate": false
     },
@@ -18,7 +18,7 @@
       },
       "IsoCode": "JPY",
       "DecimalPlaces": 4,
-      "ConversionRate": 0.0095,
+      "ConversionRate": 109.83,
       "IsActive":true,
       "IsCorporate": false
     }

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -3,6 +3,6 @@
   "edition": "Developer",
   "country": "US",
   "language": "en_US",
-  "features": [],
+  "features": ["MultiCurrency"],
   "hasSampleData": true
 }

--- a/extra-tests/classes/InvocableDrivenTests.cls
+++ b/extra-tests/classes/InvocableDrivenTests.cls
@@ -3,7 +3,7 @@ private class InvocableDrivenTests {
   @TestSetup
   static void setup() {
     upsert new RollupSettings__c(IsEnabled__c = true);
-    Account acc = new Account(Name = 'InvocableDrivenRollupTests');
+    Account acc = new Account(Name = InvocableDrivenTests.class.getName());
     insert acc;
   }
 

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -2,7 +2,6 @@
 private class RollupIntegrationTests {
   private static final Map<String, CurrencyType> CURRENCY_TYPES = loadCurrencyTypes();
 
-  // "Integration," in the sense that these include custom fields / objects that shouldn't be installed
   @TestSetup
   static void setup() {
     Account acc = new Account(Name = RollupIntegrationTests.class.getName());
@@ -1038,6 +1037,520 @@ private class RollupIntegrationTests {
     parent = [SELECT Id, Description, AnnualRevenue FROM Account WHERE Id = :parent.Id];
     System.assertEquals(2, parent.AnnualRevenue, 'Merge should have triggered rollup');
     System.assertEquals(rollupChildren[0].Name + ', ' + rollupChildren[1].Name, parent.Description, 'Second rollup should also have run');
+  }
+
+  @IsTest
+  static void shouldNotCrashForFalseMergePositive() {
+    Account acc = [SELECT Id, Name, Description, AnnualRevenue FROM Account];
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        RollupFieldOnCalcItem__c = 'PreferenceRank',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'MAX',
+        CalcItemWhereClause__c = 'Parent.Name = \'' + acc.Name + '\''
+      ),
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        RollupFieldOnCalcItem__c = 'Name',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'Description',
+        RollupOperation__c = 'CONCAT'
+      ),
+      // should be filtered out
+      new Rollup__mdt(
+        CalcItem__c = 'Account',
+        RollupFieldOnCalcItem__c = 'Name',
+        LookupObject__c = 'User',
+        LookupFieldOnCalcItem__c = 'OwnerId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'Username',
+        RollupOperation__c = 'CONCAT'
+      )
+    };
+
+    Test.startTest();
+    delete acc;
+    Test.stopTest();
+
+    System.assert(true, 'Should make it here');
+  }
+
+  @IsTest
+  static void shouldConcatDistinctOnUpdateEvenIfNewItemDoesNotMatch() {
+    Account acc = [SELECT Id, AccountNumber FROM Account];
+    acc.AccountNumber = 'test update';
+    update acc;
+
+    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = acc.AccountNumber);
+    insert cpa;
+
+    Rollup.records = new List<ContactPointAddress>{ cpa };
+    Rollup.oldRecordsMap = new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(Id = cpa.Id, Name = 'something else') };
+    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
+    Rollup.shouldRun = true;
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Name',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AccountNumber',
+        RollupOperation__c = 'CONCAT_DISTINCT',
+        CalcItem__c = 'ContactPointAddress',
+        CalcItemWhereClause__c = 'Name != \'' + acc.AccountNumber + '\''
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Account updatedAcc = [SELECT AccountNumber FROM Account];
+    System.assertEquals(null, updatedAcc.AccountNumber, 'CONCAT_DISTINCT AFTER_UPDATE should clear when updated item does not match and no other items');
+  }
+
+  @IsTest
+  static void shouldProperlyQueryNotLikeCountDistinct() {
+    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
+
+    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT not like');
+    insert new List<ContactPointAddress>{ cpa, new ContactPointAddress(ParentId = acc.Id, Name = 'Some other thing') };
+
+    Rollup.records = new List<ContactPointAddress>{ cpa };
+    Rollup.oldRecordsMap = new Map<Id, SObject>();
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.shouldRun = true;
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Id',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'COUNT_DISTINCT',
+        CalcItem__c = 'ContactPointAddress',
+        CalcItemWhereClause__c = 'Name NOT LIKE \'' + cpa.Name.substring(0, 6) + '%\''
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(1, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT should work with NOT LIKE');
+  }
+
+  @IsTest
+  static void shouldNotIncludeNullForCountDistinct() {
+    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
+
+    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT null PreferenceRank');
+    insert cpa;
+
+    Rollup.records = new List<ContactPointAddress>{ cpa };
+    Rollup.oldRecordsMap = new Map<Id, SObject>();
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.shouldRun = true;
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'PreferenceRank',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'COUNT_DISTINCT',
+        CalcItem__c = 'ContactPointAddress'
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(null, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT should ignore nulls');
+
+    Rollup.defaultControl = new RollupControl__mdt(ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.SYNCHRONOUS);
+    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
+    Rollup.records = new List<ContactPointAddress>{ cpa };
+    Rollup.oldRecordsMap = new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(PreferenceRank = 10) };
+    Rollup.runFromTrigger();
+
+    updatedAcc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(null, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT on update should ignore nulls');
+  }
+
+  @IsTest
+  static void shouldNotIncludePriorValueForCountDistinctId() {
+    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
+    acc.AnnualRevenue = 5;
+    update acc;
+
+    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT update');
+    insert new List<ContactPointAddress>{ cpa, new ContactPointAddress(ParentId = acc.Id, Name = 'Some other thing') };
+
+    Rollup.records = new List<ContactPointAddress>{ cpa };
+    Rollup.oldRecordsMap = new Map<Id, SObject>();
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.shouldRun = true;
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Id',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'COUNT_DISTINCT',
+        CalcItem__c = 'ContactPointAddress'
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(2, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT AFTER_INSERT should not overcount items');
+  }
+
+  @IsTest
+  static void shouldNotDoubleCountOldParentValueOnUpdate() {
+    Account acc = [SELECT Id, Name FROM Account];
+    acc.AnnualRevenue = 1;
+    update acc;
+
+    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'something else');
+    insert cpa;
+
+    Rollup.records = new List<ContactPointAddress>{ cpa };
+    Rollup.oldRecordsMap = new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(Id = cpa.Id, Name = acc.Name) };
+    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
+    Rollup.shouldRun = true;
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Name',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'COUNT_DISTINCT',
+        CalcItem__c = 'ContactPointAddress'
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(1, updatedAcc.AnnualRevenue, 'CONCAT_DISTINCT AFTER_UPDATE should clear when updated item does not match and no other items');
+  }
+
+  @IsTest
+  static void shouldClearParentValueIfNothingMatchesCountDistinct() {
+    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
+    acc.AnnualRevenue = 5;
+    update acc;
+
+    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT update');
+    insert new List<ContactPointAddress>{ cpa, new ContactPointAddress(ParentId = acc.Id, Name = 'Some other thing') };
+
+    Rollup.records = new List<ContactPointAddress>{ cpa };
+    Rollup.oldRecordsMap = new Map<Id, SObject>();
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.shouldRun = true;
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Name',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'COUNT_DISTINCT',
+        CalcItem__c = 'ContactPointAddress'
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(2, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT AFTER_INSERT should not overcount items');
+  }
+
+  @IsTest
+  static void shouldCountDistinctOnUpdateEvenIfNewItemDoesNotMatch() {
+    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
+    acc.AnnualRevenue = 1;
+    update acc;
+
+    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT update', PreferenceRank = 0);
+    insert cpa;
+
+    Rollup.records = new List<ContactPointAddress>{ cpa };
+    Rollup.oldRecordsMap = new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(Id = cpa.Id, PreferenceRank = 1) };
+    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
+    Rollup.shouldRun = true;
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Name',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'COUNT_DISTINCT',
+        CalcItem__c = 'ContactPointAddress',
+        CalcItemWhereClause__c = 'PreferenceRank > 0'
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(0, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT AFTER_UPDATE should clear when updated item does not match and no other items');
+  }
+
+  @IsTest
+  static void shouldRunSyncWhenFlaggedOnRollupLimit() {
+    Account acc = [SELECT Id FROM Account];
+
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
+      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 1, Name = 'oneCpa'),
+      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 1, Name = 'twoCpa')
+    };
+    insert cpas;
+
+    Rollup.records = cpas;
+    Rollup.shouldRun = true;
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = 'Synchronous Rollup');
+
+    // specifically do NOT wrap in Test.startTest() / Test.stopTest() - we need to ensure this happened synchronously
+    Rollup.countFromApex(ContactPointAddress.PreferenceRank, ContactPointAddress.ParentId, Account.Id, Account.AnnualRevenue, Account.SObjectType).runCalc();
+
+    acc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(2, acc.AnnualRevenue, 'COUNT AFTER_INSERT should add when field is populated sync calc');
+  }
+
+  @IsTest
+  static void shouldPartiallyDeferRollupCalculationWhenOverLimits() {
+    Rollup.specificControl = new RollupControl__mdt(ShouldAbortRun__c = true);
+    Account acc = [SELECT Id, OwnerId FROM Account];
+    Account secondParent = new Account(Name = 'Second parent');
+    insert secondParent;
+
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
+      new ContactPointAddress(ParentId = acc.Id, Name = 'One', PreferenceRank = 1),
+      new ContactPointAddress(ParentId = secondParent.Id, Name = 'Two', PreferenceRank = 1)
+    };
+    insert cpas;
+
+    Rollup.defaultControl = new RollupControl__mdt(BatchChunkSize__c = 1, MaxRollupRetries__c = 1, MaxNumberOfQueries__c = 2, IsRollupLoggingEnabled__c = true);
+    // start as synchronous rollup to allow for one deferral
+    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = 'Synchronous Rollup');
+
+    Rollup.shouldRun = true;
+    Rollup.records = cpas;
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        RollupFieldOnCalcItem__c = 'PreferenceRank',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupObject__c = 'Account',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        // use one of the full recalc operations - one SOQL per parent object will get us to defer
+        // between lookup items
+        RollupOperation__c = 'AVERAGE'
+      )
+    };
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    // validate that queueable ran in addition to sync job
+    System.assertEquals('Completed', [SELECT Status FROM AsyncApexJob WHERE JobType = 'Queueable' LIMIT 1]?.Status);
+    List<Account> updatedAccounts = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(2, updatedAccounts.size(), 'Both parent items should have been updated!');
+
+    for (Account updatedAcc : updatedAccounts) {
+      System.assertEquals(1, updatedAcc.AnnualRevenue, 'Average annual revenue should have been set for both records!');
+    }
+  }
+
+  @IsTest
+  static void shouldRunDirectlyFromApex() {
+    Account acc = [SELECT Id FROM Account];
+
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
+      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 5),
+      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 10)
+    };
+
+    Rollup.records = cpas;
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'PreferenceRank',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'SUM',
+        CalcItem__c = 'ContactPointAddress'
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromApex(cpas, TriggerOperation.AFTER_INSERT);
+    Test.stopTest();
+
+    acc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(15, acc.AnnualRevenue);
+  }
+
+  @IsTest
+  static void shouldDeferUpdateWhenMaxParentRowsLessThanCurrentUpdateRows() {
+    Account acc = [SELECT Id FROM Account];
+    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 50, Name = 'MaxParentRows');
+    insert cpa;
+
+    Rollup.records = new List<ContactPointAddress>{ cpa };
+    Rollup.shouldRun = true;
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    RollupAsyncProcessor.shouldRunAsBatch = true;
+    Rollup.defaultControl = new RollupControl__mdt(MaxParentRowsUpdatedAtOnce__c = 0, BatchChunkSize__c = 1, IsRollupLoggingEnabled__c = true);
+
+    Test.startTest();
+    Rollup.sumFromApex(ContactPointAddress.PreferenceRank, ContactPointAddress.ParentId, Account.Id, Account.AnnualRevenue, Account.SObjectType).runCalc();
+    Test.stopTest();
+
+    acc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(50, acc.AnnualRevenue, 'Account should have been updated since the mock is not used async');
+  }
+
+  @IsTest
+  static void shouldThrowExceptionWhenTryingToOperateOnDisallowedFieldTypes() {
+    Account acc = [SELECT Id FROM Account];
+    Rollup.records = new List<Task>{ new Task(ActivityDate = System.today(), WhatId = acc.Id) };
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.shouldRun = true;
+
+    Exception ex;
+    try {
+      Test.startTest();
+      Rollup.maxFromApex(Task.ActivityDate, Task.WhatId, Account.Id, Account.BillingAddress, Account.SObjectType).runCalc();
+      Test.stopTest();
+    } catch (Exception e) {
+      ex = e;
+    }
+
+    System.assertNotEquals(null, ex);
+    System.assertEquals('Field: BillingAddress of type: ADDRESS specified invalid for rollup operation', ex.getMessage());
+  }
+
+  /** Invocable integration tests */
+
+  @IsTest
+  static void shouldTryToUpsertFromFlow() {
+    Account acc = [SELECT Id FROM Account];
+
+    ContactPointAddress cpa = new ContactPointAddress(PreferenceRank = 500, ParentId = acc.Id, Name = 'Upsert Flow Test');
+    insert cpa; // aping an after-insert action in Flow
+
+    List<ContactPointAddress> cpas = [SELECT Id, ParentId, CreatedDate, LastModifiedDate, PreferenceRank FROM ContactPointAddress];
+
+    List<Rollup.FlowInput> flowInputs = RollupTestUtils.prepareFlowTest(cpas, 'UPSERT', 'SUM');
+    flowInputs[0].oldRecordsToRollup = new List<ContactPointAddress>{ null }; // sad but true - this is what flow passes for {!$Record__Prior} on upsert
+
+    Test.startTest();
+    List<Rollup.FlowOutput> flowOutputs = Rollup.performRollup(flowInputs);
+    Test.stopTest();
+
+    System.assertEquals(1, flowOutputs.size(), 'Flow outputs were not provided');
+    System.assertEquals('SUCCESS', flowOutputs[0].message);
+    System.assertEquals(true, flowOutputs[0].isSuccess);
+
+    Account updatedAcc = [SELECT Id, AnnualRevenue FROM Account];
+    System.assertEquals(cpas[0].PreferenceRank, updatedAcc.AnnualRevenue, 'pseudo-upsert from flow should act like insert for PreferenceRank');
+  }
+
+  @IsTest
+  static void shouldFilterNonMatchingRollupsOutOfBatch() {
+    Contact con = new Contact(FirstName = 'Something', LastName = 'Required');
+    insert con;
+    RollupAsyncProcessor batchProcessor = new RollupAsyncProcessor(
+      new Set<Id>{ con.Id },
+      Contact.FirstName,
+      Contact.Id,
+      Contact.Id,
+      Contact.FirstName,
+      Campaign.SObjectType,
+      Contact.SObjectType,
+      Rollup.Op.CONCAT,
+      null,
+      Rollup.InvocationPoint.FROM_APEX,
+      RollupControl__mdt.getInstance('Org_Defaults'),
+      new Rollup__mdt(
+        CalcItem__c = 'Contact',
+        RollupFieldOnCalcItem__c = 'FirstName',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupObject__c = 'Campaign',
+        RollupFieldOnLookupObject__c = 'FirstName',
+        LookupFieldOnLookupObject__c = 'Id'
+      )
+    );
+    RollupAsyncProcessor conductor = new RollupAsyncProcessor(Rollup.InvocationPoint.FROM_APEX, new List<Contact>{ con }, new Map<Id, SObject>());
+    conductor.rollups.add(batchProcessor);
+    Test.startTest();
+    Database.executeBatch(conductor);
+    Test.stopTest();
+
+    System.assert(true, 'Should make it here');
+  }
+
+  /** Schedulable tests */
+  @IsTest
+  static void shouldThrowExceptionForBadQuery() {
+    // it's a date field - you tell ME why this query is invalid!
+    String veryBadQuery = 'SELECT MAX(ActivityDate) FROM Task';
+
+    Exception ex;
+    try {
+      Rollup.schedule('Test bad query', '0 0 0 0 0', veryBadQuery, 'Account', null);
+    } catch (Exception e) {
+      ex = e;
+    }
+
+    System.assertNotEquals(null, ex);
+  }
+
+  @IsTest
+  static void shouldScheduleSuccessfullyForGoodQuery() {
+    String goodQuery = 'SELECT Id, Name FROM ContactPointAddress WHERE CreatedDate > YESTERDAY';
+
+    String jobId = Rollup.schedule('Test good query' + System.now(), '0 0 0 * * ?', goodQuery, 'ContactPointAddress', null);
+
+    System.assertNotEquals(null, jobId);
   }
 
   private static Map<String, CurrencyType> loadCurrencyTypes() {

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -381,7 +381,7 @@ private class RollupIntegrationTests {
 
     Rollup.rollupMetadata = new List<Rollup__mdt>{
       new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'CurrencyIsoCode',
+        RollupFieldOnCalcItem__c = 'Id',
         LookupObject__c = 'Account',
         LookupFieldOnCalcItem__c = 'AccountId',
         LookupFieldOnLookupObject__c = 'Id',
@@ -400,18 +400,18 @@ private class RollupIntegrationTests {
     Test.stopTest();
 
     Decimal firstAmount;
-    String firstOpportunityCurrencyIsoCode;
+    Id firstOpportunityId;
     List<Opportunity> opportunities = [SELECT Id, convertCurrency(Amount) ConvertedAmount, CurrencyIsoCode FROM Opportunity];
     for (Opportunity opp : opportunities) {
       Decimal oppConvertedAmount = (Decimal) opp.get('ConvertedAmount');
       if (firstAmount == null || oppConvertedAmount < firstAmount) {
         firstAmount = oppConvertedAmount;
-        firstOpportunityCurrencyIsoCode = opp.CurrencyIsoCode;
+        firstOpportunityId = opp.Id;
       }
     }
 
     acc = [SELECT Id, Name FROM Account];
-    System.assertEquals(firstOpportunityCurrencyIsoCode, acc.Name, 'Should have taken first based on multi-currency Amount! Records: ' + opportunities);
+    System.assertEquals(firstOpportunityId, acc.Name, 'Should have taken first based on multi-currency Amount! Records: ' + opportunities);
   }
 
   @isTest
@@ -434,7 +434,7 @@ private class RollupIntegrationTests {
 
     Rollup.rollupMetadata = new List<Rollup__mdt>{
       new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'CurrencyIsoCode',
+        RollupFieldOnCalcItem__c = 'Id',
         LookupObject__c = 'Account',
         LookupFieldOnCalcItem__c = 'AccountId',
         LookupFieldOnLookupObject__c = 'Id',
@@ -453,18 +453,18 @@ private class RollupIntegrationTests {
     Test.stopTest();
 
     Decimal lastAmount;
-    String lastOpportunityCurrencyIsoCode;
+    Id lastOpportunityId;
     List<Opportunity> opportunities = [SELECT Id, convertCurrency(Amount) ConvertedAmount, CurrencyIsoCode FROM Opportunity];
     for (Opportunity opp : opportunities) {
       Decimal oppConvertedAmount = (Decimal) opp.get('ConvertedAmount');
       if (lastAmount == null || oppConvertedAmount > lastAmount) {
         lastAmount = oppConvertedAmount;
-        lastOpportunityCurrencyIsoCode = opp.CurrencyIsoCode;
+        lastOpportunityId = opp.Id;
       }
     }
 
     acc = [SELECT Id, Name FROM Account];
-    System.assertEquals(lastOpportunityCurrencyIsoCode, acc.Name, 'Should have taken last based on multi-currency Amount! Records: ' + opportunities);
+    System.assertEquals(lastOpportunityId, acc.Name, 'Should have taken last based on multi-currency Amount! Records: ' + opportunities);
   }
 
   @isTest

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -1,5 +1,8 @@
 @IsTest
 private class RollupIntegrationTests {
+  private static final Map<String, CurrencyType> CURRENCY_TYPES = loadCurrencyTypes();
+
+  // "Integration," in the sense that these include custom fields / objects that shouldn't be installed
   @TestSetup
   static void setup() {
     Account acc = new Account(Name = 'RollupIntegrationTests');
@@ -157,7 +160,193 @@ private class RollupIntegrationTests {
     System.assertEquals(45 / 3, updatedParent.Engagement_Rollup__c, 'Average should be calculated based off of matching items');
   }
 
-  @IsTest
+  @isTest
+  static void shouldCorrectlyRollupMaxForMultiCurrency() {
+    Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
+    System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
+    System.assertEquals('USD', acc.CurrencyIsoCode, 'Test has started under the wrong conditions!');
+    acc.CurrencyIsoCode = 'EUR';
+    update acc;
+
+    Opportunity usdOpp = [
+      SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountIdText__c, AccountId
+      FROM Opportunity
+      WHERE CurrencyIsoCode = 'USD'
+      LIMIT 1
+    ];
+
+    Opportunity eurOpp = usdOpp.clone(false, true);
+    eurOpp.CurrencyIsoCode = 'EUR';
+    Opportunity jpyOpp = eurOpp.clone(false, true);
+    jpyOpp.CurrencyIsoCode = 'JPY';
+    insert new List<Opportunity>{ eurOpp, jpyOpp };
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Amount',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'SUM',
+        IsFullRecordSet__c = true,
+        CalcItem__c = 'Opportunity'
+      )
+    };
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.records = new List<Opportunity>{ usdOpp, eurOpp, jpyOpp };
+    Rollup.shouldRun = true;
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Decimal expectedMaxAmount;
+    for (Opportunity opp : [SELECT convertCurrency(Amount) ConvertedAmount FROM Opportunity WHERE Id IN :Rollup.records]) {
+      Decimal oppConvertedAmount = (Decimal) opp.get('ConvertedAmount');
+      if (expectedMaxAmount == null || oppConvertedAmount > expectedMaxAmount) {
+        expectedMaxAmount = oppConvertedAmount;
+      }
+    }
+    expectedMaxAmount *= CURRENCY_TYPES.get(acc.CurrencyIsoCode).ConversionRate;
+
+    acc = [SELECT Id, CurrencyIsoCode, AnnualRevenue, MaxAmountRollupSummary__c FROM Account];
+    System.assertEquals(
+      expectedMaxAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      acc.MaxAmountRollupSummary__c.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      'Calculated TotalRevenue and rollup-summary field MaxAmountRollupSummary__c should match!'
+    );
+    System.assertEquals(
+      expectedMaxAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      'Multi-currency MAX rollup not calculated correctly!'
+    );
+  }
+
+  @isTest
+  static void shouldCorrectlyRollupMinForMultiCurrency() {
+    Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
+    System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
+    System.assertEquals('USD', acc.CurrencyIsoCode, 'Test has started under the wrong conditions!');
+    acc.CurrencyIsoCode = 'EUR';
+    update acc;
+
+    Opportunity usdOpp = [
+      SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountIdText__c, AccountId
+      FROM Opportunity
+      WHERE CurrencyIsoCode = 'USD'
+      LIMIT 1
+    ];
+
+    Opportunity eurOpp = usdOpp.clone(false, true);
+    eurOpp.CurrencyIsoCode = 'EUR';
+    Opportunity jpyOpp = eurOpp.clone(false, true);
+    jpyOpp.CurrencyIsoCode = 'JPY';
+    insert new List<Opportunity>{ eurOpp, jpyOpp };
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Amount',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'SUM',
+        IsFullRecordSet__c = true,
+        CalcItem__c = 'Opportunity'
+      )
+    };
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.records = new List<Opportunity>{ usdOpp, eurOpp, jpyOpp };
+    Rollup.shouldRun = true;
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Decimal expectedMinAmount;
+    for (Opportunity opp : [SELECT convertCurrency(Amount) ConvertedAmount FROM Opportunity WHERE Id IN :Rollup.records]) {
+      Decimal oppConvertedAmount = (Decimal) opp.get('ConvertedAmount');
+      if (expectedMinAmount == null || oppConvertedAmount < expectedMinAmount) {
+        expectedMinAmount = oppConvertedAmount;
+      }
+    }
+    expectedMinAmount *= CURRENCY_TYPES.get(acc.CurrencyIsoCode).ConversionRate;
+
+    acc = [SELECT Id, CurrencyIsoCode, AnnualRevenue, MinAmountRollupSummary__c FROM Account];
+    System.assertEquals(
+      expectedMinAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      acc.MinAmountRollupSummary__c.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      'Calculated TotalRevenue and rollup-summary field MinAmountRollupSummary__c should match!'
+    );
+    System.assertEquals(
+      expectedMinAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      'Multi-currency MIN rollup not calculated correctly!'
+    );
+  }
+
+  @isTest
+  static void shouldCorrectlyRollupSumForMultiCurrency() {
+    Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
+    System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
+    System.assertEquals('USD', acc.CurrencyIsoCode, 'Test has started under the wrong conditions!');
+    acc.CurrencyIsoCode = 'EUR';
+    update acc;
+
+    Opportunity usdOpp = [
+      SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountIdText__c, AccountId
+      FROM Opportunity
+      WHERE CurrencyIsoCode = 'USD'
+      LIMIT 1
+    ];
+
+    Opportunity eurOpp = usdOpp.clone(false, true);
+    eurOpp.CurrencyIsoCode = 'EUR';
+    Opportunity jpyOpp = eurOpp.clone(false, true);
+    jpyOpp.CurrencyIsoCode = 'JPY';
+    insert new List<Opportunity>{ eurOpp, jpyOpp };
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Amount',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'SUM',
+        IsFullRecordSet__c = true,
+        CalcItem__c = 'Opportunity'
+      )
+    };
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.records = new List<Opportunity>{ usdOpp, eurOpp, jpyOpp };
+    Rollup.shouldRun = true;
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Decimal expectedSumAmount = 0;
+    for (Opportunity opp : [SELECT convertCurrency(Amount) ConvertedAmount FROM Opportunity WHERE Id IN :Rollup.records]) {
+      expectedSumAmount += (Decimal) opp.get('ConvertedAmount');
+    }
+    expectedSumAmount *= CURRENCY_TYPES.get(acc.CurrencyIsoCode).ConversionRate;
+
+    acc = [SELECT Id, CurrencyIsoCode, AnnualRevenue, SumAmountRollupSummary__c FROM Account];
+    System.assertEquals(
+      expectedSumAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      acc.SumAmountRollupSummary__c.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      'Calculated TotalRevenue and rollup-summary field SumAmountRollupSummary__c should match!'
+    );
+    System.assertEquals(
+      expectedSumAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      'Multi-currency SUM rollup not calculated correctly!'
+    );
+  }
+
+  @isTest
   static void shouldSupportCustomObjectsWhenRollupTriggeredFromParent() {
     ParentApplication__c parentApp = new ParentApplication__c(Name = 'Custom Object Parent App');
     insert parentApp;
@@ -728,517 +917,11 @@ private class RollupIntegrationTests {
     System.assertEquals(rollupChildren[0].Name + ', ' + rollupChildren[1].Name, parent.Description, 'Second rollup should also have run');
   }
 
-  @IsTest
-  static void shouldNotCrashForFalseMergePositive() {
-    Account acc = [SELECT Id, Name, Description, AnnualRevenue FROM Account];
-
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        CalcItem__c = 'ContactPointAddress',
-        RollupFieldOnCalcItem__c = 'PreferenceRank',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'MAX',
-        CalcItemWhereClause__c = 'Parent.Name = \'' + acc.Name + '\''
-      ),
-      new Rollup__mdt(
-        CalcItem__c = 'ContactPointAddress',
-        RollupFieldOnCalcItem__c = 'Name',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'Description',
-        RollupOperation__c = 'CONCAT'
-      ),
-      // should be filtered out
-      new Rollup__mdt(
-        CalcItem__c = 'Account',
-        RollupFieldOnCalcItem__c = 'Name',
-        LookupObject__c = 'User',
-        LookupFieldOnCalcItem__c = 'OwnerId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'Username',
-        RollupOperation__c = 'CONCAT'
-      )
-    };
-
-    Test.startTest();
-    delete acc;
-    Test.stopTest();
-
-    System.assert(true, 'Should make it here');
-  }
-
-  @IsTest
-  static void shouldConcatDistinctOnUpdateEvenIfNewItemDoesNotMatch() {
-    Account acc = [SELECT Id, AccountNumber FROM Account];
-    acc.AccountNumber = 'test update';
-    update acc;
-
-    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = acc.AccountNumber);
-    insert cpa;
-
-    Rollup.records = new List<ContactPointAddress>{ cpa };
-    Rollup.oldRecordsMap = new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(Id = cpa.Id, Name = 'something else') };
-    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
-    Rollup.shouldRun = true;
-
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'Name',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AccountNumber',
-        RollupOperation__c = 'CONCAT_DISTINCT',
-        CalcItem__c = 'ContactPointAddress',
-        CalcItemWhereClause__c = 'Name != \'' + acc.AccountNumber + '\''
-      )
-    };
-
-    Test.startTest();
-    Rollup.runFromTrigger();
-    Test.stopTest();
-
-    Account updatedAcc = [SELECT AccountNumber FROM Account];
-    System.assertEquals(null, updatedAcc.AccountNumber, 'CONCAT_DISTINCT AFTER_UPDATE should clear when updated item does not match and no other items');
-  }
-
-  @IsTest
-  static void shouldProperlyQueryNotLikeCountDistinct() {
-    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
-
-    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT not like');
-    insert new List<ContactPointAddress>{ cpa, new ContactPointAddress(ParentId = acc.Id, Name = 'Some other thing') };
-
-    Rollup.records = new List<ContactPointAddress>{ cpa };
-    Rollup.oldRecordsMap = new Map<Id, SObject>();
-    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    Rollup.shouldRun = true;
-
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'Id',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'COUNT_DISTINCT',
-        CalcItem__c = 'ContactPointAddress',
-        CalcItemWhereClause__c = 'Name NOT LIKE \'' + cpa.Name.substring(0, 6) + '%\''
-      )
-    };
-
-    Test.startTest();
-    Rollup.runFromTrigger();
-    Test.stopTest();
-
-    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(1, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT should work with NOT LIKE');
-  }
-
-  @IsTest
-  static void shouldNotIncludeNullForCountDistinct() {
-    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
-
-    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT null PreferenceRank');
-    insert cpa;
-
-    Rollup.records = new List<ContactPointAddress>{ cpa };
-    Rollup.oldRecordsMap = new Map<Id, SObject>();
-    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    Rollup.shouldRun = true;
-
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'PreferenceRank',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'COUNT_DISTINCT',
-        CalcItem__c = 'ContactPointAddress'
-      )
-    };
-
-    Test.startTest();
-    Rollup.runFromTrigger();
-    Test.stopTest();
-
-    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(null, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT should ignore nulls');
-
-    Rollup.defaultControl = new RollupControl__mdt(ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.SYNCHRONOUS);
-    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
-    Rollup.records = new List<ContactPointAddress>{ cpa };
-    Rollup.oldRecordsMap = new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(PreferenceRank = 10) };
-    Rollup.runFromTrigger();
-
-    updatedAcc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(null, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT on update should ignore nulls');
-  }
-
-  @IsTest
-  static void shouldNotIncludePriorValueForCountDistinctId() {
-    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
-    acc.AnnualRevenue = 5;
-    update acc;
-
-    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT update');
-    insert new List<ContactPointAddress>{ cpa, new ContactPointAddress(ParentId = acc.Id, Name = 'Some other thing') };
-
-    Rollup.records = new List<ContactPointAddress>{ cpa };
-    Rollup.oldRecordsMap = new Map<Id, SObject>();
-    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    Rollup.shouldRun = true;
-
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'Id',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'COUNT_DISTINCT',
-        CalcItem__c = 'ContactPointAddress'
-      )
-    };
-
-    Test.startTest();
-    Rollup.runFromTrigger();
-    Test.stopTest();
-
-    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(2, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT AFTER_INSERT should not overcount items');
-  }
-
-  @IsTest
-  static void shouldNotDoubleCountOldParentValueOnUpdate() {
-    Account acc = [SELECT Id, Name FROM Account];
-    acc.AnnualRevenue = 1;
-    update acc;
-
-    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'something else');
-    insert cpa;
-
-    Rollup.records = new List<ContactPointAddress>{ cpa };
-    Rollup.oldRecordsMap = new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(Id = cpa.Id, Name = acc.Name) };
-    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
-    Rollup.shouldRun = true;
-
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'Name',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'COUNT_DISTINCT',
-        CalcItem__c = 'ContactPointAddress'
-      )
-    };
-
-    Test.startTest();
-    Rollup.runFromTrigger();
-    Test.stopTest();
-
-    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(1, updatedAcc.AnnualRevenue, 'CONCAT_DISTINCT AFTER_UPDATE should clear when updated item does not match and no other items');
-  }
-
-  @IsTest
-  static void shouldClearParentValueIfNothingMatchesCountDistinct() {
-    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
-    acc.AnnualRevenue = 5;
-    update acc;
-
-    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT update');
-    insert new List<ContactPointAddress>{ cpa, new ContactPointAddress(ParentId = acc.Id, Name = 'Some other thing') };
-
-    Rollup.records = new List<ContactPointAddress>{ cpa };
-    Rollup.oldRecordsMap = new Map<Id, SObject>();
-    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    Rollup.shouldRun = true;
-
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'Name',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'COUNT_DISTINCT',
-        CalcItem__c = 'ContactPointAddress'
-      )
-    };
-
-    Test.startTest();
-    Rollup.runFromTrigger();
-    Test.stopTest();
-
-    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(2, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT AFTER_INSERT should not overcount items');
-  }
-
-  @IsTest
-  static void shouldCountDistinctOnUpdateEvenIfNewItemDoesNotMatch() {
-    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
-    acc.AnnualRevenue = 1;
-    update acc;
-
-    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT update', PreferenceRank = 0);
-    insert cpa;
-
-    Rollup.records = new List<ContactPointAddress>{ cpa };
-    Rollup.oldRecordsMap = new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(Id = cpa.Id, PreferenceRank = 1) };
-    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
-    Rollup.shouldRun = true;
-
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'Name',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'COUNT_DISTINCT',
-        CalcItem__c = 'ContactPointAddress',
-        CalcItemWhereClause__c = 'PreferenceRank > 0'
-      )
-    };
-
-    Test.startTest();
-    Rollup.runFromTrigger();
-    Test.stopTest();
-
-    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(0, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT AFTER_UPDATE should clear when updated item does not match and no other items');
-  }
-
-  @IsTest
-  static void shouldRunSyncWhenFlaggedOnRollupLimit() {
-    Account acc = [SELECT Id FROM Account];
-
-    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
-      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 1, Name = 'oneCpa'),
-      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 1, Name = 'twoCpa')
-    };
-    insert cpas;
-
-    Rollup.records = cpas;
-    Rollup.shouldRun = true;
-    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = 'Synchronous Rollup');
-
-    // specifically do NOT wrap in Test.startTest() / Test.stopTest() - we need to ensure this happened synchronously
-    Rollup.countFromApex(ContactPointAddress.PreferenceRank, ContactPointAddress.ParentId, Account.Id, Account.AnnualRevenue, Account.SObjectType).runCalc();
-
-    acc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(2, acc.AnnualRevenue, 'COUNT AFTER_INSERT should add when field is populated sync calc');
-  }
-
-  @IsTest
-  static void shouldPartiallyDeferRollupCalculationWhenOverLimits() {
-    Rollup.specificControl = new RollupControl__mdt(ShouldAbortRun__c = true);
-    Account acc = [SELECT Id, OwnerId FROM Account];
-    Account secondParent = new Account(Name = 'Second parent');
-    insert secondParent;
-
-    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
-      new ContactPointAddress(ParentId = acc.Id, Name = 'One', PreferenceRank = 1),
-      new ContactPointAddress(ParentId = secondParent.Id, Name = 'Two', PreferenceRank = 1)
-    };
-    insert cpas;
-
-    Rollup.defaultControl = new RollupControl__mdt(BatchChunkSize__c = 1, MaxRollupRetries__c = 1, MaxNumberOfQueries__c = 2, IsRollupLoggingEnabled__c = true);
-    // start as synchronous rollup to allow for one deferral
-    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = 'Synchronous Rollup');
-
-    Rollup.shouldRun = true;
-    Rollup.records = cpas;
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        CalcItem__c = 'ContactPointAddress',
-        RollupFieldOnCalcItem__c = 'PreferenceRank',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupObject__c = 'Account',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        // use one of the full recalc operations - one SOQL per parent object will get us to defer
-        // between lookup items
-        RollupOperation__c = 'AVERAGE'
-      )
-    };
-    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-
-    Test.startTest();
-    Rollup.runFromTrigger();
-    Test.stopTest();
-
-    // validate that queueable ran in addition to sync job
-    System.assertEquals('Completed', [SELECT Status FROM AsyncApexJob WHERE JobType = 'Queueable' LIMIT 1]?.Status);
-    List<Account> updatedAccounts = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(2, updatedAccounts.size(), 'Both parent items should have been updated!');
-
-    for (Account updatedAcc : updatedAccounts) {
-      System.assertEquals(1, updatedAcc.AnnualRevenue, 'Average annual revenue should have been set for both records!');
+  private static Map<String, CurrencyType> loadCurrencyTypes() {
+    Map<String, CurrencyType> CURRENCY_TYPES = new Map<String, CurrencyType>();
+    for (CurrencyType currencyType : [SELECT IsoCode, ConversionRate, DecimalPlaces FROM CurrencyType WHERE IsActive = TRUE]) {
+      CURRENCY_TYPES.put(currencyType.IsoCode, currencyType);
     }
-  }
-
-  @IsTest
-  static void shouldRunDirectlyFromApex() {
-    Account acc = [SELECT Id FROM Account];
-
-    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
-      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 5),
-      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 10)
-    };
-
-    Rollup.records = cpas;
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'PreferenceRank',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'SUM',
-        CalcItem__c = 'ContactPointAddress'
-      )
-    };
-
-    Test.startTest();
-    Rollup.runFromApex(cpas, TriggerOperation.AFTER_INSERT);
-    Test.stopTest();
-
-    acc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(15, acc.AnnualRevenue);
-  }
-
-  @IsTest
-  static void shouldDeferUpdateWhenMaxParentRowsLessThanCurrentUpdateRows() {
-    Account acc = [SELECT Id FROM Account];
-    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 50, Name = 'MaxParentRows');
-    insert cpa;
-
-    Rollup.records = new List<ContactPointAddress>{ cpa };
-    Rollup.shouldRun = true;
-    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    RollupAsyncProcessor.shouldRunAsBatch = true;
-    Rollup.defaultControl = new RollupControl__mdt(MaxParentRowsUpdatedAtOnce__c = 0, BatchChunkSize__c = 1, IsRollupLoggingEnabled__c = true);
-
-    Test.startTest();
-    Rollup.sumFromApex(ContactPointAddress.PreferenceRank, ContactPointAddress.ParentId, Account.Id, Account.AnnualRevenue, Account.SObjectType).runCalc();
-    Test.stopTest();
-
-    acc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(50, acc.AnnualRevenue, 'Account should have been updated since the mock is not used async');
-  }
-
-  @IsTest
-  static void shouldThrowExceptionWhenTryingToOperateOnDisallowedFieldTypes() {
-    Account acc = [SELECT Id FROM Account];
-    Rollup.records = new List<Task>{ new Task(ActivityDate = System.today(), WhatId = acc.Id) };
-    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    Rollup.shouldRun = true;
-
-    Exception ex;
-    try {
-      Test.startTest();
-      Rollup.maxFromApex(Task.ActivityDate, Task.WhatId, Account.Id, Account.BillingAddress, Account.SObjectType).runCalc();
-      Test.stopTest();
-    } catch (Exception e) {
-      ex = e;
-    }
-
-    System.assertNotEquals(null, ex);
-    System.assertEquals('Field: BillingAddress of type: ADDRESS specified invalid for rollup operation', ex.getMessage());
-  }
-
-  /** Invocable integration tests */
-
-  @IsTest
-  static void shouldTryToUpsertFromFlow() {
-    Account acc = [SELECT Id FROM Account];
-
-    ContactPointAddress cpa = new ContactPointAddress(PreferenceRank = 500, ParentId = acc.Id, Name = 'Upsert Flow Test');
-    insert cpa; // aping an after-insert action in Flow
-
-    List<ContactPointAddress> cpas = [SELECT Id, ParentId, CreatedDate, LastModifiedDate, PreferenceRank FROM ContactPointAddress];
-
-    List<Rollup.FlowInput> flowInputs = RollupTestUtils.prepareFlowTest(cpas, 'UPSERT', 'SUM');
-    flowInputs[0].oldRecordsToRollup = new List<ContactPointAddress>{ null }; // sad but true - this is what flow passes for {!$Record__Prior} on upsert
-
-    Test.startTest();
-    List<Rollup.FlowOutput> flowOutputs = Rollup.performRollup(flowInputs);
-    Test.stopTest();
-
-    System.assertEquals(1, flowOutputs.size(), 'Flow outputs were not provided');
-    System.assertEquals('SUCCESS', flowOutputs[0].message);
-    System.assertEquals(true, flowOutputs[0].isSuccess);
-
-    Account updatedAcc = [SELECT Id, AnnualRevenue FROM Account];
-    System.assertEquals(cpas[0].PreferenceRank, updatedAcc.AnnualRevenue, 'pseudo-upsert from flow should act like insert for PreferenceRank');
-  }
-
-  @IsTest
-  static void shouldFilterNonMatchingRollupsOutOfBatch() {
-    Contact con = new Contact(FirstName = 'Something', LastName = 'Required');
-    insert con;
-    RollupAsyncProcessor batchProcessor = new RollupAsyncProcessor(
-      new Set<Id>{ con.Id },
-      Contact.FirstName,
-      Contact.Id,
-      Contact.Id,
-      Contact.FirstName,
-      Campaign.SObjectType,
-      Contact.SObjectType,
-      Rollup.Op.CONCAT,
-      null,
-      Rollup.InvocationPoint.FROM_APEX,
-      RollupControl__mdt.getInstance('Org_Defaults'),
-      new Rollup__mdt(
-        CalcItem__c = 'Contact',
-        RollupFieldOnCalcItem__c = 'FirstName',
-        LookupFieldOnCalcItem__c = 'AccountId',
-        LookupObject__c = 'Campaign',
-        RollupFieldOnLookupObject__c = 'FirstName',
-        LookupFieldOnLookupObject__c = 'Id'
-      )
-    );
-    RollupAsyncProcessor conductor = new RollupAsyncProcessor(Rollup.InvocationPoint.FROM_APEX, new List<Contact>{ con }, new Map<Id, SObject>());
-    conductor.rollups.add(batchProcessor);
-    Test.startTest();
-    Database.executeBatch(conductor);
-    Test.stopTest();
-
-    System.assert(true, 'Should make it here');
-  }
-
-  /** Schedulable tests */
-  @IsTest
-  static void shouldThrowExceptionForBadQuery() {
-    // it's a date field - you tell ME why this query is invalid!
-    String veryBadQuery = 'SELECT MAX(ActivityDate) FROM Task';
-
-    Exception ex;
-    try {
-      Rollup.schedule('Test bad query', '0 0 0 0 0', veryBadQuery, 'Account', null);
-    } catch (Exception e) {
-      ex = e;
-    }
-
-    System.assertNotEquals(null, ex);
-  }
-
-  @IsTest
-  static void shouldScheduleSuccessfullyForGoodQuery() {
-    String goodQuery = 'SELECT Id, Name FROM ContactPointAddress WHERE CreatedDate > YESTERDAY';
-
-    String jobId = Rollup.schedule('Test good query' + System.now(), '0 0 0 * * ?', goodQuery, 'ContactPointAddress', null);
-
-    System.assertNotEquals(null, jobId);
+    return CURRENCY_TYPES;
   }
 }

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -353,8 +353,10 @@ private class RollupIntegrationTests {
   /** grandparent rollup tests */
   @IsTest
   static void shouldFindGreatGrandParentRelationshipBetweenCustomObjects() {
-    Account greatGrandparent = new Account(Name = 'Great-grandparent');
-    Account secondGreatGrandparent = new Account(Name = 'Second great-grandparent');
+    // The CurrencyIsoCode field isn't directly used here, but the field will be automatically included by Rollup's queries,
+    // so include it on the accounts so the asserts below show that the accounts do, in fact, match
+    Account greatGrandparent = new Account(Name = 'Great-grandparent', CurrencyIsoCode = 'USD');
+    Account secondGreatGrandparent = new Account(Name = 'Second great-grandparent', CurrencyIsoCode = 'USD');
     insert new List<Account>{ greatGrandparent, secondGreatGrandparent };
 
     ParentApplication__c grandParent = new ParentApplication__c(Name = 'Grandparent', Account__c = greatGrandparent.Id);

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -13,6 +13,7 @@ private class RollupIntegrationTests {
       StageName = 'testInt',
       CloseDate = System.today(),
       Amount = 1,
+      CurrencyIsoCode = 'USD',
       AccountIdText__c = acc.Id,
       AccountId = acc.Id
     );

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -168,12 +168,7 @@ private class RollupIntegrationTests {
     acc.CurrencyIsoCode = 'EUR';
     update acc;
 
-    Opportunity usdOpp = [
-      SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountId
-      FROM Opportunity
-      WHERE CurrencyIsoCode = 'USD'
-      LIMIT 1
-    ];
+    Opportunity usdOpp = [SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountId FROM Opportunity WHERE CurrencyIsoCode = 'USD' LIMIT 1];
 
     Opportunity eurOpp = usdOpp.clone(false, true);
     eurOpp.CurrencyIsoCode = 'EUR';
@@ -209,8 +204,6 @@ private class RollupIntegrationTests {
       'Multi-currency MAX rollup not calculated correctly!'
     );
   }
-
-  // TODO - first/last/average calculations
 
   @isTest
   static void shouldCorrectlyRollupMinForMultiCurrency() {
@@ -314,6 +307,164 @@ private class RollupIntegrationTests {
       acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       'Multi-currency SUM rollup not calculated correctly!'
     );
+  }
+
+  @isTest
+  static void shouldCorrectlyRollupAverageForMultiCurrency() {
+    Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
+    System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
+    System.assertEquals('USD', acc.CurrencyIsoCode, 'Test has started under the wrong conditions!');
+    acc.CurrencyIsoCode = 'EUR';
+    update acc;
+
+    Opportunity usdOpp = [SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountId FROM Opportunity WHERE CurrencyIsoCode = 'USD' LIMIT 1];
+
+    Opportunity eurOpp = usdOpp.clone(false, true);
+    eurOpp.CurrencyIsoCode = 'EUR';
+    eurOpp.Amount = .95;
+    Opportunity jpyOpp = eurOpp.clone(false, true);
+    jpyOpp.CurrencyIsoCode = 'JPY';
+    jpyOpp.Amount = 100;
+    insert new List<Opportunity>{ eurOpp, jpyOpp };
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Amount',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'AVERAGE',
+        CalcItem__c = 'Opportunity'
+      )
+    };
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.records = new List<Opportunity>{ usdOpp, eurOpp, jpyOpp };
+    Rollup.shouldRun = true;
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    List<Opportunity> opportunities = [SELECT Id, convertCurrency(Amount) ConvertedAmount, CurrencyIsoCode FROM Opportunity];
+    Decimal convertedAmountSum = 0;
+    for (Opportunity opp : opportunities) {
+      convertedAmountSum += (Decimal) opp.get('ConvertedAmount');
+    }
+    Decimal expectedAverage = (convertedAmountSum / opportunities.size()) * CURRENCY_TYPES.get(acc.CurrencyIsoCode).ConversionRate;
+
+    acc = [SELECT Id, CurrencyIsoCode, AnnualRevenue FROM Account];
+    System.assertEquals(
+      expectedAverage.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      'Multi-currency AVERAGE rollup not calculated correctly! Records: ' + opportunities
+    );
+  }
+
+  @isTest
+  static void shouldCorrectlyRollupFirstForMultiCurrency() {
+    Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
+    System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
+    System.assertEquals('USD', acc.CurrencyIsoCode, 'Test has started under the wrong conditions!');
+    acc.CurrencyIsoCode = 'EUR';
+    update acc;
+
+    Opportunity usdOpp = [SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountId FROM Opportunity WHERE CurrencyIsoCode = 'USD' LIMIT 1];
+
+    Opportunity eurOpp = usdOpp.clone(false, true);
+    eurOpp.CurrencyIsoCode = 'EUR';
+    eurOpp.Amount = .95;
+    Opportunity jpyOpp = eurOpp.clone(false, true);
+    jpyOpp.CurrencyIsoCode = 'JPY';
+    jpyOpp.Amount = 100;
+    insert new List<Opportunity>{ eurOpp, jpyOpp };
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'CurrencyIsoCode',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'Name',
+        RollupOperation__c = 'FIRST',
+        CalcItem__c = 'Opportunity',
+        OrderByFirstLast__c = 'Amount'
+      )
+    };
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.records = new List<Opportunity>{ usdOpp, eurOpp, jpyOpp };
+    Rollup.shouldRun = true;
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Decimal firstAmount;
+    String firstOpportunityCurrencyIsoCode;
+    List<Opportunity> opportunities = [SELECT Id, convertCurrency(Amount) ConvertedAmount, CurrencyIsoCode FROM Opportunity];
+    for (Opportunity opp : opportunities) {
+      Decimal oppConvertedAmount = (Decimal) opp.get('ConvertedAmount');
+      if (firstAmount == null || oppConvertedAmount < firstAmount) {
+        firstAmount = oppConvertedAmount;
+        firstOpportunityCurrencyIsoCode = opp.CurrencyIsoCode;
+      }
+    }
+
+    acc = [SELECT Id, Name FROM Account];
+    System.assertEquals(firstOpportunityCurrencyIsoCode, acc.Name, 'Should have taken first based on multi-currency Amount! Records: ' + opportunities);
+  }
+
+  @isTest
+  static void shouldCorrectlyRollupLastForMultiCurrency() {
+    Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
+    System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
+    System.assertEquals('USD', acc.CurrencyIsoCode, 'Test has started under the wrong conditions!');
+    acc.CurrencyIsoCode = 'EUR';
+    update acc;
+
+    Opportunity usdOpp = [SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountId FROM Opportunity WHERE CurrencyIsoCode = 'USD' LIMIT 1];
+
+    Opportunity eurOpp = usdOpp.clone(false, true);
+    eurOpp.CurrencyIsoCode = 'EUR';
+    eurOpp.Amount = .95;
+    Opportunity jpyOpp = eurOpp.clone(false, true);
+    jpyOpp.CurrencyIsoCode = 'JPY';
+    jpyOpp.Amount = 100;
+    insert new List<Opportunity>{ eurOpp, jpyOpp };
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'CurrencyIsoCode',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'Name',
+        RollupOperation__c = 'LAST',
+        CalcItem__c = 'Opportunity',
+        OrderByFirstLast__c = 'Amount'
+      )
+    };
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.records = new List<Opportunity>{ usdOpp, eurOpp, jpyOpp };
+    Rollup.shouldRun = true;
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Decimal lastAmount;
+    String lastOpportunityCurrencyIsoCode;
+    List<Opportunity> opportunities = [SELECT Id, convertCurrency(Amount) ConvertedAmount, CurrencyIsoCode FROM Opportunity];
+    for (Opportunity opp : opportunities) {
+      Decimal oppConvertedAmount = (Decimal) opp.get('ConvertedAmount');
+      if (lastAmount == null || oppConvertedAmount > lastAmount) {
+        lastAmount = oppConvertedAmount;
+        lastOpportunityCurrencyIsoCode = opp.CurrencyIsoCode;
+      }
+    }
+
+    acc = [SELECT Id, Name FROM Account];
+    System.assertEquals(lastOpportunityCurrencyIsoCode, acc.Name, 'Should have taken last based on multi-currency Amount! Records: ' + opportunities);
   }
 
   @isTest

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -5,7 +5,7 @@ private class RollupIntegrationTests {
   // "Integration," in the sense that these include custom fields / objects that shouldn't be installed
   @TestSetup
   static void setup() {
-    Account acc = new Account(Name = 'RollupIntegrationTests');
+    Account acc = new Account(Name = RollupIntegrationTests.class.getName());
     insert acc;
 
     acc.AccountIdText__c = acc.Id;
@@ -28,7 +28,7 @@ private class RollupIntegrationTests {
   static void shouldWorkUsingCustomFieldWithCmdt() {
     Account prior = [SELECT Id, AnnualRevenue FROM Account];
     System.assertEquals(null, prior.AnnualRevenue, 'Test has started under the wrong conditions!');
-    Rollup.records = [SELECT Id, Amount, AccountIdText__c FROM Opportunity];
+    Rollup.records = [SELECT Id, Amount, AccountIdText__c, CurrencyIsoCode FROM Opportunity];
     Rollup.shouldRun = true;
 
     Rollup.rollupMetadata = new List<Rollup__mdt>{
@@ -57,7 +57,7 @@ private class RollupIntegrationTests {
   static void shouldSupportFormulaFieldsOnChildObjectsOnFullRecordSet() {
     Account acc = [SELECT Id, AnnualRevenue FROM Account];
     System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
-    List<Opportunity> opps = [SELECT Id, Name, AmountFormula__c, AccountId FROM Opportunity];
+    List<Opportunity> opps = [SELECT Id, Name, AmountFormula__c, AccountId, CurrencyIsoCode FROM Opportunity];
     System.assertEquals(1, opps[0].AmountFormula__c, 'Test has started with wrong opp conditions!');
     Rollup.records = opps;
     Rollup.shouldRun = true;
@@ -169,7 +169,7 @@ private class RollupIntegrationTests {
     update acc;
 
     Opportunity usdOpp = [
-      SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountIdText__c, AccountId
+      SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountId
       FROM Opportunity
       WHERE CurrencyIsoCode = 'USD'
       LIMIT 1
@@ -177,8 +177,10 @@ private class RollupIntegrationTests {
 
     Opportunity eurOpp = usdOpp.clone(false, true);
     eurOpp.CurrencyIsoCode = 'EUR';
+    eurOpp.Amount = .95;
     Opportunity jpyOpp = eurOpp.clone(false, true);
     jpyOpp.CurrencyIsoCode = 'JPY';
+    jpyOpp.Amount = 100;
     insert new List<Opportunity>{ eurOpp, jpyOpp };
 
     Rollup.rollupMetadata = new List<Rollup__mdt>{
@@ -188,8 +190,7 @@ private class RollupIntegrationTests {
         LookupFieldOnCalcItem__c = 'AccountId',
         LookupFieldOnLookupObject__c = 'Id',
         RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'SUM',
-        IsFullRecordSet__c = true,
+        RollupOperation__c = 'MAX',
         CalcItem__c = 'Opportunity'
       )
     };
@@ -201,27 +202,15 @@ private class RollupIntegrationTests {
     Rollup.runFromTrigger();
     Test.stopTest();
 
-    Decimal expectedMaxAmount;
-    for (Opportunity opp : [SELECT convertCurrency(Amount) ConvertedAmount FROM Opportunity WHERE Id IN :Rollup.records]) {
-      Decimal oppConvertedAmount = (Decimal) opp.get('ConvertedAmount');
-      if (expectedMaxAmount == null || oppConvertedAmount > expectedMaxAmount) {
-        expectedMaxAmount = oppConvertedAmount;
-      }
-    }
-    expectedMaxAmount *= CURRENCY_TYPES.get(acc.CurrencyIsoCode).ConversionRate;
-
     acc = [SELECT Id, CurrencyIsoCode, AnnualRevenue, MaxAmountRollupSummary__c FROM Account];
     System.assertEquals(
-      expectedMaxAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       acc.MaxAmountRollupSummary__c.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
-      'Calculated TotalRevenue and rollup-summary field MaxAmountRollupSummary__c should match!'
-    );
-    System.assertEquals(
-      expectedMaxAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       'Multi-currency MAX rollup not calculated correctly!'
     );
   }
+
+  // TODO - first/last/average calculations
 
   @isTest
   static void shouldCorrectlyRollupMinForMultiCurrency() {
@@ -240,8 +229,10 @@ private class RollupIntegrationTests {
 
     Opportunity eurOpp = usdOpp.clone(false, true);
     eurOpp.CurrencyIsoCode = 'EUR';
+    eurOpp.Amount = .95;
     Opportunity jpyOpp = eurOpp.clone(false, true);
     jpyOpp.CurrencyIsoCode = 'JPY';
+    jpyOpp.Amount = 100;
     insert new List<Opportunity>{ eurOpp, jpyOpp };
 
     Rollup.rollupMetadata = new List<Rollup__mdt>{
@@ -251,7 +242,7 @@ private class RollupIntegrationTests {
         LookupFieldOnCalcItem__c = 'AccountId',
         LookupFieldOnLookupObject__c = 'Id',
         RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'SUM',
+        RollupOperation__c = 'MIN',
         IsFullRecordSet__c = true,
         CalcItem__c = 'Opportunity'
       )
@@ -264,23 +255,10 @@ private class RollupIntegrationTests {
     Rollup.runFromTrigger();
     Test.stopTest();
 
-    Decimal expectedMinAmount;
-    for (Opportunity opp : [SELECT convertCurrency(Amount) ConvertedAmount FROM Opportunity WHERE Id IN :Rollup.records]) {
-      Decimal oppConvertedAmount = (Decimal) opp.get('ConvertedAmount');
-      if (expectedMinAmount == null || oppConvertedAmount < expectedMinAmount) {
-        expectedMinAmount = oppConvertedAmount;
-      }
-    }
-    expectedMinAmount *= CURRENCY_TYPES.get(acc.CurrencyIsoCode).ConversionRate;
-
     acc = [SELECT Id, CurrencyIsoCode, AnnualRevenue, MinAmountRollupSummary__c FROM Account];
+
     System.assertEquals(
-      expectedMinAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       acc.MinAmountRollupSummary__c.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
-      'Calculated TotalRevenue and rollup-summary field MinAmountRollupSummary__c should match!'
-    );
-    System.assertEquals(
-      expectedMinAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       'Multi-currency MIN rollup not calculated correctly!'
     );
@@ -303,8 +281,10 @@ private class RollupIntegrationTests {
 
     Opportunity eurOpp = usdOpp.clone(false, true);
     eurOpp.CurrencyIsoCode = 'EUR';
+    eurOpp.Amount = .95;
     Opportunity jpyOpp = eurOpp.clone(false, true);
     jpyOpp.CurrencyIsoCode = 'JPY';
+    jpyOpp.Amount = 100;
     insert new List<Opportunity>{ eurOpp, jpyOpp };
 
     Rollup.rollupMetadata = new List<Rollup__mdt>{
@@ -327,20 +307,10 @@ private class RollupIntegrationTests {
     Rollup.runFromTrigger();
     Test.stopTest();
 
-    Decimal expectedSumAmount = 0;
-    for (Opportunity opp : [SELECT convertCurrency(Amount) ConvertedAmount FROM Opportunity WHERE Id IN :Rollup.records]) {
-      expectedSumAmount += (Decimal) opp.get('ConvertedAmount');
-    }
-    expectedSumAmount *= CURRENCY_TYPES.get(acc.CurrencyIsoCode).ConversionRate;
-
     acc = [SELECT Id, CurrencyIsoCode, AnnualRevenue, SumAmountRollupSummary__c FROM Account];
+
     System.assertEquals(
-      expectedSumAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       acc.SumAmountRollupSummary__c.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
-      'Calculated TotalRevenue and rollup-summary field SumAmountRollupSummary__c should match!'
-    );
-    System.assertEquals(
-      expectedSumAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       'Multi-currency SUM rollup not calculated correctly!'
     );

--- a/extra-tests/classes/RollupRelationshipFieldFinderTests.cls
+++ b/extra-tests/classes/RollupRelationshipFieldFinderTests.cls
@@ -21,6 +21,7 @@ private class RollupRelationshipFieldFinderTests {
 
     RollupRelationshipFieldFinder.Traversal traversal = finder.getParents(new List<ContactPointAddress>{ cpa });
 
+    parent = (Account) queryRecord(parent.Id);
     System.assertEquals(parent, traversal.retrieveParent(cpa.Id));
 
     // validates that the relationship field finder works even if a fully qualified path isn't provided if the parent
@@ -55,8 +56,9 @@ private class RollupRelationshipFieldFinderTests {
     RollupRelationshipFieldFinder.Traversal traversal = finder.getParents(new List<ContactPointAddress>{ cpa });
 
     parent = [SELECT OwnerId FROM Account WHERE Id = :parent.Id];
+    User expectedUser = (User) queryRecord(parent.OwnerId);
     System.assertEquals(
-      [SELECT Id, Name FROM User WHERE Id = :parent.OwnerId][0],
+      expectedUser,
       traversal.retrieveParent(cpa.Id),
       'User should have been retrieved correctly!'
     );
@@ -214,6 +216,7 @@ private class RollupRelationshipFieldFinderTests {
     );
     RollupRelationshipFieldFinder.Traversal traversal = finder.getParents(cpas);
 
+    parentOne = (Account) queryRecord(parentOne.Id);
     System.assertEquals(parentOne, traversal.retrieveParent(cpaOne.Id), 'First opp parent should not be exluded!');
     System.assertEquals(parentOne, traversal.retrieveParent(cpaTwo.Id), 'Second opp should not have been excluded!');
   }
@@ -250,7 +253,8 @@ private class RollupRelationshipFieldFinderTests {
     RollupRelationshipFieldFinder.Traversal traversal = finder.getParents(cpas);
 
     // we don't anticipate it being necessary to return fields used in the where clause; just that records are filtered correctly
-    Account expectedFirst = new Account(Id = parentOne.Id, Name = parentOne.Name);
+    Account expectedFirst = (Account) queryRecord(parentOne.Id);
+    parentThree = (Account) queryRecord(parentThree.Id);
     System.assertEquals(expectedFirst, traversal.retrieveParent(cpaOne.Id), 'First cpa parent should be returned, matches nested conditional!');
     System.assertEquals(null, traversal.retrieveParent(cpaTwo.Id), 'Second cpa parent should have been excluded with clause after nested conditional!');
     // parent three doesn't have additional fields (like AccountNumber), fine to use as is
@@ -296,8 +300,19 @@ private class RollupRelationshipFieldFinderTests {
     );
     RollupRelationshipFieldFinder.Traversal traversal = finder.getParents(cpas);
 
-    Account expectedAcc = new Account(Id = parentOne.Id, Name = parentOne.Name);
+    Account expectedAcc = (Account) queryRecord(parentOne.Id);
     System.assertEquals(expectedAcc, traversal.retrieveParent(cpaOne.Id), 'Ultimate parent should have been used!');
     System.assertEquals(expectedAcc, traversal.retrieveParent(cpaTwo.Id), 'Ultimate parent should be found even if 5+ levels deep in hierarchy');
+  }
+
+  private static SObject queryRecord(Id recordId) {
+    SObjectType sObjectType = recordId.getSObjectType();
+    String currencyIscoCodeFieldName = 'CurrencyIsoCode';
+    List<String> fields = new List<String>{ 'Id', 'Name' };
+    if (UserInfo.isMultiCurrencyOrganization() && sObjectType.getDescribe().fields.getMap().containsKey(currencyIscoCodeFieldName)) {
+      fields.add(currencyIscoCodeFieldName);
+    }
+    String recordQuery = 'SELECT ' + String.join(fields, ', ') + '\nFROM ' + sObjectType + '\nWHERE Id = :recordId';
+    return Database.query(recordQuery);
   }
 }

--- a/extra-tests/objects/Account/fields/MaxAmountRollupSummary__c.field-meta.xml
+++ b/extra-tests/objects/Account/fields/MaxAmountRollupSummary__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>MaxAmountRollupSummary__c</fullName>
+    <description>Rollup field of Opportunity.Amount, using standard Salesforce rollup summary field functionality</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Rollup field of Opportunity.Amount, using standard Salesforce rollup summary field functionality</inlineHelpText>
+    <label>Max Amount (Rollup Summary)</label>
+    <summarizedField>Opportunity.Amount</summarizedField>
+    <summaryForeignKey>Opportunity.AccountId</summaryForeignKey>
+    <summaryOperation>max</summaryOperation>
+    <type>Summary</type>
+</CustomField>

--- a/extra-tests/objects/Account/fields/MinAmountRollupSummary__c.field-meta.xml
+++ b/extra-tests/objects/Account/fields/MinAmountRollupSummary__c.field-meta.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>TotalAmountRollupSummary__c</fullName>
+    <fullName>MinAmountRollupSummary__c</fullName>
     <description>Rollup field of Opportunity.Amount, using standard Salesforce rollup summary field functionality</description>
     <externalId>false</externalId>
     <inlineHelpText>Rollup field of Opportunity.Amount, using standard Salesforce rollup summary field functionality</inlineHelpText>
-    <label>Total Amount (Rollup Summary)</label>
+    <label>Min Amount (Rollup Summary)</label>
     <summarizedField>Opportunity.Amount</summarizedField>
     <summaryForeignKey>Opportunity.AccountId</summaryForeignKey>
-    <summaryOperation>sum</summaryOperation>
+    <summaryOperation>min</summaryOperation>
     <type>Summary</type>
 </CustomField>

--- a/extra-tests/objects/Account/fields/SumAmountRollupSummary__c.field-meta.xml
+++ b/extra-tests/objects/Account/fields/SumAmountRollupSummary__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>SumAmountRollupSummary__c</fullName>
+    <description>Rollup field of Opportunity.Amount, using standard Salesforce rollup summary field functionality</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Rollup field of Opportunity.Amount, using standard Salesforce rollup summary field functionality</inlineHelpText>
+    <label>Sum Amount (Rollup Summary)</label>
+    <summarizedField>Opportunity.Amount</summarizedField>
+    <summaryForeignKey>Opportunity.AccountId</summaryForeignKey>
+    <summaryOperation>sum</summaryOperation>
+    <type>Summary</type>
+</CustomField>

--- a/extra-tests/objects/Account/fields/TotalAmountRollupSummary__c.field-meta.xml
+++ b/extra-tests/objects/Account/fields/TotalAmountRollupSummary__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>TotalAmountRollupSummary__c</fullName>
+    <description>Rollup field of Opportunity.Amount, using standard Salesforce rollup summary field functionality</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Rollup field of Opportunity.Amount, using standard Salesforce rollup summary field functionality</inlineHelpText>
+    <label>Total Amount (Rollup Summary)</label>
+    <summarizedField>Opportunity.Amount</summarizedField>
+    <summaryForeignKey>Opportunity.AccountId</summaryForeignKey>
+    <summaryOperation>sum</summaryOperation>
+    <type>Summary</type>
+</CustomField>

--- a/extra-tests/profiles/Admin.profile-meta.xml
+++ b/extra-tests/profiles/Admin.profile-meta.xml
@@ -77,6 +77,21 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Account.MaxAmountRollupSummary__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Account.MinAmountRollupSummary__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Account.SumAmountRollupSummary__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Application__c.Engagement_Score__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -906,7 +906,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
         // Check for changed values
         Object priorVal = lookupRecord.get(rollup.opFieldOnLookupObject);
-        Object newVal = this.getRollupVal(rollup, localCalcItems, priorVal, key, rollup.lookupFieldOnCalcItem);
+        Object newVal = this.calculateNewRollupVal(rollup, localCalcItems, lookupRecord, priorVal, key, rollup.lookupFieldOnCalcItem);
         this.conditionallyPerformUpdate(priorVal, newVal, lookupRecord, rollup, recordsToUpdate, updater, 'lookup');
       }
     }
@@ -1018,7 +1018,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     return oldCalcItem;
   }
 
-  private Object getRollupVal(RollupAsyncProcessor roll, List<SObject> calcItems, Object priorVal, String lookupRecordKey, SObjectField lookupKeyField) {
+  private Object calculateNewRollupVal(RollupAsyncProcessor roll, List<SObject> calcItems, SObject lookupRecord, Object priorVal, String lookupRecordKey, SObjectField lookupKeyField) {
     RollupCalculator rollupCalc = RollupCalculator.Factory.getCalculator(
       priorVal,
       roll.op,
@@ -1031,6 +1031,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     rollupCalc.setFullRecalc(roll.isFullRecalc);
     rollupCalc.setEvaluator(roll.eval);
     rollupCalc.setCDCUpdate(this.isCDCUpdate);
+    rollupCalc.setMultiCurrencyInfo(lookupRecord);
     rollupCalc.performRollup(calcItems, this.oldCalcItems);
     return rollupCalc.getReturnValue();
   }
@@ -1076,7 +1077,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         RollupLogger.Instance.log('reparenting operation: ', oldLookupsRollup, LoggingLevel.DEBUG);
 
         Object priorVal = lookupRecord.get(roll.opFieldOnLookupObject);
-        Object newVal = this.getRollupVal(oldLookupsRollup, reparentedCalcItems, priorVal, key, roll.lookupFieldOnCalcItem);
+        Object newVal = this.calculateNewRollupVal(oldLookupsRollup, reparentedCalcItems, lookupRecord, priorVal, key, roll.lookupFieldOnCalcItem);
 
         this.conditionallyPerformUpdate(priorVal, newVal, lookupRecord, roll, recordsToUpdate, updater, 'reparented');
       }

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -1,10 +1,10 @@
 public without sharing abstract class RollupCalculator {
   private static final String CURRENCY_ISO_CODE_FIELD_NAME = 'CurrencyIsoCode';
 
-  private final Boolean isMultiCurrencyRollup;
 
   private Boolean isCDCUpdate = false;
   private Boolean isFirstTimeThrough = true;
+  private Boolean isMultiCurrencyRollup = false;
   private Boolean isRecursiveRecalc = false;
   private Boolean isFullRecalc = false;
 
@@ -117,7 +117,7 @@ public without sharing abstract class RollupCalculator {
       (String.isBlank(metadata.CalcItemWhereClause__c) ? '' : ' AND (' + metadata.CalcItemWhereClause__c + ')');
     this.isMultiCurrencyRollup =
       UserInfo.isMultiCurrencyOrganization() &&
-      (this.opFieldOnCalcItem.getDescribe().getType() == DisplayType.CURRENCY ||
+      (this.opFieldOnCalcItem?.getDescribe().getType() == DisplayType.CURRENCY ||
       this.opFieldOnLookupObject?.getDescribe().getType() == DisplayType.CURRENCY);
   }
   public virtual Object getReturnValue() {
@@ -365,12 +365,26 @@ public without sharing abstract class RollupCalculator {
       return;
     }
     // the worst possible scenario has occurred - the currencies differ and we haven't already populated the map
-    Decimal calcItemAmountInOrgCurrency = CURRENCY_ISO_CODE_TO_CURRENCY.get(calcItemIsoCode).ConversionRate / (Decimal) calcItem.get(this.opFieldOnCalcItem);
-    Decimal calcItemAmountInParentCurrency = CURRENCY_ISO_CODE_TO_CURRENCY.get(this.parentIsoCode).ConversionRate / calcItemAmountInOrgCurrency;
     skinnyCalcItem = skinnyCalcItem == null ? calcItem.clone(true, true, true, true) : skinnyCalcItem;
-    skinnyCalcItem.put(CURRENCY_ISO_CODE_FIELD_NAME, this.parentIsoCode);
-    skinnyCalcItem.put(this.opFieldOnCalcItem, calcItemAmountInParentCurrency);
+    this.convertToParentCurrency(calcItem, skinnyCalcItem, this.opFieldOnCalcItem, calcItemIsoCode);
+
+    SObjectField orderByFirstLastField = calcItem.getSObjectType().getDescribe().fields.getMap().get(this.metadata.OrderByFirstLast__c);
+    if (orderByFirstLastField != null && orderByFirstLastField != this.opFieldOnCalcItem) {
+      this.convertToParentCurrency(calcItem, skinnyCalcItem, orderByFirstLastField, calcItemIsoCode);
+    }
+
     TRANSFORMED_MULTICURRENCY_CALC_ITEMS.put(calcItem.Id, skinnyCalcItem);
+  }
+
+  private void convertToParentCurrency(SObject calcItem, SObject skinnyCalcItem, SObjectField fieldOnCalcItem, String calcItemIsoCode) {
+    if (fieldOnCalcItem.getDescribe().getType() != DisplayType.CURRENCY) {
+      return;
+    }
+
+    Decimal calcItemAmountInOrgCurrency = CURRENCY_ISO_CODE_TO_CURRENCY.get(calcItemIsoCode).ConversionRate / (Decimal) calcItem.get(fieldOnCalcItem);
+    Decimal calcItemAmountInParentCurrency = CURRENCY_ISO_CODE_TO_CURRENCY.get(this.parentIsoCode).ConversionRate / calcItemAmountInOrgCurrency;
+    skinnyCalcItem.put(CURRENCY_ISO_CODE_FIELD_NAME, this.parentIsoCode);
+    skinnyCalcItem.put(fieldOnCalcItem, calcItemAmountInParentCurrency);
   }
 
   private class CountDistinctRollupCalculator extends RollupCalculator {
@@ -1081,6 +1095,12 @@ public without sharing abstract class RollupCalculator {
         lookupKeyField
       );
       this.metadata.OrderByFirstLast__c = String.isNotBlank(metadata.OrderByFirstLast__c) ? metadata.OrderByFirstLast__c : metadata.RollupFieldOnCalcItem__c;
+      SObjectType calcItemSObjectType = ((SObject)Type.forName(this.metadata.CalcItem__c).newInstance()).getSObjectType();
+      SObjectField orderByFirstLastField = calcItemSObjectType.getDescribe().fields.getMap().get(this.metadata.OrderByFirstLast__c);
+      this.isMultiCurrencyRollup =
+        UserInfo.isMultiCurrencyOrganization() &&
+        orderByFirstLastField != null &&
+        orderByFirstLastField.getDescribe().getType() == DisplayType.CURRENCY;
     }
 
     public override void performRollup(List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -1,7 +1,6 @@
 public without sharing abstract class RollupCalculator {
   private static final String CURRENCY_ISO_CODE_FIELD_NAME = 'CurrencyIsoCode';
 
-
   private Boolean isCDCUpdate = false;
   private Boolean isFirstTimeThrough = true;
   private Boolean isMultiCurrencyRollup = false;
@@ -1095,12 +1094,9 @@ public without sharing abstract class RollupCalculator {
         lookupKeyField
       );
       this.metadata.OrderByFirstLast__c = String.isNotBlank(metadata.OrderByFirstLast__c) ? metadata.OrderByFirstLast__c : metadata.RollupFieldOnCalcItem__c;
-      SObjectType calcItemSObjectType = ((SObject)Type.forName(this.metadata.CalcItem__c).newInstance()).getSObjectType();
+      SObjectType calcItemSObjectType = ((SObject) Type.forName(this.metadata.CalcItem__c).newInstance()).getSObjectType();
       SObjectField orderByFirstLastField = calcItemSObjectType.getDescribe().fields.getMap().get(this.metadata.OrderByFirstLast__c);
-      this.isMultiCurrencyRollup =
-        UserInfo.isMultiCurrencyOrganization() &&
-        orderByFirstLastField != null &&
-        orderByFirstLastField.getDescribe().getType() == DisplayType.CURRENCY;
+      this.isMultiCurrencyRollup = UserInfo.isMultiCurrencyOrganization() && orderByFirstLastField?.getDescribe().getType() == DisplayType.CURRENCY;
     }
 
     public override void performRollup(List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -115,7 +115,10 @@ public without sharing abstract class RollupCalculator {
       lookupRecordKey +
       '\'' +
       (String.isBlank(metadata.CalcItemWhereClause__c) ? '' : ' AND (' + metadata.CalcItemWhereClause__c + ')');
-    this.isMultiCurrencyRollup = UserInfo.isMultiCurrencyOrganization() && this.opFieldOnLookupObject?.getDescribe().getType() == DisplayType.CURRENCY;
+    this.isMultiCurrencyRollup =
+      UserInfo.isMultiCurrencyOrganization() &&
+      (this.opFieldOnCalcItem.getDescribe().getType() == DisplayType.CURRENCY ||
+      this.opFieldOnLookupObject?.getDescribe().getType() == DisplayType.CURRENCY);
   }
   public virtual Object getReturnValue() {
     return this.returnVal;

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -1,9 +1,12 @@
 public without sharing abstract class RollupCalculator {
+  private static final String CURRENCY_ISO_CODE_FIELD_NAME = 'CurrencyIsoCode';
+
+  private final Boolean isMultiCurrencyRollup;
+
   private Boolean isCDCUpdate = false;
   private Boolean isFirstTimeThrough = true;
   private Boolean isRecursiveRecalc = false;
   private Boolean isFullRecalc = false;
-  private Boolean isMultiCurrencyRollup;
 
   protected final SObjectField opFieldOnCalcItem;
   protected final SObjectField opFieldOnLookupObject;
@@ -112,7 +115,7 @@ public without sharing abstract class RollupCalculator {
       lookupRecordKey +
       '\'' +
       (String.isBlank(metadata.CalcItemWhereClause__c) ? '' : ' AND (' + metadata.CalcItemWhereClause__c + ')');
-    this.isMultiCurrencyRollup = UserInfo.isMultiCurrencyOrganization() && this.opFieldOnLookupObject.getDescribe().getType() == DisplayType.CURRENCY;
+    this.isMultiCurrencyRollup = UserInfo.isMultiCurrencyOrganization() && this.opFieldOnLookupObject?.getDescribe().getType() == DisplayType.CURRENCY;
   }
   public virtual Object getReturnValue() {
     return this.returnVal;
@@ -131,8 +134,8 @@ public without sharing abstract class RollupCalculator {
   }
 
   public void setMultiCurrencyInfo(SObject parentRecord) {
-    if (parentRecord.getPopulatedFieldsAsMap().containsKey('CurrencyIsoCode')) {
-      this.parentIsoCode = (String) parentRecord.get('CurrencyIsoCode');
+    if (parentRecord.getPopulatedFieldsAsMap().containsKey(CURRENCY_ISO_CODE_FIELD_NAME)) {
+      this.parentIsoCode = (String) parentRecord.get(CURRENCY_ISO_CODE_FIELD_NAME);
     }
   }
 
@@ -344,24 +347,25 @@ public without sharing abstract class RollupCalculator {
   }
 
   private void transformForMultiCurrencyOrgs(SObject calcItem) {
-    if (this.isMultiCurrencyRollup == false || calcItem.getSObjectType().getDescribe().fields.getMap().containsKey('CurrencyIsoCode') == false) {
+    if (this.isMultiCurrencyRollup == false || calcItem.getSObjectType().getDescribe().fields.getMap().containsKey(CURRENCY_ISO_CODE_FIELD_NAME) == false) {
       return;
     }
 
-    String calcItemIsoCode = (String) calcItem.get('CurrencyIsoCode');
+    String calcItemIsoCode = (String) calcItem.get(CURRENCY_ISO_CODE_FIELD_NAME);
     SObject skinnyCalcItem = TRANSFORMED_MULTICURRENCY_CALC_ITEMS.get(calcItem.Id);
     if (
+      String.isBlank(this.parentIsoCode) ||
+      String.isBlank(calcItemIsoCode) ||
       calcItemIsoCode == this.parentIsoCode ||
-      skinnyCalcItem?.getPopulatedFieldsAsMap().containsKey(this.opFieldOnCalcItem.getDescribe().getName()) == true)
-     {
+      skinnyCalcItem?.getPopulatedFieldsAsMap().containsKey(this.opFieldOnCalcItem.getDescribe().getName()) == true
+    ) {
       return;
     }
     // the worst possible scenario has occurred - the currencies differ and we haven't already populated the map
     Decimal calcItemAmountInOrgCurrency = CURRENCY_ISO_CODE_TO_CURRENCY.get(calcItemIsoCode).ConversionRate / (Decimal) calcItem.get(this.opFieldOnCalcItem);
     Decimal calcItemAmountInParentCurrency = CURRENCY_ISO_CODE_TO_CURRENCY.get(this.parentIsoCode).ConversionRate / calcItemAmountInOrgCurrency;
-    // skinnyCalcItem = skinnyCalcItem == null ? calcItem.getSObjectType().newSObject(calcItem.Id) : skinnyCalcItem;
     skinnyCalcItem = skinnyCalcItem == null ? calcItem.clone(true, true, true, true) : skinnyCalcItem;
-    skinnyCalcItem.put('CurrencyIsoCode', this.parentIsoCode);
+    skinnyCalcItem.put(CURRENCY_ISO_CODE_FIELD_NAME, this.parentIsoCode);
     skinnyCalcItem.put(this.opFieldOnCalcItem, calcItemAmountInParentCurrency);
     TRANSFORMED_MULTICURRENCY_CALC_ITEMS.put(calcItem.Id, skinnyCalcItem);
   }

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -3,6 +3,7 @@ public without sharing abstract class RollupCalculator {
   private Boolean isFirstTimeThrough = true;
   private Boolean isRecursiveRecalc = false;
   private Boolean isFullRecalc = false;
+  private Boolean isMultiCurrencyRollup;
 
   protected final SObjectField opFieldOnCalcItem;
   protected final SObjectField opFieldOnLookupObject;
@@ -17,9 +18,13 @@ public without sharing abstract class RollupCalculator {
   protected Object returnVal;
   protected Boolean isLastItem = false;
   protected Boolean shouldTriggerFullRecalc;
+  protected String parentIsoCode;
 
   @TestVisible
   private static Factory testFactory;
+
+  private static final Map<String, CurrencyInfo> CURRENCY_ISO_CODE_TO_CURRENCY = getCurrencyMap();
+  private static Map<Id, SObject> TRANSFORMED_MULTICURRENCY_CALC_ITEMS = new Map<Id, SObject>();
 
   public static Factory Factory {
     get {
@@ -107,6 +112,7 @@ public without sharing abstract class RollupCalculator {
       lookupRecordKey +
       '\'' +
       (String.isBlank(metadata.CalcItemWhereClause__c) ? '' : ' AND (' + metadata.CalcItemWhereClause__c + ')');
+    this.isMultiCurrencyRollup = UserInfo.isMultiCurrencyOrganization() && this.opFieldOnLookupObject.getDescribe().getType() == DisplayType.CURRENCY;
   }
   public virtual Object getReturnValue() {
     return this.returnVal;
@@ -122,6 +128,12 @@ public without sharing abstract class RollupCalculator {
 
   public void setFullRecalc(Boolean isFullRecalc) {
     this.isFullRecalc = isFullRecalc;
+  }
+
+  public void setMultiCurrencyInfo(SObject parentRecord) {
+    if (parentRecord.getPopulatedFieldsAsMap().containsKey('CurrencyIsoCode')) {
+      this.parentIsoCode = (String) parentRecord.get('CurrencyIsoCode');
+    }
   }
 
   public virtual void performRollup(List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
@@ -255,10 +267,12 @@ public without sharing abstract class RollupCalculator {
     for (SObject item : temporaryItems) {
       SObject potentialOldItem = oldCalcItems.containsKey(item.Id) ? oldCalcItems.get(item.Id) : item;
       if (this.eval?.matches(item) != false) {
-        items.add(item);
+        this.transformForMultiCurrencyOrgs(item);
+        items.add(this.getTransformedCalcItem(item));
       } else if (this.op == Rollup.Op.UPDATE_COUNT && this.eval?.matches(item) == false && this.eval?.matches(potentialOldItem) == true) {
         // TODO - handle old item matching, new item not matching situation for (other non-full recalc) operations
-        items.add(item);
+        this.transformForMultiCurrencyOrgs(item);
+        items.add(this.getTransformedCalcItem(item));
       }
     }
 
@@ -278,6 +292,10 @@ public without sharing abstract class RollupCalculator {
 
   protected Boolean isReparented(SObject calcItem, SObject oldCalcItem) {
     return calcItem.get(this.lookupKeyField) != oldCalcItem.get(this.lookupKeyField);
+  }
+
+  protected SObject getTransformedCalcItem(SObject calcItem) {
+    return TRANSFORMED_MULTICURRENCY_CALC_ITEMS.containsKey(calcItem.Id) ? TRANSFORMED_MULTICURRENCY_CALC_ITEMS.get(calcItem.Id) : calcItem;
   }
 
   protected Object performBaseCalculation(Rollup.Op op, Set<Id> objIds, SObjectType sObjectType) {
@@ -305,6 +323,7 @@ public without sharing abstract class RollupCalculator {
           this.lookupRecordKey,
           this.lookupKeyField
         );
+        calc.parentIsoCode = this.parentIsoCode;
         calc.performRollup(allOtherItems, new Map<Id, SObject>());
         this.returnVal = calc.getReturnValue();
       }
@@ -322,6 +341,29 @@ public without sharing abstract class RollupCalculator {
       results = Database.query(query);
     }
     return results;
+  }
+
+  private void transformForMultiCurrencyOrgs(SObject calcItem) {
+    if (this.isMultiCurrencyRollup == false || calcItem.getSObjectType().getDescribe().fields.getMap().containsKey('CurrencyIsoCode') == false) {
+      return;
+    }
+
+    String calcItemIsoCode = (String) calcItem.get('CurrencyIsoCode');
+    SObject skinnyCalcItem = TRANSFORMED_MULTICURRENCY_CALC_ITEMS.get(calcItem.Id);
+    if (
+      calcItemIsoCode == this.parentIsoCode ||
+      skinnyCalcItem?.getPopulatedFieldsAsMap().containsKey(this.opFieldOnCalcItem.getDescribe().getName()) == true)
+     {
+      return;
+    }
+    // the worst possible scenario has occurred - the currencies differ and we haven't already populated the map
+    Decimal calcItemAmountInOrgCurrency = CURRENCY_ISO_CODE_TO_CURRENCY.get(calcItemIsoCode).ConversionRate / (Decimal) calcItem.get(this.opFieldOnCalcItem);
+    Decimal calcItemAmountInParentCurrency = CURRENCY_ISO_CODE_TO_CURRENCY.get(this.parentIsoCode).ConversionRate / calcItemAmountInOrgCurrency;
+    // skinnyCalcItem = skinnyCalcItem == null ? calcItem.getSObjectType().newSObject(calcItem.Id) : skinnyCalcItem;
+    skinnyCalcItem = skinnyCalcItem == null ? calcItem.clone(true, true, true, true) : skinnyCalcItem;
+    skinnyCalcItem.put('CurrencyIsoCode', this.parentIsoCode);
+    skinnyCalcItem.put(this.opFieldOnCalcItem, calcItemAmountInParentCurrency);
+    TRANSFORMED_MULTICURRENCY_CALC_ITEMS.put(calcItem.Id, skinnyCalcItem);
   }
 
   private class CountDistinctRollupCalculator extends RollupCalculator {
@@ -1112,5 +1154,26 @@ public without sharing abstract class RollupCalculator {
 
       return this.isFirst ? returnVal : returnVal * -1;
     }
+  }
+
+  private class CurrencyInfo {
+    public String IsoCode { get; set; }
+    public Decimal ConversionRate { get; set; }
+    public Integer DecimalPlaces { get; set; }
+    public Boolean IsCorporate { get; set; }
+  }
+
+  private static Map<String, CurrencyInfo> getCurrencyMap() {
+    Map<String, CurrencyInfo> currencyInfoMap = new Map<String, CurrencyInfo>();
+    if (UserInfo.isMultiCurrencyOrganization() == false) {
+      return currencyInfoMap;
+    }
+
+    String query = 'SELECT IsoCode, ConversionRate, DecimalPlaces, IsCorporate FROM CurrencyType WHERE IsActive = TRUE';
+    List<CurrencyInfo> currencyTypes = (List<CurrencyInfo>) JSON.deserialize(JSON.serialize(Database.query(query)), List<CurrencyInfo>.class);
+    for (CurrencyInfo currencyType : currencyTypes) {
+      currencyInfoMap.put(currencyType.IsoCode, currencyType);
+    }
+    return currencyInfoMap;
   }
 }

--- a/rollup/core/classes/RollupQueryBuilder.cls
+++ b/rollup/core/classes/RollupQueryBuilder.cls
@@ -19,6 +19,10 @@ public without sharing class RollupQueryBuilder {
     Map<String, SObjectField> baseFields = sObjectToken.fields.getMap();
     Set<String> lowerCaseFieldNames = new Set<String>();
 
+    if (UserInfo.isMultiCurrencyOrganization() && uniqueQueryFieldNames.contains('Count()') == false) {
+      uniqueQueryFieldNames.add('CurrencyIsoCode');
+    }
+
     for (Integer index = uniqueQueryFieldNames.size() - 1; index >= 0; index--) {
       String uniqueFieldName = uniqueQueryFieldNames[index];
       if (String.isBlank(uniqueFieldName)) {

--- a/rollup/core/classes/RollupQueryBuilder.cls
+++ b/rollup/core/classes/RollupQueryBuilder.cls
@@ -5,6 +5,8 @@ public without sharing class RollupQueryBuilder {
   public static final RollupQueryBuilder Current = new RollupQueryBuilder();
   public static final Integer SENTINEL_COUNT_VALUE = -1;
 
+  private static final String CURRENCY_ISO_CODE_FIELD_NAME = 'CurrencyIsoCode';
+
   /**
    * @return String `queryString` - returns a query string with "objIds" expected as a bind variable
    */
@@ -18,10 +20,6 @@ public without sharing class RollupQueryBuilder {
     DescribeSObjectResult sObjectToken = sObjectType.getDescribe();
     Map<String, SObjectField> baseFields = sObjectToken.fields.getMap();
     Set<String> lowerCaseFieldNames = new Set<String>();
-
-    if (UserInfo.isMultiCurrencyOrganization() && uniqueQueryFieldNames.contains('Count()') == false) {
-      uniqueQueryFieldNames.add('CurrencyIsoCode');
-    }
 
     for (Integer index = uniqueQueryFieldNames.size() - 1; index >= 0; index--) {
       String uniqueFieldName = uniqueQueryFieldNames[index];
@@ -54,6 +52,26 @@ public without sharing class RollupQueryBuilder {
       ) {
         uniqueQueryFieldNames[index] = uniqueFieldName;
       }
+    }
+
+    Boolean hasAggregateFunction = false;
+    for (String uniqueQueryFieldName : uniqueQueryFieldNames) {
+      // This is definitely not the most intuitive way to do this, but need to determine if the query
+      // will be a regular query vs an aggregated query - all aggregate functions use '()', so checking
+      // for '(' is a quick & lazy way to check without making larger changes to how RollupQueryBuilder works
+      // (but it's very goofy & could definitely be improved)
+      if (uniqueQueryFieldName?.contains('(')) {
+        hasAggregateFunction = true;
+        break;
+      }
+    }
+    if (
+      hasAggregateFunction == false &&
+      uniqueQueryFieldNames.contains(CURRENCY_ISO_CODE_FIELD_NAME) == false &&
+      UserInfo.isMultiCurrencyOrganization() &&
+      sObjectToken.fields.getMap().containsKey(CURRENCY_ISO_CODE_FIELD_NAME)
+    ) {
+      uniqueQueryFieldNames.add(CURRENCY_ISO_CODE_FIELD_NAME);
     }
 
     optionalWhereClause = this.adjustWhereClauseForPolymorphicFields(sObjectType, uniqueQueryFieldNames, optionalWhereClause);

--- a/rollup/core/classes/RollupQueryBuilder.cls
+++ b/rollup/core/classes/RollupQueryBuilder.cls
@@ -54,25 +54,7 @@ public without sharing class RollupQueryBuilder {
       }
     }
 
-    Boolean hasAggregateFunction = false;
-    for (String uniqueQueryFieldName : uniqueQueryFieldNames) {
-      // This is definitely not the most intuitive way to do this, but need to determine if the query
-      // will be a regular query vs an aggregated query - all aggregate functions use '()', so checking
-      // for '(' is a quick & lazy way to check without making larger changes to how RollupQueryBuilder works
-      // (but it's very goofy & could definitely be improved)
-      if (uniqueQueryFieldName?.contains('(')) {
-        hasAggregateFunction = true;
-        break;
-      }
-    }
-    if (
-      hasAggregateFunction == false &&
-      uniqueQueryFieldNames.contains(CURRENCY_ISO_CODE_FIELD_NAME) == false &&
-      UserInfo.isMultiCurrencyOrganization() &&
-      sObjectToken.fields.getMap().containsKey(CURRENCY_ISO_CODE_FIELD_NAME)
-    ) {
-      uniqueQueryFieldNames.add(CURRENCY_ISO_CODE_FIELD_NAME);
-    }
+    this.addCurrencyIsoCodeForMultiCurrencyOrgs(uniqueQueryFieldNames, sObjectToken);
 
     optionalWhereClause = this.adjustWhereClauseForPolymorphicFields(sObjectType, uniqueQueryFieldNames, optionalWhereClause);
 
@@ -155,5 +137,28 @@ public without sharing class RollupQueryBuilder {
 
   private Boolean hasPolymorphicOwnerClause(String whereClause) {
     return whereClause?.contains('.Owner') == true;
+  }
+
+  private void addCurrencyIsoCodeForMultiCurrencyOrgs(List<String> uniqueQueryFieldNames, DescribeSObjectResult sObjectToken) {
+    if (
+      UserInfo.isMultiCurrencyOrganization() &&
+      uniqueQueryFieldNames.contains(CURRENCY_ISO_CODE_FIELD_NAME) == false &&
+      sObjectToken.fields.getMap().containsKey(CURRENCY_ISO_CODE_FIELD_NAME)
+    ) {
+      Boolean hasAggregateFunction = false;
+      for (String uniqueQueryFieldName : uniqueQueryFieldNames) {
+        // This is definitely not the most intuitive way to do this, but need to determine if the query
+        // will be a regular query vs an aggregated query - all aggregate functions use '()', so checking
+        // for '(' is a quick & lazy way to check without making larger changes to how RollupQueryBuilder works
+        // (but it's very goofy & could definitely be improved)
+        if (uniqueQueryFieldName?.contains('(')) {
+          hasAggregateFunction = true;
+          break;
+        }
+      }
+      if (hasAggregateFunction == false) {
+        uniqueQueryFieldNames.add(CURRENCY_ISO_CODE_FIELD_NAME);
+      }
+    }
   }
 }

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -55,6 +55,9 @@ if($scratchOrgAllotment -gt 0) {
       throw $1
     }
     $userNameHasBeenSet = $true
+    # Multi-currency prep
+    Write-Output 'Importing multi-currency config data to scratch org ...'
+    sfdx force:data:tree:import -f ./config/data/CurrencyTypes.json
     # Deploy
     Write-Output 'Pushing source to scratch org ...'
     sfdx force:source:push


### PR DESCRIPTION
Closes #156 by adding support for multi-currency fields :dollar: :euro: :yen: 
- MIN, MAX, SUM, AVERAGE, FIRST and LAST operations now internally convert `calcItem` currency fields to the currency of the parent record so that the same currency is being used for any calculations
- Enabled multi-currency setting in `project-scratch-def.json` and added `CurrencyTypes.json` file for importing currencies - due to Salesforce limitations, currency type data can't be created in test classes, so they are loaded into the scratch org within the build pipeline
- Added platform roll-up summary fields on `Account` that are used in `RollupIntegrationTests` to ensure that `Rollup` calculations for multi-currency fields match the logic used by the platform