### PR TITLE
V1.2.43 - Multi-currency rollup support & bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Create fast, scalable custom rollups driven by Custom Metadata in your Salesforc
 
 ### Package deployment options
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShMNAA0">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShPCAA0">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShMNAA0">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShPCAA0">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -948,7 +948,7 @@ You can use the included `Rollup Logger Plugin Parameter` CMDT record `Logging D
 
 ### Multi-Currency Orgs
 
-Untested. I would expect that MAX/SUM/MIN/AVERAGE operations would have undefined behavior (or, rather, incorrect conversions) if mixed currencies are present on the children items. This would be a good first issue for somebody looking to contribute!
+As of [v1.2.43](https://github.com/jamessimone/apex-rollup/releases/tag/v1.2.43), multi-currency orgs are now supported. Similar to how Salesforce's roll-up summary fields handle multi-currency, `Rollup` automatically converts currency values on child records to the parent record's currency when calculating the rollup value.  Currently, MIN, MAX and SUM operations are supported. // TODO - AVERAGE, FIRST and LAST are WIP
 
 ## Commit History
 

--- a/README.md
+++ b/README.md
@@ -948,7 +948,7 @@ You can use the included `Rollup Logger Plugin Parameter` CMDT record `Logging D
 
 ### Multi-Currency Orgs
 
-As of [v1.2.43](https://github.com/jamessimone/apex-rollup/releases/tag/v1.2.43), multi-currency orgs are now supported for the operations: MIN, MAX, SUM, AVERAGE, FIRST and LAST. `Rollup` automatically converts currency values on child records to the parent record's currency when calculating the rollup value, similar to how Salesforce's roll-up summary fields handle multi-currency,.
+As of [v1.2.43](https://github.com/jamessimone/apex-rollup/releases/tag/v1.2.43), multi-currency orgs are now supported for the operations: MIN, MAX, SUM, AVERAGE, FIRST and LAST. `Rollup` automatically converts currency values on child records to the parent record's currency when calculating the rollup value, similar to how Salesforce's roll-up summary fields handle multi-currency. Please note that if you use Advanced Currency Management in combination with the `DatedConversionRate` object, this package does not currently support mapping the dated conversion rates. Please [submit an issue](/issues) in the event that you need support for dated conversion rates!
 
 ## Commit History
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Create fast, scalable custom rollups driven by Custom Metadata in your Salesforc
 
 ### Package deployment options
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShPCAA0">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShPMAA0">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShPCAA0">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShPMAA0">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -948,7 +948,7 @@ You can use the included `Rollup Logger Plugin Parameter` CMDT record `Logging D
 
 ### Multi-Currency Orgs
 
-As of [v1.2.43](https://github.com/jamessimone/apex-rollup/releases/tag/v1.2.43), multi-currency orgs are now supported. Similar to how Salesforce's roll-up summary fields handle multi-currency, `Rollup` automatically converts currency values on child records to the parent record's currency when calculating the rollup value.  Currently, MIN, MAX and SUM operations are supported. // TODO - AVERAGE, FIRST and LAST are WIP
+As of [v1.2.43](https://github.com/jamessimone/apex-rollup/releases/tag/v1.2.43), multi-currency orgs are now supported for the operations: MIN, MAX, SUM, AVERAGE, FIRST and LAST. `Rollup` automatically converts currency values on child records to the parent record's currency when calculating the rollup value, similar to how Salesforce's roll-up summary fields handle multi-currency,.
 
 ## Commit History
 

--- a/config/data/CurrencyTypes.json
+++ b/config/data/CurrencyTypes.json
@@ -3,6 +3,17 @@
     {
       "attributes": {
         "type": "CurrencyType",
+        "referenceId": "ref0"
+      },
+      "IsoCode": "USD",
+      "DecimalPlaces": 2,
+      "ConversionRate": 1,
+      "IsActive":true,
+      "IsCorporate": true
+    },
+    {
+      "attributes": {
+        "type": "CurrencyType",
         "referenceId": "ref1"
       },
       "IsoCode": "EUR",

--- a/config/data/CurrencyTypes.json
+++ b/config/data/CurrencyTypes.json
@@ -1,0 +1,26 @@
+{
+  "records": [
+    {
+      "attributes": {
+        "type": "CurrencyType",
+        "referenceId": "ref1"
+      },
+      "IsoCode": "EUR",
+      "DecimalPlaces": 2,
+      "ConversionRate": 1.5,
+      "IsActive":true,
+      "IsCorporate": false
+    },
+    {
+      "attributes": {
+        "type": "CurrencyType",
+        "referenceId": "ref2"
+      },
+      "IsoCode": "JPY",
+      "DecimalPlaces": 4,
+      "ConversionRate": 0.0095,
+      "IsActive":true,
+      "IsCorporate": false
+    }
+  ]
+}

--- a/config/data/CurrencyTypes.json
+++ b/config/data/CurrencyTypes.json
@@ -7,7 +7,7 @@
       },
       "IsoCode": "EUR",
       "DecimalPlaces": 2,
-      "ConversionRate": 1.5,
+      "ConversionRate": 1.37,
       "IsActive":true,
       "IsCorporate": false
     },

--- a/config/data/CurrencyTypes.json
+++ b/config/data/CurrencyTypes.json
@@ -7,7 +7,7 @@
       },
       "IsoCode": "EUR",
       "DecimalPlaces": 2,
-      "ConversionRate": 1.37,
+      "ConversionRate": 0.85,
       "IsActive":true,
       "IsCorporate": false
     },
@@ -18,7 +18,7 @@
       },
       "IsoCode": "JPY",
       "DecimalPlaces": 4,
-      "ConversionRate": 0.0095,
+      "ConversionRate": 109.83,
       "IsActive":true,
       "IsCorporate": false
     }

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -3,6 +3,6 @@
   "edition": "Developer",
   "country": "US",
   "language": "en_US",
-  "features": [],
+  "features": ["MultiCurrency"],
   "hasSampleData": true
 }

--- a/extra-tests/classes/InvocableDrivenTests.cls
+++ b/extra-tests/classes/InvocableDrivenTests.cls
@@ -3,7 +3,7 @@ private class InvocableDrivenTests {
   @TestSetup
   static void setup() {
     upsert new RollupSettings__c(IsEnabled__c = true);
-    Account acc = new Account(Name = 'InvocableDrivenRollupTests');
+    Account acc = new Account(Name = InvocableDrivenTests.class.getName());
     insert acc;
   }
 

--- a/extra-tests/classes/RollupEvaluatorTests.cls
+++ b/extra-tests/classes/RollupEvaluatorTests.cls
@@ -924,4 +924,13 @@ private class RollupEvaluatorTests {
 
     System.assertEquals('TaskSubType != \'Email\' OR (NOT Subject LIKE \'Email\')', eval.getSafeQuery());
   }
+
+  @IsTest
+  static void shouldNotMangleValuesWithNameInThem() {
+    String whereClause = 'Name != \'oneName\'';
+
+    RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, ContactPointAddress.SObjectType);
+
+    System.assertEquals(false, eval.matches(new ContactPointAddress(Name = 'oneName')));
+  }
 }

--- a/extra-tests/classes/RollupFlowBulkProcessorTests.cls
+++ b/extra-tests/classes/RollupFlowBulkProcessorTests.cls
@@ -154,4 +154,30 @@ private class RollupFlowBulkProcessorTests {
     System.assertEquals(1, outputs.size());
     System.assertEquals(true, outputs[0].isSuccess);
   }
+
+  @IsTest
+  static void shouldNotThrowValidationErrorForHierarchyRollups() {
+    RollupFlowBulkProcessor.FlowInput input = new RollupFlowBulkProcessor.FlowInput();
+    input.recordsToRollup = new List<SObject>{ new Opportunity(Amount = 5) };
+    input.rollupContext = 'REFRESH';
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupOperation__c = 'SUM',
+        CalcItem__c = 'Opportunity',
+        LookupObject__c = 'Account',
+        RollupFieldOnCalcItem__c = 'Amount',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        UltimateParentLookup__c = 'ParentId',
+        RollupToUltimateParent__c = true
+      )
+    };
+
+    List<Rollup.FlowOutput>  outputs = RollupFlowBulkProcessor.addRollup(new List<RollupFlowBulkProcessor.FlowInput>{ input });
+
+    System.assertEquals(1, outputs.size());
+    System.assertEquals(true, outputs[0].isSuccess, outputs);
+  }
 }

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -693,6 +693,48 @@ private class RollupFullRecalcTests {
     System.assertEquals(cpas[1].Name, updatedAcc.Name, 'Should have taken first based on PreferenceRank');
   }
 
+  @IsTest
+  static void shouldRetainFullRecalcValuesForMutuallyExclusiveRollupsToSameField() {
+    Account acc = [SELECT Id, AnnualRevenue, Name FROM Account];
+
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
+      new ContactPointAddress(Name = 'oneName', ParentId = acc.Id, PreferenceRank = 3),
+      new ContactPointAddress(Name = 'twoName', ParentId = acc.Id, PreferenceRank = 1),
+      new ContactPointAddress(Name = 'threeName', ParentId = acc.Id, PreferenceRank = 2)
+    };
+    insert cpas;
+
+    List<Rollup__mdt> metas = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        RollupFieldOnCalcItem__c = 'PreferenceRank',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        LookupObject__c = 'Account',
+        RollupOperation__c = 'SUM',
+        CalcItemWhereClause__c = 'PreferenceRank = ' + cpas[0].PreferenceRank
+      ),
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        RollupFieldOnCalcItem__c = 'PreferenceRank',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        LookupObject__c = 'Account',
+        RollupOperation__c = 'SUM',
+        CalcItemWhereClause__c = 'Name != \'' + cpas[0].Name + '\''
+      )
+    };
+
+    Test.startTest();
+    Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_LWC.name());
+    Test.stopTest();
+
+    acc = [SELECT AnnualRevenue FROM Account WHERE Id = :acc.Id];
+    System.assertEquals(6, acc.AnnualRevenue, 'Full child amount should be included');
+  }
+
   // TODO - uncomment this and implement to work on fix for https://github.com/jamessimone/apex-rollup/issues/149
   // @IsTest
   // static void shouldCorrectlyResetParentValueFromSingularRecalcWithNoChildren() {

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -58,6 +58,33 @@ private class RollupFullRecalcTests {
   }
 
   @IsTest
+  static void shouldPerformFullRecalcWithHierarchy() {
+    Account acc = [SELECT Id FROM Account];
+    Account childAccount = new Account(Name = 'Hierarchy child', ParentId = acc.Id);
+    insert childAccount;
+    insert new ContactPointAddress(PreferenceRank = 500, ParentId = childAccount.Id, Name = 'One');
+
+    // ensure that a top-level child item linked only to the ultimate parent is included
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{ new ContactPointAddress(PreferenceRank = 1000, ParentId = acc.Id, Name = 'Two') };
+    insert cpas;
+
+    List<Rollup.FlowInput> flowInputs = RollupTestUtils.prepareFlowTest(cpas, 'REFRESH', 'SUM');
+    flowInputs[0].ultimateParentLookup = 'ParentId';
+    flowInputs[0].rollupToUltimateParent = true;
+
+    Test.startTest();
+    List<Rollup.FlowOutput> flowOutputs = Rollup.performRollup(flowInputs);
+    Test.stopTest();
+
+    System.assertEquals(1, flowOutputs.size(), 'Flow outputs were not provided');
+    System.assertEquals('SUCCESS', flowOutputs[0].message);
+    System.assertEquals(true, flowOutputs[0].isSuccess);
+
+    Account updatedAcc = [SELECT Id, AnnualRevenue FROM Account WHERE Id = :acc.Id];
+    System.assertEquals(1500, updatedAcc.AnnualRevenue, 'SUM REFRESH from flow should fully recalc');
+  }
+
+  @IsTest
   static void shouldBulkifyBatchFullRecalcsProperly() {
     Rollup.defaultControl = new RollupControl__mdt(MaxLookupRowsBeforeBatching__c = 1, IsRollupLoggingEnabled__c = true, BatchChunkSize__c = 2);
     Account acc = [SELECT Id FROM Account];

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -2,7 +2,6 @@
 private class RollupIntegrationTests {
   private static final Map<String, CurrencyType> CURRENCY_TYPES = loadCurrencyTypes();
 
-  // "Integration," in the sense that these include custom fields / objects that shouldn't be installed
   @TestSetup
   static void setup() {
     Account acc = new Account(Name = RollupIntegrationTests.class.getName());
@@ -1038,6 +1037,520 @@ private class RollupIntegrationTests {
     parent = [SELECT Id, Description, AnnualRevenue FROM Account WHERE Id = :parent.Id];
     System.assertEquals(2, parent.AnnualRevenue, 'Merge should have triggered rollup');
     System.assertEquals(rollupChildren[0].Name + ', ' + rollupChildren[1].Name, parent.Description, 'Second rollup should also have run');
+  }
+
+  @IsTest
+  static void shouldNotCrashForFalseMergePositive() {
+    Account acc = [SELECT Id, Name, Description, AnnualRevenue FROM Account];
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        RollupFieldOnCalcItem__c = 'PreferenceRank',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'MAX',
+        CalcItemWhereClause__c = 'Parent.Name = \'' + acc.Name + '\''
+      ),
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        RollupFieldOnCalcItem__c = 'Name',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'Description',
+        RollupOperation__c = 'CONCAT'
+      ),
+      // should be filtered out
+      new Rollup__mdt(
+        CalcItem__c = 'Account',
+        RollupFieldOnCalcItem__c = 'Name',
+        LookupObject__c = 'User',
+        LookupFieldOnCalcItem__c = 'OwnerId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'Username',
+        RollupOperation__c = 'CONCAT'
+      )
+    };
+
+    Test.startTest();
+    delete acc;
+    Test.stopTest();
+
+    System.assert(true, 'Should make it here');
+  }
+
+  @IsTest
+  static void shouldConcatDistinctOnUpdateEvenIfNewItemDoesNotMatch() {
+    Account acc = [SELECT Id, AccountNumber FROM Account];
+    acc.AccountNumber = 'test update';
+    update acc;
+
+    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = acc.AccountNumber);
+    insert cpa;
+
+    Rollup.records = new List<ContactPointAddress>{ cpa };
+    Rollup.oldRecordsMap = new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(Id = cpa.Id, Name = 'something else') };
+    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
+    Rollup.shouldRun = true;
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Name',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AccountNumber',
+        RollupOperation__c = 'CONCAT_DISTINCT',
+        CalcItem__c = 'ContactPointAddress',
+        CalcItemWhereClause__c = 'Name != \'' + acc.AccountNumber + '\''
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Account updatedAcc = [SELECT AccountNumber FROM Account];
+    System.assertEquals(null, updatedAcc.AccountNumber, 'CONCAT_DISTINCT AFTER_UPDATE should clear when updated item does not match and no other items');
+  }
+
+  @IsTest
+  static void shouldProperlyQueryNotLikeCountDistinct() {
+    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
+
+    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT not like');
+    insert new List<ContactPointAddress>{ cpa, new ContactPointAddress(ParentId = acc.Id, Name = 'Some other thing') };
+
+    Rollup.records = new List<ContactPointAddress>{ cpa };
+    Rollup.oldRecordsMap = new Map<Id, SObject>();
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.shouldRun = true;
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Id',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'COUNT_DISTINCT',
+        CalcItem__c = 'ContactPointAddress',
+        CalcItemWhereClause__c = 'Name NOT LIKE \'' + cpa.Name.substring(0, 6) + '%\''
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(1, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT should work with NOT LIKE');
+  }
+
+  @IsTest
+  static void shouldNotIncludeNullForCountDistinct() {
+    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
+
+    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT null PreferenceRank');
+    insert cpa;
+
+    Rollup.records = new List<ContactPointAddress>{ cpa };
+    Rollup.oldRecordsMap = new Map<Id, SObject>();
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.shouldRun = true;
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'PreferenceRank',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'COUNT_DISTINCT',
+        CalcItem__c = 'ContactPointAddress'
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(null, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT should ignore nulls');
+
+    Rollup.defaultControl = new RollupControl__mdt(ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.SYNCHRONOUS);
+    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
+    Rollup.records = new List<ContactPointAddress>{ cpa };
+    Rollup.oldRecordsMap = new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(PreferenceRank = 10) };
+    Rollup.runFromTrigger();
+
+    updatedAcc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(null, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT on update should ignore nulls');
+  }
+
+  @IsTest
+  static void shouldNotIncludePriorValueForCountDistinctId() {
+    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
+    acc.AnnualRevenue = 5;
+    update acc;
+
+    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT update');
+    insert new List<ContactPointAddress>{ cpa, new ContactPointAddress(ParentId = acc.Id, Name = 'Some other thing') };
+
+    Rollup.records = new List<ContactPointAddress>{ cpa };
+    Rollup.oldRecordsMap = new Map<Id, SObject>();
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.shouldRun = true;
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Id',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'COUNT_DISTINCT',
+        CalcItem__c = 'ContactPointAddress'
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(2, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT AFTER_INSERT should not overcount items');
+  }
+
+  @IsTest
+  static void shouldNotDoubleCountOldParentValueOnUpdate() {
+    Account acc = [SELECT Id, Name FROM Account];
+    acc.AnnualRevenue = 1;
+    update acc;
+
+    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'something else');
+    insert cpa;
+
+    Rollup.records = new List<ContactPointAddress>{ cpa };
+    Rollup.oldRecordsMap = new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(Id = cpa.Id, Name = acc.Name) };
+    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
+    Rollup.shouldRun = true;
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Name',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'COUNT_DISTINCT',
+        CalcItem__c = 'ContactPointAddress'
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(1, updatedAcc.AnnualRevenue, 'CONCAT_DISTINCT AFTER_UPDATE should clear when updated item does not match and no other items');
+  }
+
+  @IsTest
+  static void shouldClearParentValueIfNothingMatchesCountDistinct() {
+    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
+    acc.AnnualRevenue = 5;
+    update acc;
+
+    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT update');
+    insert new List<ContactPointAddress>{ cpa, new ContactPointAddress(ParentId = acc.Id, Name = 'Some other thing') };
+
+    Rollup.records = new List<ContactPointAddress>{ cpa };
+    Rollup.oldRecordsMap = new Map<Id, SObject>();
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.shouldRun = true;
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Name',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'COUNT_DISTINCT',
+        CalcItem__c = 'ContactPointAddress'
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(2, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT AFTER_INSERT should not overcount items');
+  }
+
+  @IsTest
+  static void shouldCountDistinctOnUpdateEvenIfNewItemDoesNotMatch() {
+    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
+    acc.AnnualRevenue = 1;
+    update acc;
+
+    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT update', PreferenceRank = 0);
+    insert cpa;
+
+    Rollup.records = new List<ContactPointAddress>{ cpa };
+    Rollup.oldRecordsMap = new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(Id = cpa.Id, PreferenceRank = 1) };
+    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
+    Rollup.shouldRun = true;
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Name',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'COUNT_DISTINCT',
+        CalcItem__c = 'ContactPointAddress',
+        CalcItemWhereClause__c = 'PreferenceRank > 0'
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(0, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT AFTER_UPDATE should clear when updated item does not match and no other items');
+  }
+
+  @IsTest
+  static void shouldRunSyncWhenFlaggedOnRollupLimit() {
+    Account acc = [SELECT Id FROM Account];
+
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
+      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 1, Name = 'oneCpa'),
+      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 1, Name = 'twoCpa')
+    };
+    insert cpas;
+
+    Rollup.records = cpas;
+    Rollup.shouldRun = true;
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = 'Synchronous Rollup');
+
+    // specifically do NOT wrap in Test.startTest() / Test.stopTest() - we need to ensure this happened synchronously
+    Rollup.countFromApex(ContactPointAddress.PreferenceRank, ContactPointAddress.ParentId, Account.Id, Account.AnnualRevenue, Account.SObjectType).runCalc();
+
+    acc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(2, acc.AnnualRevenue, 'COUNT AFTER_INSERT should add when field is populated sync calc');
+  }
+
+  @IsTest
+  static void shouldPartiallyDeferRollupCalculationWhenOverLimits() {
+    Rollup.specificControl = new RollupControl__mdt(ShouldAbortRun__c = true);
+    Account acc = [SELECT Id, OwnerId FROM Account];
+    Account secondParent = new Account(Name = 'Second parent');
+    insert secondParent;
+
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
+      new ContactPointAddress(ParentId = acc.Id, Name = 'One', PreferenceRank = 1),
+      new ContactPointAddress(ParentId = secondParent.Id, Name = 'Two', PreferenceRank = 1)
+    };
+    insert cpas;
+
+    Rollup.defaultControl = new RollupControl__mdt(BatchChunkSize__c = 1, MaxRollupRetries__c = 1, MaxNumberOfQueries__c = 2, IsRollupLoggingEnabled__c = true);
+    // start as synchronous rollup to allow for one deferral
+    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = 'Synchronous Rollup');
+
+    Rollup.shouldRun = true;
+    Rollup.records = cpas;
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        RollupFieldOnCalcItem__c = 'PreferenceRank',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupObject__c = 'Account',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        // use one of the full recalc operations - one SOQL per parent object will get us to defer
+        // between lookup items
+        RollupOperation__c = 'AVERAGE'
+      )
+    };
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    // validate that queueable ran in addition to sync job
+    System.assertEquals('Completed', [SELECT Status FROM AsyncApexJob WHERE JobType = 'Queueable' LIMIT 1]?.Status);
+    List<Account> updatedAccounts = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(2, updatedAccounts.size(), 'Both parent items should have been updated!');
+
+    for (Account updatedAcc : updatedAccounts) {
+      System.assertEquals(1, updatedAcc.AnnualRevenue, 'Average annual revenue should have been set for both records!');
+    }
+  }
+
+  @IsTest
+  static void shouldRunDirectlyFromApex() {
+    Account acc = [SELECT Id FROM Account];
+
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
+      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 5),
+      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 10)
+    };
+
+    Rollup.records = cpas;
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'PreferenceRank',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'SUM',
+        CalcItem__c = 'ContactPointAddress'
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromApex(cpas, TriggerOperation.AFTER_INSERT);
+    Test.stopTest();
+
+    acc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(15, acc.AnnualRevenue);
+  }
+
+  @IsTest
+  static void shouldDeferUpdateWhenMaxParentRowsLessThanCurrentUpdateRows() {
+    Account acc = [SELECT Id FROM Account];
+    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 50, Name = 'MaxParentRows');
+    insert cpa;
+
+    Rollup.records = new List<ContactPointAddress>{ cpa };
+    Rollup.shouldRun = true;
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    RollupAsyncProcessor.shouldRunAsBatch = true;
+    Rollup.defaultControl = new RollupControl__mdt(MaxParentRowsUpdatedAtOnce__c = 0, BatchChunkSize__c = 1, IsRollupLoggingEnabled__c = true);
+
+    Test.startTest();
+    Rollup.sumFromApex(ContactPointAddress.PreferenceRank, ContactPointAddress.ParentId, Account.Id, Account.AnnualRevenue, Account.SObjectType).runCalc();
+    Test.stopTest();
+
+    acc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(50, acc.AnnualRevenue, 'Account should have been updated since the mock is not used async');
+  }
+
+  @IsTest
+  static void shouldThrowExceptionWhenTryingToOperateOnDisallowedFieldTypes() {
+    Account acc = [SELECT Id FROM Account];
+    Rollup.records = new List<Task>{ new Task(ActivityDate = System.today(), WhatId = acc.Id) };
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.shouldRun = true;
+
+    Exception ex;
+    try {
+      Test.startTest();
+      Rollup.maxFromApex(Task.ActivityDate, Task.WhatId, Account.Id, Account.BillingAddress, Account.SObjectType).runCalc();
+      Test.stopTest();
+    } catch (Exception e) {
+      ex = e;
+    }
+
+    System.assertNotEquals(null, ex);
+    System.assertEquals('Field: BillingAddress of type: ADDRESS specified invalid for rollup operation', ex.getMessage());
+  }
+
+  /** Invocable integration tests */
+
+  @IsTest
+  static void shouldTryToUpsertFromFlow() {
+    Account acc = [SELECT Id FROM Account];
+
+    ContactPointAddress cpa = new ContactPointAddress(PreferenceRank = 500, ParentId = acc.Id, Name = 'Upsert Flow Test');
+    insert cpa; // aping an after-insert action in Flow
+
+    List<ContactPointAddress> cpas = [SELECT Id, ParentId, CreatedDate, LastModifiedDate, PreferenceRank FROM ContactPointAddress];
+
+    List<Rollup.FlowInput> flowInputs = RollupTestUtils.prepareFlowTest(cpas, 'UPSERT', 'SUM');
+    flowInputs[0].oldRecordsToRollup = new List<ContactPointAddress>{ null }; // sad but true - this is what flow passes for {!$Record__Prior} on upsert
+
+    Test.startTest();
+    List<Rollup.FlowOutput> flowOutputs = Rollup.performRollup(flowInputs);
+    Test.stopTest();
+
+    System.assertEquals(1, flowOutputs.size(), 'Flow outputs were not provided');
+    System.assertEquals('SUCCESS', flowOutputs[0].message);
+    System.assertEquals(true, flowOutputs[0].isSuccess);
+
+    Account updatedAcc = [SELECT Id, AnnualRevenue FROM Account];
+    System.assertEquals(cpas[0].PreferenceRank, updatedAcc.AnnualRevenue, 'pseudo-upsert from flow should act like insert for PreferenceRank');
+  }
+
+  @IsTest
+  static void shouldFilterNonMatchingRollupsOutOfBatch() {
+    Contact con = new Contact(FirstName = 'Something', LastName = 'Required');
+    insert con;
+    RollupAsyncProcessor batchProcessor = new RollupAsyncProcessor(
+      new Set<Id>{ con.Id },
+      Contact.FirstName,
+      Contact.Id,
+      Contact.Id,
+      Contact.FirstName,
+      Campaign.SObjectType,
+      Contact.SObjectType,
+      Rollup.Op.CONCAT,
+      null,
+      Rollup.InvocationPoint.FROM_APEX,
+      RollupControl__mdt.getInstance('Org_Defaults'),
+      new Rollup__mdt(
+        CalcItem__c = 'Contact',
+        RollupFieldOnCalcItem__c = 'FirstName',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupObject__c = 'Campaign',
+        RollupFieldOnLookupObject__c = 'FirstName',
+        LookupFieldOnLookupObject__c = 'Id'
+      )
+    );
+    RollupAsyncProcessor conductor = new RollupAsyncProcessor(Rollup.InvocationPoint.FROM_APEX, new List<Contact>{ con }, new Map<Id, SObject>());
+    conductor.rollups.add(batchProcessor);
+    Test.startTest();
+    Database.executeBatch(conductor);
+    Test.stopTest();
+
+    System.assert(true, 'Should make it here');
+  }
+
+  /** Schedulable tests */
+  @IsTest
+  static void shouldThrowExceptionForBadQuery() {
+    // it's a date field - you tell ME why this query is invalid!
+    String veryBadQuery = 'SELECT MAX(ActivityDate) FROM Task';
+
+    Exception ex;
+    try {
+      Rollup.schedule('Test bad query', '0 0 0 0 0', veryBadQuery, 'Account', null);
+    } catch (Exception e) {
+      ex = e;
+    }
+
+    System.assertNotEquals(null, ex);
+  }
+
+  @IsTest
+  static void shouldScheduleSuccessfullyForGoodQuery() {
+    String goodQuery = 'SELECT Id, Name FROM ContactPointAddress WHERE CreatedDate > YESTERDAY';
+
+    String jobId = Rollup.schedule('Test good query' + System.now(), '0 0 0 * * ?', goodQuery, 'ContactPointAddress', null);
+
+    System.assertNotEquals(null, jobId);
   }
 
   private static Map<String, CurrencyType> loadCurrencyTypes() {

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -381,7 +381,7 @@ private class RollupIntegrationTests {
 
     Rollup.rollupMetadata = new List<Rollup__mdt>{
       new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'CurrencyIsoCode',
+        RollupFieldOnCalcItem__c = 'Id',
         LookupObject__c = 'Account',
         LookupFieldOnCalcItem__c = 'AccountId',
         LookupFieldOnLookupObject__c = 'Id',
@@ -400,18 +400,18 @@ private class RollupIntegrationTests {
     Test.stopTest();
 
     Decimal firstAmount;
-    String firstOpportunityCurrencyIsoCode;
+    Id firstOpportunityId;
     List<Opportunity> opportunities = [SELECT Id, convertCurrency(Amount) ConvertedAmount, CurrencyIsoCode FROM Opportunity];
     for (Opportunity opp : opportunities) {
       Decimal oppConvertedAmount = (Decimal) opp.get('ConvertedAmount');
       if (firstAmount == null || oppConvertedAmount < firstAmount) {
         firstAmount = oppConvertedAmount;
-        firstOpportunityCurrencyIsoCode = opp.CurrencyIsoCode;
+        firstOpportunityId = opp.Id;
       }
     }
 
     acc = [SELECT Id, Name FROM Account];
-    System.assertEquals(firstOpportunityCurrencyIsoCode, acc.Name, 'Should have taken first based on multi-currency Amount! Records: ' + opportunities);
+    System.assertEquals(firstOpportunityId, acc.Name, 'Should have taken first based on multi-currency Amount! Records: ' + opportunities);
   }
 
   @isTest
@@ -434,7 +434,7 @@ private class RollupIntegrationTests {
 
     Rollup.rollupMetadata = new List<Rollup__mdt>{
       new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'CurrencyIsoCode',
+        RollupFieldOnCalcItem__c = 'Id',
         LookupObject__c = 'Account',
         LookupFieldOnCalcItem__c = 'AccountId',
         LookupFieldOnLookupObject__c = 'Id',
@@ -453,18 +453,18 @@ private class RollupIntegrationTests {
     Test.stopTest();
 
     Decimal lastAmount;
-    String lastOpportunityCurrencyIsoCode;
+    Id lastOpportunityId;
     List<Opportunity> opportunities = [SELECT Id, convertCurrency(Amount) ConvertedAmount, CurrencyIsoCode FROM Opportunity];
     for (Opportunity opp : opportunities) {
       Decimal oppConvertedAmount = (Decimal) opp.get('ConvertedAmount');
       if (lastAmount == null || oppConvertedAmount > lastAmount) {
         lastAmount = oppConvertedAmount;
-        lastOpportunityCurrencyIsoCode = opp.CurrencyIsoCode;
+        lastOpportunityId = opp.Id;
       }
     }
 
     acc = [SELECT Id, Name FROM Account];
-    System.assertEquals(lastOpportunityCurrencyIsoCode, acc.Name, 'Should have taken last based on multi-currency Amount! Records: ' + opportunities);
+    System.assertEquals(lastOpportunityId, acc.Name, 'Should have taken last based on multi-currency Amount! Records: ' + opportunities);
   }
 
   @isTest

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -1,5 +1,8 @@
 @IsTest
 private class RollupIntegrationTests {
+  private static final Map<String, CurrencyType> CURRENCY_TYPES = loadCurrencyTypes();
+
+  // "Integration," in the sense that these include custom fields / objects that shouldn't be installed
   @TestSetup
   static void setup() {
     Account acc = new Account(Name = 'RollupIntegrationTests');
@@ -157,7 +160,193 @@ private class RollupIntegrationTests {
     System.assertEquals(45 / 3, updatedParent.Engagement_Rollup__c, 'Average should be calculated based off of matching items');
   }
 
-  @IsTest
+  @isTest
+  static void shouldCorrectlyRollupMaxForMultiCurrency() {
+    Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
+    System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
+    System.assertEquals('USD', acc.CurrencyIsoCode, 'Test has started under the wrong conditions!');
+    acc.CurrencyIsoCode = 'EUR';
+    update acc;
+
+    Opportunity usdOpp = [
+      SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountIdText__c, AccountId
+      FROM Opportunity
+      WHERE CurrencyIsoCode = 'USD'
+      LIMIT 1
+    ];
+
+    Opportunity eurOpp = usdOpp.clone(false, true);
+    eurOpp.CurrencyIsoCode = 'EUR';
+    Opportunity jpyOpp = eurOpp.clone(false, true);
+    jpyOpp.CurrencyIsoCode = 'JPY';
+    insert new List<Opportunity>{ eurOpp, jpyOpp };
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Amount',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'SUM',
+        IsFullRecordSet__c = true,
+        CalcItem__c = 'Opportunity'
+      )
+    };
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.records = new List<Opportunity>{ usdOpp, eurOpp, jpyOpp };
+    Rollup.shouldRun = true;
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Decimal expectedMaxAmount;
+    for (Opportunity opp : [SELECT convertCurrency(Amount) ConvertedAmount FROM Opportunity WHERE Id IN :Rollup.records]) {
+      Decimal oppConvertedAmount = (Decimal) opp.get('ConvertedAmount');
+      if (expectedMaxAmount == null || oppConvertedAmount > expectedMaxAmount) {
+        expectedMaxAmount = oppConvertedAmount;
+      }
+    }
+    expectedMaxAmount *= CURRENCY_TYPES.get(acc.CurrencyIsoCode).ConversionRate;
+
+    acc = [SELECT Id, CurrencyIsoCode, AnnualRevenue, MaxAmountRollupSummary__c FROM Account];
+    System.assertEquals(
+      expectedMaxAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      acc.MaxAmountRollupSummary__c.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      'Calculated TotalRevenue and rollup-summary field MaxAmountRollupSummary__c should match!'
+    );
+    System.assertEquals(
+      expectedMaxAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      'Multi-currency MAX rollup not calculated correctly!'
+    );
+  }
+
+  @isTest
+  static void shouldCorrectlyRollupMinForMultiCurrency() {
+    Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
+    System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
+    System.assertEquals('USD', acc.CurrencyIsoCode, 'Test has started under the wrong conditions!');
+    acc.CurrencyIsoCode = 'EUR';
+    update acc;
+
+    Opportunity usdOpp = [
+      SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountIdText__c, AccountId
+      FROM Opportunity
+      WHERE CurrencyIsoCode = 'USD'
+      LIMIT 1
+    ];
+
+    Opportunity eurOpp = usdOpp.clone(false, true);
+    eurOpp.CurrencyIsoCode = 'EUR';
+    Opportunity jpyOpp = eurOpp.clone(false, true);
+    jpyOpp.CurrencyIsoCode = 'JPY';
+    insert new List<Opportunity>{ eurOpp, jpyOpp };
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Amount',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'SUM',
+        IsFullRecordSet__c = true,
+        CalcItem__c = 'Opportunity'
+      )
+    };
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.records = new List<Opportunity>{ usdOpp, eurOpp, jpyOpp };
+    Rollup.shouldRun = true;
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Decimal expectedMinAmount;
+    for (Opportunity opp : [SELECT convertCurrency(Amount) ConvertedAmount FROM Opportunity WHERE Id IN :Rollup.records]) {
+      Decimal oppConvertedAmount = (Decimal) opp.get('ConvertedAmount');
+      if (expectedMinAmount == null || oppConvertedAmount < expectedMinAmount) {
+        expectedMinAmount = oppConvertedAmount;
+      }
+    }
+    expectedMinAmount *= CURRENCY_TYPES.get(acc.CurrencyIsoCode).ConversionRate;
+
+    acc = [SELECT Id, CurrencyIsoCode, AnnualRevenue, MinAmountRollupSummary__c FROM Account];
+    System.assertEquals(
+      expectedMinAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      acc.MinAmountRollupSummary__c.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      'Calculated TotalRevenue and rollup-summary field MinAmountRollupSummary__c should match!'
+    );
+    System.assertEquals(
+      expectedMinAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      'Multi-currency MIN rollup not calculated correctly!'
+    );
+  }
+
+  @isTest
+  static void shouldCorrectlyRollupSumForMultiCurrency() {
+    Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
+    System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
+    System.assertEquals('USD', acc.CurrencyIsoCode, 'Test has started under the wrong conditions!');
+    acc.CurrencyIsoCode = 'EUR';
+    update acc;
+
+    Opportunity usdOpp = [
+      SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountIdText__c, AccountId
+      FROM Opportunity
+      WHERE CurrencyIsoCode = 'USD'
+      LIMIT 1
+    ];
+
+    Opportunity eurOpp = usdOpp.clone(false, true);
+    eurOpp.CurrencyIsoCode = 'EUR';
+    Opportunity jpyOpp = eurOpp.clone(false, true);
+    jpyOpp.CurrencyIsoCode = 'JPY';
+    insert new List<Opportunity>{ eurOpp, jpyOpp };
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Amount',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'SUM',
+        IsFullRecordSet__c = true,
+        CalcItem__c = 'Opportunity'
+      )
+    };
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.records = new List<Opportunity>{ usdOpp, eurOpp, jpyOpp };
+    Rollup.shouldRun = true;
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Decimal expectedSumAmount = 0;
+    for (Opportunity opp : [SELECT convertCurrency(Amount) ConvertedAmount FROM Opportunity WHERE Id IN :Rollup.records]) {
+      expectedSumAmount += (Decimal) opp.get('ConvertedAmount');
+    }
+    expectedSumAmount *= CURRENCY_TYPES.get(acc.CurrencyIsoCode).ConversionRate;
+
+    acc = [SELECT Id, CurrencyIsoCode, AnnualRevenue, SumAmountRollupSummary__c FROM Account];
+    System.assertEquals(
+      expectedSumAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      acc.SumAmountRollupSummary__c.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      'Calculated TotalRevenue and rollup-summary field SumAmountRollupSummary__c should match!'
+    );
+    System.assertEquals(
+      expectedSumAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      'Multi-currency SUM rollup not calculated correctly!'
+    );
+  }
+
+  @isTest
   static void shouldSupportCustomObjectsWhenRollupTriggeredFromParent() {
     ParentApplication__c parentApp = new ParentApplication__c(Name = 'Custom Object Parent App');
     insert parentApp;
@@ -728,517 +917,11 @@ private class RollupIntegrationTests {
     System.assertEquals(rollupChildren[0].Name + ', ' + rollupChildren[1].Name, parent.Description, 'Second rollup should also have run');
   }
 
-  @IsTest
-  static void shouldNotCrashForFalseMergePositive() {
-    Account acc = [SELECT Id, Name, Description, AnnualRevenue FROM Account];
-
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        CalcItem__c = 'ContactPointAddress',
-        RollupFieldOnCalcItem__c = 'PreferenceRank',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'MAX',
-        CalcItemWhereClause__c = 'Parent.Name = \'' + acc.Name + '\''
-      ),
-      new Rollup__mdt(
-        CalcItem__c = 'ContactPointAddress',
-        RollupFieldOnCalcItem__c = 'Name',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'Description',
-        RollupOperation__c = 'CONCAT'
-      ),
-      // should be filtered out
-      new Rollup__mdt(
-        CalcItem__c = 'Account',
-        RollupFieldOnCalcItem__c = 'Name',
-        LookupObject__c = 'User',
-        LookupFieldOnCalcItem__c = 'OwnerId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'Username',
-        RollupOperation__c = 'CONCAT'
-      )
-    };
-
-    Test.startTest();
-    delete acc;
-    Test.stopTest();
-
-    System.assert(true, 'Should make it here');
-  }
-
-  @IsTest
-  static void shouldConcatDistinctOnUpdateEvenIfNewItemDoesNotMatch() {
-    Account acc = [SELECT Id, AccountNumber FROM Account];
-    acc.AccountNumber = 'test update';
-    update acc;
-
-    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = acc.AccountNumber);
-    insert cpa;
-
-    Rollup.records = new List<ContactPointAddress>{ cpa };
-    Rollup.oldRecordsMap = new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(Id = cpa.Id, Name = 'something else') };
-    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
-    Rollup.shouldRun = true;
-
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'Name',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AccountNumber',
-        RollupOperation__c = 'CONCAT_DISTINCT',
-        CalcItem__c = 'ContactPointAddress',
-        CalcItemWhereClause__c = 'Name != \'' + acc.AccountNumber + '\''
-      )
-    };
-
-    Test.startTest();
-    Rollup.runFromTrigger();
-    Test.stopTest();
-
-    Account updatedAcc = [SELECT AccountNumber FROM Account];
-    System.assertEquals(null, updatedAcc.AccountNumber, 'CONCAT_DISTINCT AFTER_UPDATE should clear when updated item does not match and no other items');
-  }
-
-  @IsTest
-  static void shouldProperlyQueryNotLikeCountDistinct() {
-    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
-
-    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT not like');
-    insert new List<ContactPointAddress>{ cpa, new ContactPointAddress(ParentId = acc.Id, Name = 'Some other thing') };
-
-    Rollup.records = new List<ContactPointAddress>{ cpa };
-    Rollup.oldRecordsMap = new Map<Id, SObject>();
-    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    Rollup.shouldRun = true;
-
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'Id',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'COUNT_DISTINCT',
-        CalcItem__c = 'ContactPointAddress',
-        CalcItemWhereClause__c = 'Name NOT LIKE \'' + cpa.Name.substring(0, 6) + '%\''
-      )
-    };
-
-    Test.startTest();
-    Rollup.runFromTrigger();
-    Test.stopTest();
-
-    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(1, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT should work with NOT LIKE');
-  }
-
-  @IsTest
-  static void shouldNotIncludeNullForCountDistinct() {
-    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
-
-    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT null PreferenceRank');
-    insert cpa;
-
-    Rollup.records = new List<ContactPointAddress>{ cpa };
-    Rollup.oldRecordsMap = new Map<Id, SObject>();
-    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    Rollup.shouldRun = true;
-
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'PreferenceRank',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'COUNT_DISTINCT',
-        CalcItem__c = 'ContactPointAddress'
-      )
-    };
-
-    Test.startTest();
-    Rollup.runFromTrigger();
-    Test.stopTest();
-
-    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(null, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT should ignore nulls');
-
-    Rollup.defaultControl = new RollupControl__mdt(ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.SYNCHRONOUS);
-    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
-    Rollup.records = new List<ContactPointAddress>{ cpa };
-    Rollup.oldRecordsMap = new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(PreferenceRank = 10) };
-    Rollup.runFromTrigger();
-
-    updatedAcc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(null, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT on update should ignore nulls');
-  }
-
-  @IsTest
-  static void shouldNotIncludePriorValueForCountDistinctId() {
-    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
-    acc.AnnualRevenue = 5;
-    update acc;
-
-    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT update');
-    insert new List<ContactPointAddress>{ cpa, new ContactPointAddress(ParentId = acc.Id, Name = 'Some other thing') };
-
-    Rollup.records = new List<ContactPointAddress>{ cpa };
-    Rollup.oldRecordsMap = new Map<Id, SObject>();
-    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    Rollup.shouldRun = true;
-
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'Id',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'COUNT_DISTINCT',
-        CalcItem__c = 'ContactPointAddress'
-      )
-    };
-
-    Test.startTest();
-    Rollup.runFromTrigger();
-    Test.stopTest();
-
-    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(2, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT AFTER_INSERT should not overcount items');
-  }
-
-  @IsTest
-  static void shouldNotDoubleCountOldParentValueOnUpdate() {
-    Account acc = [SELECT Id, Name FROM Account];
-    acc.AnnualRevenue = 1;
-    update acc;
-
-    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'something else');
-    insert cpa;
-
-    Rollup.records = new List<ContactPointAddress>{ cpa };
-    Rollup.oldRecordsMap = new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(Id = cpa.Id, Name = acc.Name) };
-    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
-    Rollup.shouldRun = true;
-
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'Name',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'COUNT_DISTINCT',
-        CalcItem__c = 'ContactPointAddress'
-      )
-    };
-
-    Test.startTest();
-    Rollup.runFromTrigger();
-    Test.stopTest();
-
-    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(1, updatedAcc.AnnualRevenue, 'CONCAT_DISTINCT AFTER_UPDATE should clear when updated item does not match and no other items');
-  }
-
-  @IsTest
-  static void shouldClearParentValueIfNothingMatchesCountDistinct() {
-    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
-    acc.AnnualRevenue = 5;
-    update acc;
-
-    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT update');
-    insert new List<ContactPointAddress>{ cpa, new ContactPointAddress(ParentId = acc.Id, Name = 'Some other thing') };
-
-    Rollup.records = new List<ContactPointAddress>{ cpa };
-    Rollup.oldRecordsMap = new Map<Id, SObject>();
-    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    Rollup.shouldRun = true;
-
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'Name',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'COUNT_DISTINCT',
-        CalcItem__c = 'ContactPointAddress'
-      )
-    };
-
-    Test.startTest();
-    Rollup.runFromTrigger();
-    Test.stopTest();
-
-    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(2, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT AFTER_INSERT should not overcount items');
-  }
-
-  @IsTest
-  static void shouldCountDistinctOnUpdateEvenIfNewItemDoesNotMatch() {
-    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
-    acc.AnnualRevenue = 1;
-    update acc;
-
-    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT update', PreferenceRank = 0);
-    insert cpa;
-
-    Rollup.records = new List<ContactPointAddress>{ cpa };
-    Rollup.oldRecordsMap = new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(Id = cpa.Id, PreferenceRank = 1) };
-    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
-    Rollup.shouldRun = true;
-
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'Name',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'COUNT_DISTINCT',
-        CalcItem__c = 'ContactPointAddress',
-        CalcItemWhereClause__c = 'PreferenceRank > 0'
-      )
-    };
-
-    Test.startTest();
-    Rollup.runFromTrigger();
-    Test.stopTest();
-
-    Account updatedAcc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(0, updatedAcc.AnnualRevenue, 'COUNT_DISTINCT AFTER_UPDATE should clear when updated item does not match and no other items');
-  }
-
-  @IsTest
-  static void shouldRunSyncWhenFlaggedOnRollupLimit() {
-    Account acc = [SELECT Id FROM Account];
-
-    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
-      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 1, Name = 'oneCpa'),
-      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 1, Name = 'twoCpa')
-    };
-    insert cpas;
-
-    Rollup.records = cpas;
-    Rollup.shouldRun = true;
-    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = 'Synchronous Rollup');
-
-    // specifically do NOT wrap in Test.startTest() / Test.stopTest() - we need to ensure this happened synchronously
-    Rollup.countFromApex(ContactPointAddress.PreferenceRank, ContactPointAddress.ParentId, Account.Id, Account.AnnualRevenue, Account.SObjectType).runCalc();
-
-    acc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(2, acc.AnnualRevenue, 'COUNT AFTER_INSERT should add when field is populated sync calc');
-  }
-
-  @IsTest
-  static void shouldPartiallyDeferRollupCalculationWhenOverLimits() {
-    Rollup.specificControl = new RollupControl__mdt(ShouldAbortRun__c = true);
-    Account acc = [SELECT Id, OwnerId FROM Account];
-    Account secondParent = new Account(Name = 'Second parent');
-    insert secondParent;
-
-    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
-      new ContactPointAddress(ParentId = acc.Id, Name = 'One', PreferenceRank = 1),
-      new ContactPointAddress(ParentId = secondParent.Id, Name = 'Two', PreferenceRank = 1)
-    };
-    insert cpas;
-
-    Rollup.defaultControl = new RollupControl__mdt(BatchChunkSize__c = 1, MaxRollupRetries__c = 1, MaxNumberOfQueries__c = 2, IsRollupLoggingEnabled__c = true);
-    // start as synchronous rollup to allow for one deferral
-    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = 'Synchronous Rollup');
-
-    Rollup.shouldRun = true;
-    Rollup.records = cpas;
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        CalcItem__c = 'ContactPointAddress',
-        RollupFieldOnCalcItem__c = 'PreferenceRank',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupObject__c = 'Account',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        // use one of the full recalc operations - one SOQL per parent object will get us to defer
-        // between lookup items
-        RollupOperation__c = 'AVERAGE'
-      )
-    };
-    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-
-    Test.startTest();
-    Rollup.runFromTrigger();
-    Test.stopTest();
-
-    // validate that queueable ran in addition to sync job
-    System.assertEquals('Completed', [SELECT Status FROM AsyncApexJob WHERE JobType = 'Queueable' LIMIT 1]?.Status);
-    List<Account> updatedAccounts = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(2, updatedAccounts.size(), 'Both parent items should have been updated!');
-
-    for (Account updatedAcc : updatedAccounts) {
-      System.assertEquals(1, updatedAcc.AnnualRevenue, 'Average annual revenue should have been set for both records!');
+  private static Map<String, CurrencyType> loadCurrencyTypes() {
+    Map<String, CurrencyType> CURRENCY_TYPES = new Map<String, CurrencyType>();
+    for (CurrencyType currencyType : [SELECT IsoCode, ConversionRate, DecimalPlaces FROM CurrencyType WHERE IsActive = TRUE]) {
+      CURRENCY_TYPES.put(currencyType.IsoCode, currencyType);
     }
-  }
-
-  @IsTest
-  static void shouldRunDirectlyFromApex() {
-    Account acc = [SELECT Id FROM Account];
-
-    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
-      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 5),
-      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 10)
-    };
-
-    Rollup.records = cpas;
-    Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(
-        RollupFieldOnCalcItem__c = 'PreferenceRank',
-        LookupObject__c = 'Account',
-        LookupFieldOnCalcItem__c = 'ParentId',
-        LookupFieldOnLookupObject__c = 'Id',
-        RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'SUM',
-        CalcItem__c = 'ContactPointAddress'
-      )
-    };
-
-    Test.startTest();
-    Rollup.runFromApex(cpas, TriggerOperation.AFTER_INSERT);
-    Test.stopTest();
-
-    acc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(15, acc.AnnualRevenue);
-  }
-
-  @IsTest
-  static void shouldDeferUpdateWhenMaxParentRowsLessThanCurrentUpdateRows() {
-    Account acc = [SELECT Id FROM Account];
-    ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 50, Name = 'MaxParentRows');
-    insert cpa;
-
-    Rollup.records = new List<ContactPointAddress>{ cpa };
-    Rollup.shouldRun = true;
-    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    RollupAsyncProcessor.shouldRunAsBatch = true;
-    Rollup.defaultControl = new RollupControl__mdt(MaxParentRowsUpdatedAtOnce__c = 0, BatchChunkSize__c = 1, IsRollupLoggingEnabled__c = true);
-
-    Test.startTest();
-    Rollup.sumFromApex(ContactPointAddress.PreferenceRank, ContactPointAddress.ParentId, Account.Id, Account.AnnualRevenue, Account.SObjectType).runCalc();
-    Test.stopTest();
-
-    acc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(50, acc.AnnualRevenue, 'Account should have been updated since the mock is not used async');
-  }
-
-  @IsTest
-  static void shouldThrowExceptionWhenTryingToOperateOnDisallowedFieldTypes() {
-    Account acc = [SELECT Id FROM Account];
-    Rollup.records = new List<Task>{ new Task(ActivityDate = System.today(), WhatId = acc.Id) };
-    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    Rollup.shouldRun = true;
-
-    Exception ex;
-    try {
-      Test.startTest();
-      Rollup.maxFromApex(Task.ActivityDate, Task.WhatId, Account.Id, Account.BillingAddress, Account.SObjectType).runCalc();
-      Test.stopTest();
-    } catch (Exception e) {
-      ex = e;
-    }
-
-    System.assertNotEquals(null, ex);
-    System.assertEquals('Field: BillingAddress of type: ADDRESS specified invalid for rollup operation', ex.getMessage());
-  }
-
-  /** Invocable integration tests */
-
-  @IsTest
-  static void shouldTryToUpsertFromFlow() {
-    Account acc = [SELECT Id FROM Account];
-
-    ContactPointAddress cpa = new ContactPointAddress(PreferenceRank = 500, ParentId = acc.Id, Name = 'Upsert Flow Test');
-    insert cpa; // aping an after-insert action in Flow
-
-    List<ContactPointAddress> cpas = [SELECT Id, ParentId, CreatedDate, LastModifiedDate, PreferenceRank FROM ContactPointAddress];
-
-    List<Rollup.FlowInput> flowInputs = RollupTestUtils.prepareFlowTest(cpas, 'UPSERT', 'SUM');
-    flowInputs[0].oldRecordsToRollup = new List<ContactPointAddress>{ null }; // sad but true - this is what flow passes for {!$Record__Prior} on upsert
-
-    Test.startTest();
-    List<Rollup.FlowOutput> flowOutputs = Rollup.performRollup(flowInputs);
-    Test.stopTest();
-
-    System.assertEquals(1, flowOutputs.size(), 'Flow outputs were not provided');
-    System.assertEquals('SUCCESS', flowOutputs[0].message);
-    System.assertEquals(true, flowOutputs[0].isSuccess);
-
-    Account updatedAcc = [SELECT Id, AnnualRevenue FROM Account];
-    System.assertEquals(cpas[0].PreferenceRank, updatedAcc.AnnualRevenue, 'pseudo-upsert from flow should act like insert for PreferenceRank');
-  }
-
-  @IsTest
-  static void shouldFilterNonMatchingRollupsOutOfBatch() {
-    Contact con = new Contact(FirstName = 'Something', LastName = 'Required');
-    insert con;
-    RollupAsyncProcessor batchProcessor = new RollupAsyncProcessor(
-      new Set<Id>{ con.Id },
-      Contact.FirstName,
-      Contact.Id,
-      Contact.Id,
-      Contact.FirstName,
-      Campaign.SObjectType,
-      Contact.SObjectType,
-      Rollup.Op.CONCAT,
-      null,
-      Rollup.InvocationPoint.FROM_APEX,
-      RollupControl__mdt.getInstance('Org_Defaults'),
-      new Rollup__mdt(
-        CalcItem__c = 'Contact',
-        RollupFieldOnCalcItem__c = 'FirstName',
-        LookupFieldOnCalcItem__c = 'AccountId',
-        LookupObject__c = 'Campaign',
-        RollupFieldOnLookupObject__c = 'FirstName',
-        LookupFieldOnLookupObject__c = 'Id'
-      )
-    );
-    RollupAsyncProcessor conductor = new RollupAsyncProcessor(Rollup.InvocationPoint.FROM_APEX, new List<Contact>{ con }, new Map<Id, SObject>());
-    conductor.rollups.add(batchProcessor);
-    Test.startTest();
-    Database.executeBatch(conductor);
-    Test.stopTest();
-
-    System.assert(true, 'Should make it here');
-  }
-
-  /** Schedulable tests */
-  @IsTest
-  static void shouldThrowExceptionForBadQuery() {
-    // it's a date field - you tell ME why this query is invalid!
-    String veryBadQuery = 'SELECT MAX(ActivityDate) FROM Task';
-
-    Exception ex;
-    try {
-      Rollup.schedule('Test bad query', '0 0 0 0 0', veryBadQuery, 'Account', null);
-    } catch (Exception e) {
-      ex = e;
-    }
-
-    System.assertNotEquals(null, ex);
-  }
-
-  @IsTest
-  static void shouldScheduleSuccessfullyForGoodQuery() {
-    String goodQuery = 'SELECT Id, Name FROM ContactPointAddress WHERE CreatedDate > YESTERDAY';
-
-    String jobId = Rollup.schedule('Test good query' + System.now(), '0 0 0 * * ?', goodQuery, 'ContactPointAddress', null);
-
-    System.assertNotEquals(null, jobId);
+    return CURRENCY_TYPES;
   }
 }

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -1,6 +1,6 @@
 @IsTest
 private class RollupIntegrationTests {
-  private static final Map<String, CurrencyType> CURRENCY_TYPES = loadCurrencyTypes();
+  private static final Map<String, RollupCurrencyInfo> CURRENCY_TYPES = RollupCurrencyInfo.getCurrencyMap();
 
   @TestSetup
   static void setup() {
@@ -15,10 +15,11 @@ private class RollupIntegrationTests {
       StageName = 'testInt',
       CloseDate = System.today(),
       Amount = 1,
-      CurrencyIsoCode = 'USD',
       AccountIdText__c = acc.Id,
       AccountId = acc.Id
     );
+    setCurrencyIsoCode(opp, 'USD');
+
     insert opp;
     upsert new RollupSettings__c(IsEnabled__c = true);
   }
@@ -27,7 +28,7 @@ private class RollupIntegrationTests {
   static void shouldWorkUsingCustomFieldWithCmdt() {
     Account prior = [SELECT Id, AnnualRevenue FROM Account];
     System.assertEquals(null, prior.AnnualRevenue, 'Test has started under the wrong conditions!');
-    Rollup.records = [SELECT Id, Amount, AccountIdText__c, CurrencyIsoCode FROM Opportunity];
+    Rollup.records = new List<Opportunity>{ (Opportunity) RollupTestUtils.queryRecord('Opportunity', new List<String>{ 'Amount', 'AccountIdText__c' }) };
     Rollup.shouldRun = true;
 
     Rollup.rollupMetadata = new List<Rollup__mdt>{
@@ -56,9 +57,9 @@ private class RollupIntegrationTests {
   static void shouldSupportFormulaFieldsOnChildObjectsOnFullRecordSet() {
     Account acc = [SELECT Id, AnnualRevenue FROM Account];
     System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
-    List<Opportunity> opps = [SELECT Id, Name, AmountFormula__c, AccountId, CurrencyIsoCode FROM Opportunity];
-    System.assertEquals(1, opps[0].AmountFormula__c, 'Test has started with wrong opp conditions!');
-    Rollup.records = opps;
+    Opportunity opp = (Opportunity) RollupTestUtils.queryrecord('Opportunity', new List<String>{ 'AmountFormula__c', 'AccountId' });
+    System.assertEquals(1, opp.AmountFormula__c, 'Test has started with wrong opp conditions!');
+    Rollup.records = new List<Opportunity>{ opp };
     Rollup.shouldRun = true;
 
     Rollup.rollupMetadata = new List<Rollup__mdt>{
@@ -70,7 +71,7 @@ private class RollupIntegrationTests {
         RollupFieldOnLookupObject__c = 'AnnualRevenue',
         RollupOperation__c = 'SUM',
         IsFullRecordSet__c = true,
-        CalcItemWhereClause__c = 'Name != \'' + opps[0].Name + '\'',
+        CalcItemWhereClause__c = 'Name != \'' + opp.Name + '\'',
         FullRecalculationDefaultNumberValue__c = 0,
         CalcItem__c = 'Opportunity'
       )
@@ -161,19 +162,19 @@ private class RollupIntegrationTests {
 
   @IsTest
   static void shouldCorrectlyRollupMaxForMultiCurrency() {
-    Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
+    Account acc = (Account) RollupTestUtils.queryRecord('Account', new List<String>{ 'AnnualRevenue' });
     System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
-    System.assertEquals('USD', acc.CurrencyIsoCode, 'Test has started under the wrong conditions!');
-    acc.CurrencyIsoCode = 'EUR';
+    System.assertEquals('USD', getCurrencyIsoCode(acc), 'Test has started under the wrong conditions!');
+    setCurrencyIsoCode(acc, 'EUR');
     update acc;
 
-    Opportunity usdOpp = [SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountId FROM Opportunity WHERE CurrencyIsoCode = 'USD' LIMIT 1];
+    Opportunity usdOpp = (Opportunity) RollupTestUtils.queryRecord('Opportunity', new List<String>{ 'StageName', 'CloseDate', 'Amount', 'AccountId' });
 
     Opportunity eurOpp = usdOpp.clone(false, true);
-    eurOpp.CurrencyIsoCode = 'EUR';
+    setCurrencyIsoCode(eurOpp, 'EUR');
     eurOpp.Amount = .95;
     Opportunity jpyOpp = eurOpp.clone(false, true);
-    jpyOpp.CurrencyIsoCode = 'JPY';
+    setCurrencyIsoCode(jpyOpp, 'JPY');
     jpyOpp.Amount = 100;
     insert new List<Opportunity>{ eurOpp, jpyOpp };
 
@@ -196,34 +197,30 @@ private class RollupIntegrationTests {
     Rollup.runFromTrigger();
     Test.stopTest();
 
-    acc = [SELECT Id, CurrencyIsoCode, AnnualRevenue, MaxAmountRollupSummary__c FROM Account];
+    acc = (Account) RollupTestUtils.queryRecord(acc.Id, new List<String>{ 'AnnualRevenue', 'MaxAmountRollupSummary__c' });
+    Integer scaleSize = CURRENCY_TYPES.containsKey(getCurrencyIsoCode(acc)) ? CURRENCY_TYPES.get(getCurrencyIsoCode(acc)).DecimalPlaces : 2;
     System.assertEquals(
-      acc.MaxAmountRollupSummary__c.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
-      acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      acc.MaxAmountRollupSummary__c.setScale(scaleSize),
+      acc.AnnualRevenue.setScale(scaleSize),
       'Multi-currency MAX rollup not calculated correctly!'
     );
   }
 
   @IsTest
   static void shouldCorrectlyRollupMinForMultiCurrency() {
-    Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
+    Account acc = (Account) RollupTestUtils.queryRecord('Account', new List<String>{ 'AnnualRevenue' });
     System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
-    System.assertEquals('USD', acc.CurrencyIsoCode, 'Test has started under the wrong conditions!');
-    acc.CurrencyIsoCode = 'EUR';
+    System.assertEquals('USD', getCurrencyIsoCode(acc), 'Test has started under the wrong conditions!');
+    setCurrencyIsoCode(acc, 'EUR');
     update acc;
 
-    Opportunity usdOpp = [
-      SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountIdText__c, AccountId
-      FROM Opportunity
-      WHERE CurrencyIsoCode = 'USD'
-      LIMIT 1
-    ];
+    Opportunity usdOpp = (Opportunity) RollupTestUtils.queryRecord('Opportunity', new List<String>{ 'StageName', 'CloseDate', 'Amount', 'AccountId' });
 
     Opportunity eurOpp = usdOpp.clone(false, true);
-    eurOpp.CurrencyIsoCode = 'EUR';
+    setCurrencyIsoCode(eurOpp, 'EUR');
     eurOpp.Amount = .95;
     Opportunity jpyOpp = eurOpp.clone(false, true);
-    jpyOpp.CurrencyIsoCode = 'JPY';
+    setCurrencyIsoCode(jpyOpp, 'JPY');
     jpyOpp.Amount = 100;
     insert new List<Opportunity>{ eurOpp, jpyOpp };
 
@@ -247,35 +244,30 @@ private class RollupIntegrationTests {
     Rollup.runFromTrigger();
     Test.stopTest();
 
-    acc = [SELECT Id, CurrencyIsoCode, AnnualRevenue, MinAmountRollupSummary__c FROM Account];
-
+    acc = (Account) RollupTestUtils.queryRecord(acc.Id, new List<String>{ 'AnnualRevenue', 'MinAmountRollupSummary__c' });
+    Integer scaleSize = CURRENCY_TYPES.containsKey(getCurrencyIsoCode(acc)) ? CURRENCY_TYPES.get(getCurrencyIsoCode(acc)).DecimalPlaces : 2;
     System.assertEquals(
-      acc.MinAmountRollupSummary__c.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
-      acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      acc.MinAmountRollupSummary__c.setScale(scaleSize),
+      acc.AnnualRevenue.setScale(scaleSize),
       'Multi-currency MIN rollup not calculated correctly!'
     );
   }
 
   @IsTest
   static void shouldCorrectlyRollupSumForMultiCurrency() {
-    Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
+    Account acc = (Account) RollupTestUtils.queryRecord('Account', new List<String>{ 'AnnualRevenue' });
     System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
-    System.assertEquals('USD', acc.CurrencyIsoCode, 'Test has started under the wrong conditions!');
-    acc.CurrencyIsoCode = 'EUR';
+    System.assertEquals('USD', getCurrencyIsoCode(acc), 'Test has started under the wrong conditions!');
+    setCurrencyIsoCode(acc, 'EUR');
     update acc;
 
-    Opportunity usdOpp = [
-      SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountIdText__c, AccountId
-      FROM Opportunity
-      WHERE CurrencyIsoCode = 'USD'
-      LIMIT 1
-    ];
+    Opportunity usdOpp = (Opportunity) RollupTestUtils.queryRecord('Opportunity', new List<String>{ 'StageName', 'CloseDate', 'Amount', 'AccountId' });
 
     Opportunity eurOpp = usdOpp.clone(false, true);
-    eurOpp.CurrencyIsoCode = 'EUR';
+    setCurrencyIsoCode(eurOpp, 'EUR');
     eurOpp.Amount = .95;
     Opportunity jpyOpp = eurOpp.clone(false, true);
-    jpyOpp.CurrencyIsoCode = 'JPY';
+    setCurrencyIsoCode(jpyOpp, 'JPY');
     jpyOpp.Amount = 100;
     insert new List<Opportunity>{ eurOpp, jpyOpp };
 
@@ -299,30 +291,30 @@ private class RollupIntegrationTests {
     Rollup.runFromTrigger();
     Test.stopTest();
 
-    acc = [SELECT Id, CurrencyIsoCode, AnnualRevenue, SumAmountRollupSummary__c FROM Account];
-
+    acc = (Account) RollupTestUtils.queryRecord(acc.Id, new List<String>{ 'AnnualRevenue', 'SumAmountRollupSummary__c' });
+    Integer scaleSize = CURRENCY_TYPES.containsKey(getCurrencyIsoCode(acc)) ? CURRENCY_TYPES.get(getCurrencyIsoCode(acc)).DecimalPlaces : 2;
     System.assertEquals(
-      acc.SumAmountRollupSummary__c.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
-      acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      acc.SumAmountRollupSummary__c.setScale(scaleSize),
+      acc.AnnualRevenue.setScale(scaleSize),
       'Multi-currency SUM rollup not calculated correctly!'
     );
   }
 
   @IsTest
   static void shouldCorrectlyRollupAverageForMultiCurrency() {
-    Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
+    Account acc = (Account) RollupTestUtils.queryRecord('Account', new List<String>{ 'AnnualRevenue' });
     System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
-    System.assertEquals('USD', acc.CurrencyIsoCode, 'Test has started under the wrong conditions!');
-    acc.CurrencyIsoCode = 'EUR';
+    System.assertEquals('USD', getCurrencyIsoCode(acc), 'Test has started under the wrong conditions!');
+    setCurrencyIsoCode(acc, 'EUR');
     update acc;
 
-    Opportunity usdOpp = [SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountId FROM Opportunity WHERE CurrencyIsoCode = 'USD' LIMIT 1];
+    Opportunity usdOpp = (Opportunity) RollupTestUtils.queryRecord('Opportunity', new List<String>{ 'StageName', 'CloseDate', 'Amount', 'AccountId' });
 
     Opportunity eurOpp = usdOpp.clone(false, true);
-    eurOpp.CurrencyIsoCode = 'EUR';
+    setCurrencyIsoCode(eurOpp, 'EUR');
     eurOpp.Amount = .95;
     Opportunity jpyOpp = eurOpp.clone(false, true);
-    jpyOpp.CurrencyIsoCode = 'JPY';
+    setCurrencyIsoCode(jpyOpp, 'JPY');
     jpyOpp.Amount = 100;
     insert new List<Opportunity>{ eurOpp, jpyOpp };
 
@@ -345,36 +337,40 @@ private class RollupIntegrationTests {
     Rollup.runFromTrigger();
     Test.stopTest();
 
-    List<Opportunity> opportunities = [SELECT Id, convertCurrency(Amount) ConvertedAmount, CurrencyIsoCode FROM Opportunity];
+    List<SObject> opportunities = UserInfo.isMultiCurrencyOrganization()
+      ? Database.query('SELECT Id, convertCurrency(Amount) ConvertedAmount FROM Opportunity')
+      : [SELECT MAX(Amount) ConvertedAmount, Id FROM Opportunity GROUP BY Id];
     Decimal convertedAmountSum = 0;
-    for (Opportunity opp : opportunities) {
+    for (SObject opp : opportunities) {
       convertedAmountSum += (Decimal) opp.get('ConvertedAmount');
     }
-    Decimal expectedAverage = (convertedAmountSum / opportunities.size()) * CURRENCY_TYPES.get(acc.CurrencyIsoCode).ConversionRate;
+    Decimal conversionRate = CURRENCY_TYPES.containsKey(getCurrencyIsoCode(acc)) ? CURRENCY_TYPES.get(getCurrencyIsoCode(acc)).ConversionRate : 1;
+    Decimal expectedAverage = (convertedAmountSum / opportunities.size()) * conversionRate;
 
-    acc = [SELECT Id, CurrencyIsoCode, AnnualRevenue FROM Account];
+    Integer scaleSize = CURRENCY_TYPES.containsKey(getCurrencyIsoCode(acc)) ? CURRENCY_TYPES.get(getCurrencyIsoCode(acc)).DecimalPlaces : 2;
+    acc = (Account) RollupTestUtils.queryRecord(acc.Id, new List<String>{ 'AnnualRevenue' });
     System.assertEquals(
-      expectedAverage.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
-      acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      expectedAverage.setScale(scaleSize),
+      acc.AnnualRevenue.setScale(scaleSize),
       'Multi-currency AVERAGE rollup not calculated correctly! Records: ' + opportunities
     );
   }
 
   @IsTest
   static void shouldCorrectlyRollupFirstForMultiCurrency() {
-    Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
+    Account acc = (Account) RollupTestUtils.queryRecord('Account', new List<String>{ 'AnnualRevenue' });
     System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
-    System.assertEquals('USD', acc.CurrencyIsoCode, 'Test has started under the wrong conditions!');
-    acc.CurrencyIsoCode = 'EUR';
+    System.assertEquals('USD', getCurrencyIsoCode(acc), 'Test has started under the wrong conditions!');
+    setCurrencyIsoCode(acc, 'EUR');
     update acc;
 
-    Opportunity usdOpp = [SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountId FROM Opportunity WHERE CurrencyIsoCode = 'USD' LIMIT 1];
+    Opportunity usdOpp = (Opportunity) RollupTestUtils.queryRecord('Opportunity', new List<String>{ 'StageName', 'CloseDate', 'Amount', 'AccountId' });
 
     Opportunity eurOpp = usdOpp.clone(false, true);
-    eurOpp.CurrencyIsoCode = 'EUR';
+    setCurrencyIsoCode(eurOpp, 'EUR');
     eurOpp.Amount = .95;
     Opportunity jpyOpp = eurOpp.clone(false, true);
-    jpyOpp.CurrencyIsoCode = 'JPY';
+    setCurrencyIsoCode(jpyOpp, 'JPY');
     jpyOpp.Amount = 100;
     insert new List<Opportunity>{ eurOpp, jpyOpp };
 
@@ -400,8 +396,10 @@ private class RollupIntegrationTests {
 
     Decimal firstAmount;
     Id firstOpportunityId;
-    List<Opportunity> opportunities = [SELECT Id, convertCurrency(Amount) ConvertedAmount, CurrencyIsoCode FROM Opportunity];
-    for (Opportunity opp : opportunities) {
+    List<SObject> opportunities = UserInfo.isMultiCurrencyOrganization()
+      ? Database.query('SELECT Id, convertCurrency(Amount) ConvertedAmount FROM Opportunity')
+      : [SELECT MAX(Amount) ConvertedAmount, Id FROM Opportunity GROUP BY Id];
+    for (SObject opp : opportunities) {
       Decimal oppConvertedAmount = (Decimal) opp.get('ConvertedAmount');
       if (firstAmount == null || oppConvertedAmount < firstAmount) {
         firstAmount = oppConvertedAmount;
@@ -415,19 +413,19 @@ private class RollupIntegrationTests {
 
   @IsTest
   static void shouldCorrectlyRollupLastForMultiCurrency() {
-    Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
+    Account acc = (Account) RollupTestUtils.queryRecord('Account', new List<String>{ 'AnnualRevenue' });
     System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
-    System.assertEquals('USD', acc.CurrencyIsoCode, 'Test has started under the wrong conditions!');
-    acc.CurrencyIsoCode = 'EUR';
+    System.assertEquals('USD', getCurrencyIsoCode(acc), 'Test has started under the wrong conditions!');
+    setCurrencyIsoCode(acc, 'EUR');
     update acc;
 
-    Opportunity usdOpp = [SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountId FROM Opportunity WHERE CurrencyIsoCode = 'USD' LIMIT 1];
+    Opportunity usdOpp = (Opportunity) RollupTestUtils.queryRecord('Opportunity', new List<String>{ 'StageName', 'CloseDate', 'Amount', 'AccountId' });
 
     Opportunity eurOpp = usdOpp.clone(false, true);
-    eurOpp.CurrencyIsoCode = 'EUR';
+    setCurrencyIsoCode(eurOpp, 'EUR');
     eurOpp.Amount = .95;
     Opportunity jpyOpp = eurOpp.clone(false, true);
-    jpyOpp.CurrencyIsoCode = 'JPY';
+    setCurrencyIsoCode(jpyOpp, 'JPY');
     jpyOpp.Amount = 100;
     insert new List<Opportunity>{ eurOpp, jpyOpp };
 
@@ -453,8 +451,10 @@ private class RollupIntegrationTests {
 
     Decimal lastAmount;
     Id lastOpportunityId;
-    List<Opportunity> opportunities = [SELECT Id, convertCurrency(Amount) ConvertedAmount, CurrencyIsoCode FROM Opportunity];
-    for (Opportunity opp : opportunities) {
+    List<SObject> opportunities = UserInfo.isMultiCurrencyOrganization()
+      ? Database.query('SELECT Id, convertCurrency(Amount) ConvertedAmount FROM Opportunity')
+      : [SELECT MAX(Amount) ConvertedAmount, Id FROM Opportunity GROUP BY Id];
+    for (SObject opp : opportunities) {
       Decimal oppConvertedAmount = (Decimal) opp.get('ConvertedAmount');
       if (lastAmount == null || oppConvertedAmount > lastAmount) {
         lastAmount = oppConvertedAmount;
@@ -505,8 +505,10 @@ private class RollupIntegrationTests {
   static void shouldFindGreatGrandParentRelationshipBetweenCustomObjects() {
     // The CurrencyIsoCode field isn't directly used here, but the field will be automatically included by Rollup's queries,
     // so include it on the accounts so the asserts below show that the accounts do, in fact, match
-    Account greatGrandparent = new Account(Name = 'Great-grandparent', CurrencyIsoCode = 'USD');
-    Account secondGreatGrandparent = new Account(Name = 'Second great-grandparent', CurrencyIsoCode = 'USD');
+    Account greatGrandparent = new Account(Name = 'Great-grandparent');
+    setCurrencyISoCode(greatGrandparent, 'USD');
+    Account secondGreatGrandparent = new Account(Name = 'Second great-grandparent');
+    setCurrencyISoCode(secondGreatGrandparent, 'USD');
     insert new List<Account>{ greatGrandparent, secondGreatGrandparent };
 
     ParentApplication__c grandParent = new ParentApplication__c(Name = 'Grandparent', Account__c = greatGrandparent.Id);
@@ -1553,11 +1555,13 @@ private class RollupIntegrationTests {
     System.assertNotEquals(null, jobId);
   }
 
-  private static Map<String, CurrencyType> loadCurrencyTypes() {
-    Map<String, CurrencyType> CURRENCY_TYPES = new Map<String, CurrencyType>();
-    for (CurrencyType currencyType : [SELECT IsoCode, ConversionRate, DecimalPlaces FROM CurrencyType WHERE IsActive = TRUE]) {
-      CURRENCY_TYPES.put(currencyType.IsoCode, currencyType);
+  private static void setCurrencyISoCode(SObject record, String isoCode) {
+    if (UserInfo.isMultiCurrencyOrganization()) {
+      record.put('CurrencyIsoCode', isoCode);
     }
-    return CURRENCY_TYPES;
+  }
+
+  private static String getCurrencyIsoCode(SObject record) {
+    return UserInfo.isMultiCurrencyOrganization() ? (String) record.get('CurrencyIsoCode') : 'USD';
   }
 }

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -353,8 +353,10 @@ private class RollupIntegrationTests {
   /** grandparent rollup tests */
   @IsTest
   static void shouldFindGreatGrandParentRelationshipBetweenCustomObjects() {
-    Account greatGrandparent = new Account(Name = 'Great-grandparent');
-    Account secondGreatGrandparent = new Account(Name = 'Second great-grandparent');
+    // The CurrencyIsoCode field isn't directly used here, but the field will be automatically included by Rollup's queries,
+    // so include it on the accounts so the asserts below show that the accounts do, in fact, match
+    Account greatGrandparent = new Account(Name = 'Great-grandparent', CurrencyIsoCode = 'USD');
+    Account secondGreatGrandparent = new Account(Name = 'Second great-grandparent', CurrencyIsoCode = 'USD');
     insert new List<Account>{ greatGrandparent, secondGreatGrandparent };
 
     ParentApplication__c grandParent = new ParentApplication__c(Name = 'Grandparent', Account__c = greatGrandparent.Id);

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -13,6 +13,7 @@ private class RollupIntegrationTests {
       StageName = 'testInt',
       CloseDate = System.today(),
       Amount = 1,
+      CurrencyIsoCode = 'USD',
       AccountIdText__c = acc.Id,
       AccountId = acc.Id
     );

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -159,7 +159,7 @@ private class RollupIntegrationTests {
     System.assertEquals(45 / 3, updatedParent.Engagement_Rollup__c, 'Average should be calculated based off of matching items');
   }
 
-  @isTest
+  @IsTest
   static void shouldCorrectlyRollupMaxForMultiCurrency() {
     Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
     System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
@@ -204,7 +204,7 @@ private class RollupIntegrationTests {
     );
   }
 
-  @isTest
+  @IsTest
   static void shouldCorrectlyRollupMinForMultiCurrency() {
     Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
     System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
@@ -256,7 +256,7 @@ private class RollupIntegrationTests {
     );
   }
 
-  @isTest
+  @IsTest
   static void shouldCorrectlyRollupSumForMultiCurrency() {
     Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
     System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
@@ -308,7 +308,7 @@ private class RollupIntegrationTests {
     );
   }
 
-  @isTest
+  @IsTest
   static void shouldCorrectlyRollupAverageForMultiCurrency() {
     Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
     System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
@@ -360,7 +360,7 @@ private class RollupIntegrationTests {
     );
   }
 
-  @isTest
+  @IsTest
   static void shouldCorrectlyRollupFirstForMultiCurrency() {
     Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
     System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
@@ -413,7 +413,7 @@ private class RollupIntegrationTests {
     System.assertEquals(firstOpportunityId, acc.Name, 'Should have taken first based on multi-currency Amount! Records: ' + opportunities);
   }
 
-  @isTest
+  @IsTest
   static void shouldCorrectlyRollupLastForMultiCurrency() {
     Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
     System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
@@ -466,7 +466,7 @@ private class RollupIntegrationTests {
     System.assertEquals(lastOpportunityId, acc.Name, 'Should have taken last based on multi-currency Amount! Records: ' + opportunities);
   }
 
-  @isTest
+  @IsTest
   static void shouldSupportCustomObjectsWhenRollupTriggeredFromParent() {
     ParentApplication__c parentApp = new ParentApplication__c(Name = 'Custom Object Parent App');
     insert parentApp;

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -168,12 +168,7 @@ private class RollupIntegrationTests {
     acc.CurrencyIsoCode = 'EUR';
     update acc;
 
-    Opportunity usdOpp = [
-      SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountId
-      FROM Opportunity
-      WHERE CurrencyIsoCode = 'USD'
-      LIMIT 1
-    ];
+    Opportunity usdOpp = [SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountId FROM Opportunity WHERE CurrencyIsoCode = 'USD' LIMIT 1];
 
     Opportunity eurOpp = usdOpp.clone(false, true);
     eurOpp.CurrencyIsoCode = 'EUR';
@@ -209,8 +204,6 @@ private class RollupIntegrationTests {
       'Multi-currency MAX rollup not calculated correctly!'
     );
   }
-
-  // TODO - first/last/average calculations
 
   @isTest
   static void shouldCorrectlyRollupMinForMultiCurrency() {
@@ -314,6 +307,164 @@ private class RollupIntegrationTests {
       acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       'Multi-currency SUM rollup not calculated correctly!'
     );
+  }
+
+  @isTest
+  static void shouldCorrectlyRollupAverageForMultiCurrency() {
+    Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
+    System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
+    System.assertEquals('USD', acc.CurrencyIsoCode, 'Test has started under the wrong conditions!');
+    acc.CurrencyIsoCode = 'EUR';
+    update acc;
+
+    Opportunity usdOpp = [SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountId FROM Opportunity WHERE CurrencyIsoCode = 'USD' LIMIT 1];
+
+    Opportunity eurOpp = usdOpp.clone(false, true);
+    eurOpp.CurrencyIsoCode = 'EUR';
+    eurOpp.Amount = .95;
+    Opportunity jpyOpp = eurOpp.clone(false, true);
+    jpyOpp.CurrencyIsoCode = 'JPY';
+    jpyOpp.Amount = 100;
+    insert new List<Opportunity>{ eurOpp, jpyOpp };
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'Amount',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'AVERAGE',
+        CalcItem__c = 'Opportunity'
+      )
+    };
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.records = new List<Opportunity>{ usdOpp, eurOpp, jpyOpp };
+    Rollup.shouldRun = true;
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    List<Opportunity> opportunities = [SELECT Id, convertCurrency(Amount) ConvertedAmount, CurrencyIsoCode FROM Opportunity];
+    Decimal convertedAmountSum = 0;
+    for (Opportunity opp : opportunities) {
+      convertedAmountSum += (Decimal) opp.get('ConvertedAmount');
+    }
+    Decimal expectedAverage = (convertedAmountSum / opportunities.size()) * CURRENCY_TYPES.get(acc.CurrencyIsoCode).ConversionRate;
+
+    acc = [SELECT Id, CurrencyIsoCode, AnnualRevenue FROM Account];
+    System.assertEquals(
+      expectedAverage.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
+      'Multi-currency AVERAGE rollup not calculated correctly! Records: ' + opportunities
+    );
+  }
+
+  @isTest
+  static void shouldCorrectlyRollupFirstForMultiCurrency() {
+    Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
+    System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
+    System.assertEquals('USD', acc.CurrencyIsoCode, 'Test has started under the wrong conditions!');
+    acc.CurrencyIsoCode = 'EUR';
+    update acc;
+
+    Opportunity usdOpp = [SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountId FROM Opportunity WHERE CurrencyIsoCode = 'USD' LIMIT 1];
+
+    Opportunity eurOpp = usdOpp.clone(false, true);
+    eurOpp.CurrencyIsoCode = 'EUR';
+    eurOpp.Amount = .95;
+    Opportunity jpyOpp = eurOpp.clone(false, true);
+    jpyOpp.CurrencyIsoCode = 'JPY';
+    jpyOpp.Amount = 100;
+    insert new List<Opportunity>{ eurOpp, jpyOpp };
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'CurrencyIsoCode',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'Name',
+        RollupOperation__c = 'FIRST',
+        CalcItem__c = 'Opportunity',
+        OrderByFirstLast__c = 'Amount'
+      )
+    };
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.records = new List<Opportunity>{ usdOpp, eurOpp, jpyOpp };
+    Rollup.shouldRun = true;
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Decimal firstAmount;
+    String firstOpportunityCurrencyIsoCode;
+    List<Opportunity> opportunities = [SELECT Id, convertCurrency(Amount) ConvertedAmount, CurrencyIsoCode FROM Opportunity];
+    for (Opportunity opp : opportunities) {
+      Decimal oppConvertedAmount = (Decimal) opp.get('ConvertedAmount');
+      if (firstAmount == null || oppConvertedAmount < firstAmount) {
+        firstAmount = oppConvertedAmount;
+        firstOpportunityCurrencyIsoCode = opp.CurrencyIsoCode;
+      }
+    }
+
+    acc = [SELECT Id, Name FROM Account];
+    System.assertEquals(firstOpportunityCurrencyIsoCode, acc.Name, 'Should have taken first based on multi-currency Amount! Records: ' + opportunities);
+  }
+
+  @isTest
+  static void shouldCorrectlyRollupLastForMultiCurrency() {
+    Account acc = [SELECT Id, AnnualRevenue, CurrencyIsoCode FROM Account];
+    System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
+    System.assertEquals('USD', acc.CurrencyIsoCode, 'Test has started under the wrong conditions!');
+    acc.CurrencyIsoCode = 'EUR';
+    update acc;
+
+    Opportunity usdOpp = [SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountId FROM Opportunity WHERE CurrencyIsoCode = 'USD' LIMIT 1];
+
+    Opportunity eurOpp = usdOpp.clone(false, true);
+    eurOpp.CurrencyIsoCode = 'EUR';
+    eurOpp.Amount = .95;
+    Opportunity jpyOpp = eurOpp.clone(false, true);
+    jpyOpp.CurrencyIsoCode = 'JPY';
+    jpyOpp.Amount = 100;
+    insert new List<Opportunity>{ eurOpp, jpyOpp };
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'CurrencyIsoCode',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'Name',
+        RollupOperation__c = 'LAST',
+        CalcItem__c = 'Opportunity',
+        OrderByFirstLast__c = 'Amount'
+      )
+    };
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.records = new List<Opportunity>{ usdOpp, eurOpp, jpyOpp };
+    Rollup.shouldRun = true;
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Decimal lastAmount;
+    String lastOpportunityCurrencyIsoCode;
+    List<Opportunity> opportunities = [SELECT Id, convertCurrency(Amount) ConvertedAmount, CurrencyIsoCode FROM Opportunity];
+    for (Opportunity opp : opportunities) {
+      Decimal oppConvertedAmount = (Decimal) opp.get('ConvertedAmount');
+      if (lastAmount == null || oppConvertedAmount > lastAmount) {
+        lastAmount = oppConvertedAmount;
+        lastOpportunityCurrencyIsoCode = opp.CurrencyIsoCode;
+      }
+    }
+
+    acc = [SELECT Id, Name FROM Account];
+    System.assertEquals(lastOpportunityCurrencyIsoCode, acc.Name, 'Should have taken last based on multi-currency Amount! Records: ' + opportunities);
   }
 
   @isTest

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -5,7 +5,7 @@ private class RollupIntegrationTests {
   // "Integration," in the sense that these include custom fields / objects that shouldn't be installed
   @TestSetup
   static void setup() {
-    Account acc = new Account(Name = 'RollupIntegrationTests');
+    Account acc = new Account(Name = RollupIntegrationTests.class.getName());
     insert acc;
 
     acc.AccountIdText__c = acc.Id;
@@ -28,7 +28,7 @@ private class RollupIntegrationTests {
   static void shouldWorkUsingCustomFieldWithCmdt() {
     Account prior = [SELECT Id, AnnualRevenue FROM Account];
     System.assertEquals(null, prior.AnnualRevenue, 'Test has started under the wrong conditions!');
-    Rollup.records = [SELECT Id, Amount, AccountIdText__c FROM Opportunity];
+    Rollup.records = [SELECT Id, Amount, AccountIdText__c, CurrencyIsoCode FROM Opportunity];
     Rollup.shouldRun = true;
 
     Rollup.rollupMetadata = new List<Rollup__mdt>{
@@ -57,7 +57,7 @@ private class RollupIntegrationTests {
   static void shouldSupportFormulaFieldsOnChildObjectsOnFullRecordSet() {
     Account acc = [SELECT Id, AnnualRevenue FROM Account];
     System.assertEquals(null, acc.AnnualRevenue, 'Test has started under the wrong conditions!');
-    List<Opportunity> opps = [SELECT Id, Name, AmountFormula__c, AccountId FROM Opportunity];
+    List<Opportunity> opps = [SELECT Id, Name, AmountFormula__c, AccountId, CurrencyIsoCode FROM Opportunity];
     System.assertEquals(1, opps[0].AmountFormula__c, 'Test has started with wrong opp conditions!');
     Rollup.records = opps;
     Rollup.shouldRun = true;
@@ -169,7 +169,7 @@ private class RollupIntegrationTests {
     update acc;
 
     Opportunity usdOpp = [
-      SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountIdText__c, AccountId
+      SELECT Name, StageName, CloseDate, Amount, CurrencyIsoCode, AccountId
       FROM Opportunity
       WHERE CurrencyIsoCode = 'USD'
       LIMIT 1
@@ -177,8 +177,10 @@ private class RollupIntegrationTests {
 
     Opportunity eurOpp = usdOpp.clone(false, true);
     eurOpp.CurrencyIsoCode = 'EUR';
+    eurOpp.Amount = .95;
     Opportunity jpyOpp = eurOpp.clone(false, true);
     jpyOpp.CurrencyIsoCode = 'JPY';
+    jpyOpp.Amount = 100;
     insert new List<Opportunity>{ eurOpp, jpyOpp };
 
     Rollup.rollupMetadata = new List<Rollup__mdt>{
@@ -188,8 +190,7 @@ private class RollupIntegrationTests {
         LookupFieldOnCalcItem__c = 'AccountId',
         LookupFieldOnLookupObject__c = 'Id',
         RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'SUM',
-        IsFullRecordSet__c = true,
+        RollupOperation__c = 'MAX',
         CalcItem__c = 'Opportunity'
       )
     };
@@ -201,27 +202,15 @@ private class RollupIntegrationTests {
     Rollup.runFromTrigger();
     Test.stopTest();
 
-    Decimal expectedMaxAmount;
-    for (Opportunity opp : [SELECT convertCurrency(Amount) ConvertedAmount FROM Opportunity WHERE Id IN :Rollup.records]) {
-      Decimal oppConvertedAmount = (Decimal) opp.get('ConvertedAmount');
-      if (expectedMaxAmount == null || oppConvertedAmount > expectedMaxAmount) {
-        expectedMaxAmount = oppConvertedAmount;
-      }
-    }
-    expectedMaxAmount *= CURRENCY_TYPES.get(acc.CurrencyIsoCode).ConversionRate;
-
     acc = [SELECT Id, CurrencyIsoCode, AnnualRevenue, MaxAmountRollupSummary__c FROM Account];
     System.assertEquals(
-      expectedMaxAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       acc.MaxAmountRollupSummary__c.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
-      'Calculated TotalRevenue and rollup-summary field MaxAmountRollupSummary__c should match!'
-    );
-    System.assertEquals(
-      expectedMaxAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       'Multi-currency MAX rollup not calculated correctly!'
     );
   }
+
+  // TODO - first/last/average calculations
 
   @isTest
   static void shouldCorrectlyRollupMinForMultiCurrency() {
@@ -240,8 +229,10 @@ private class RollupIntegrationTests {
 
     Opportunity eurOpp = usdOpp.clone(false, true);
     eurOpp.CurrencyIsoCode = 'EUR';
+    eurOpp.Amount = .95;
     Opportunity jpyOpp = eurOpp.clone(false, true);
     jpyOpp.CurrencyIsoCode = 'JPY';
+    jpyOpp.Amount = 100;
     insert new List<Opportunity>{ eurOpp, jpyOpp };
 
     Rollup.rollupMetadata = new List<Rollup__mdt>{
@@ -251,7 +242,7 @@ private class RollupIntegrationTests {
         LookupFieldOnCalcItem__c = 'AccountId',
         LookupFieldOnLookupObject__c = 'Id',
         RollupFieldOnLookupObject__c = 'AnnualRevenue',
-        RollupOperation__c = 'SUM',
+        RollupOperation__c = 'MIN',
         IsFullRecordSet__c = true,
         CalcItem__c = 'Opportunity'
       )
@@ -264,23 +255,10 @@ private class RollupIntegrationTests {
     Rollup.runFromTrigger();
     Test.stopTest();
 
-    Decimal expectedMinAmount;
-    for (Opportunity opp : [SELECT convertCurrency(Amount) ConvertedAmount FROM Opportunity WHERE Id IN :Rollup.records]) {
-      Decimal oppConvertedAmount = (Decimal) opp.get('ConvertedAmount');
-      if (expectedMinAmount == null || oppConvertedAmount < expectedMinAmount) {
-        expectedMinAmount = oppConvertedAmount;
-      }
-    }
-    expectedMinAmount *= CURRENCY_TYPES.get(acc.CurrencyIsoCode).ConversionRate;
-
     acc = [SELECT Id, CurrencyIsoCode, AnnualRevenue, MinAmountRollupSummary__c FROM Account];
+
     System.assertEquals(
-      expectedMinAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       acc.MinAmountRollupSummary__c.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
-      'Calculated TotalRevenue and rollup-summary field MinAmountRollupSummary__c should match!'
-    );
-    System.assertEquals(
-      expectedMinAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       'Multi-currency MIN rollup not calculated correctly!'
     );
@@ -303,8 +281,10 @@ private class RollupIntegrationTests {
 
     Opportunity eurOpp = usdOpp.clone(false, true);
     eurOpp.CurrencyIsoCode = 'EUR';
+    eurOpp.Amount = .95;
     Opportunity jpyOpp = eurOpp.clone(false, true);
     jpyOpp.CurrencyIsoCode = 'JPY';
+    jpyOpp.Amount = 100;
     insert new List<Opportunity>{ eurOpp, jpyOpp };
 
     Rollup.rollupMetadata = new List<Rollup__mdt>{
@@ -327,20 +307,10 @@ private class RollupIntegrationTests {
     Rollup.runFromTrigger();
     Test.stopTest();
 
-    Decimal expectedSumAmount = 0;
-    for (Opportunity opp : [SELECT convertCurrency(Amount) ConvertedAmount FROM Opportunity WHERE Id IN :Rollup.records]) {
-      expectedSumAmount += (Decimal) opp.get('ConvertedAmount');
-    }
-    expectedSumAmount *= CURRENCY_TYPES.get(acc.CurrencyIsoCode).ConversionRate;
-
     acc = [SELECT Id, CurrencyIsoCode, AnnualRevenue, SumAmountRollupSummary__c FROM Account];
+
     System.assertEquals(
-      expectedSumAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       acc.SumAmountRollupSummary__c.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
-      'Calculated TotalRevenue and rollup-summary field SumAmountRollupSummary__c should match!'
-    );
-    System.assertEquals(
-      expectedSumAmount.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       acc.AnnualRevenue.setScale(CURRENCY_TYPES.get(acc.CurrencyIsoCode).DecimalPlaces),
       'Multi-currency SUM rollup not calculated correctly!'
     );

--- a/extra-tests/classes/RollupRelationshipFieldFinderTests.cls
+++ b/extra-tests/classes/RollupRelationshipFieldFinderTests.cls
@@ -21,7 +21,7 @@ private class RollupRelationshipFieldFinderTests {
 
     RollupRelationshipFieldFinder.Traversal traversal = finder.getParents(new List<ContactPointAddress>{ cpa });
 
-    parent = (Account) queryRecord(parent.Id);
+    parent = (Account) RollupTestUtils.queryRecord(parent.Id);
     System.assertEquals(parent, traversal.retrieveParent(cpa.Id));
 
     // validates that the relationship field finder works even if a fully qualified path isn't provided if the parent
@@ -56,7 +56,7 @@ private class RollupRelationshipFieldFinderTests {
     RollupRelationshipFieldFinder.Traversal traversal = finder.getParents(new List<ContactPointAddress>{ cpa });
 
     parent = [SELECT OwnerId FROM Account WHERE Id = :parent.Id];
-    User expectedUser = (User) queryRecord(parent.OwnerId);
+    User expectedUser = (User) RollupTestUtils.queryRecord(parent.OwnerId);
     System.assertEquals(
       expectedUser,
       traversal.retrieveParent(cpa.Id),
@@ -216,7 +216,7 @@ private class RollupRelationshipFieldFinderTests {
     );
     RollupRelationshipFieldFinder.Traversal traversal = finder.getParents(cpas);
 
-    parentOne = (Account) queryRecord(parentOne.Id);
+    parentOne = (Account) RollupTestUtils.queryRecord(parentOne.Id);
     System.assertEquals(parentOne, traversal.retrieveParent(cpaOne.Id), 'First opp parent should not be exluded!');
     System.assertEquals(parentOne, traversal.retrieveParent(cpaTwo.Id), 'Second opp should not have been excluded!');
   }
@@ -253,8 +253,8 @@ private class RollupRelationshipFieldFinderTests {
     RollupRelationshipFieldFinder.Traversal traversal = finder.getParents(cpas);
 
     // we don't anticipate it being necessary to return fields used in the where clause; just that records are filtered correctly
-    Account expectedFirst = (Account) queryRecord(parentOne.Id);
-    parentThree = (Account) queryRecord(parentThree.Id);
+    Account expectedFirst = (Account) RollupTestUtils.queryRecord(parentOne.Id);
+    parentThree = (Account) RollupTestUtils.queryRecord(parentThree.Id);
     System.assertEquals(expectedFirst, traversal.retrieveParent(cpaOne.Id), 'First cpa parent should be returned, matches nested conditional!');
     System.assertEquals(null, traversal.retrieveParent(cpaTwo.Id), 'Second cpa parent should have been excluded with clause after nested conditional!');
     // parent three doesn't have additional fields (like AccountNumber), fine to use as is
@@ -301,19 +301,8 @@ private class RollupRelationshipFieldFinderTests {
     );
     RollupRelationshipFieldFinder.Traversal traversal = finder.getParents(cpas);
 
-    Account expectedAcc = (Account) queryRecord(parentOne.Id);
+    Account expectedAcc = (Account) RollupTestUtils.queryRecord(parentOne.Id);
     System.assertEquals(expectedAcc, traversal.retrieveParent(cpaOne.Id), 'Ultimate parent should have been used!');
     System.assertEquals(expectedAcc, traversal.retrieveParent(cpaTwo.Id), 'Ultimate parent should be found even if 5+ levels deep in hierarchy');
-  }
-
-  private static SObject queryRecord(Id recordId) {
-    SObjectType sObjectType = recordId.getSObjectType();
-    String currencyIscoCodeFieldName = 'CurrencyIsoCode';
-    List<String> fields = new List<String>{ 'Id', 'Name' };
-    if (UserInfo.isMultiCurrencyOrganization() && sObjectType.getDescribe().fields.getMap().containsKey(currencyIscoCodeFieldName)) {
-      fields.add(currencyIscoCodeFieldName);
-    }
-    String recordQuery = 'SELECT ' + String.join(fields, ', ') + '\nFROM ' + sObjectType + '\nWHERE Id = :recordId';
-    return Database.query(recordQuery);
   }
 }

--- a/extra-tests/classes/RollupRelationshipFieldFinderTests.cls
+++ b/extra-tests/classes/RollupRelationshipFieldFinderTests.cls
@@ -292,7 +292,8 @@ private class RollupRelationshipFieldFinderTests {
       new Rollup__mdt(
         RollupToUltimateParent__c = true,
         UltimateParentLookup__c = 'ParentId',
-        GrandparentRelationshipFieldPath__c = 'Parent.Name'
+        GrandparentRelationshipFieldPath__c = 'Parent.Name',
+        LookupFieldOnCalcItem__c = 'ParentId'
       ),
       new Set<String>{ 'Name', 'Id' },
       Account.SObjectType,

--- a/extra-tests/classes/RollupRelationshipFieldFinderTests.cls
+++ b/extra-tests/classes/RollupRelationshipFieldFinderTests.cls
@@ -21,6 +21,7 @@ private class RollupRelationshipFieldFinderTests {
 
     RollupRelationshipFieldFinder.Traversal traversal = finder.getParents(new List<ContactPointAddress>{ cpa });
 
+    parent = (Account) queryRecord(parent.Id);
     System.assertEquals(parent, traversal.retrieveParent(cpa.Id));
 
     // validates that the relationship field finder works even if a fully qualified path isn't provided if the parent
@@ -55,8 +56,9 @@ private class RollupRelationshipFieldFinderTests {
     RollupRelationshipFieldFinder.Traversal traversal = finder.getParents(new List<ContactPointAddress>{ cpa });
 
     parent = [SELECT OwnerId FROM Account WHERE Id = :parent.Id];
+    User expectedUser = (User) queryRecord(parent.OwnerId);
     System.assertEquals(
-      [SELECT Id, Name FROM User WHERE Id = :parent.OwnerId][0],
+      expectedUser,
       traversal.retrieveParent(cpa.Id),
       'User should have been retrieved correctly!'
     );
@@ -214,6 +216,7 @@ private class RollupRelationshipFieldFinderTests {
     );
     RollupRelationshipFieldFinder.Traversal traversal = finder.getParents(cpas);
 
+    parentOne = (Account) queryRecord(parentOne.Id);
     System.assertEquals(parentOne, traversal.retrieveParent(cpaOne.Id), 'First opp parent should not be exluded!');
     System.assertEquals(parentOne, traversal.retrieveParent(cpaTwo.Id), 'Second opp should not have been excluded!');
   }
@@ -250,7 +253,8 @@ private class RollupRelationshipFieldFinderTests {
     RollupRelationshipFieldFinder.Traversal traversal = finder.getParents(cpas);
 
     // we don't anticipate it being necessary to return fields used in the where clause; just that records are filtered correctly
-    Account expectedFirst = new Account(Id = parentOne.Id, Name = parentOne.Name);
+    Account expectedFirst = (Account) queryRecord(parentOne.Id);
+    parentThree = (Account) queryRecord(parentThree.Id);
     System.assertEquals(expectedFirst, traversal.retrieveParent(cpaOne.Id), 'First cpa parent should be returned, matches nested conditional!');
     System.assertEquals(null, traversal.retrieveParent(cpaTwo.Id), 'Second cpa parent should have been excluded with clause after nested conditional!');
     // parent three doesn't have additional fields (like AccountNumber), fine to use as is
@@ -296,8 +300,19 @@ private class RollupRelationshipFieldFinderTests {
     );
     RollupRelationshipFieldFinder.Traversal traversal = finder.getParents(cpas);
 
-    Account expectedAcc = new Account(Id = parentOne.Id, Name = parentOne.Name);
+    Account expectedAcc = (Account) queryRecord(parentOne.Id);
     System.assertEquals(expectedAcc, traversal.retrieveParent(cpaOne.Id), 'Ultimate parent should have been used!');
     System.assertEquals(expectedAcc, traversal.retrieveParent(cpaTwo.Id), 'Ultimate parent should be found even if 5+ levels deep in hierarchy');
+  }
+
+  private static SObject queryRecord(Id recordId) {
+    SObjectType sObjectType = recordId.getSObjectType();
+    String currencyIscoCodeFieldName = 'CurrencyIsoCode';
+    List<String> fields = new List<String>{ 'Id', 'Name' };
+    if (UserInfo.isMultiCurrencyOrganization() && sObjectType.getDescribe().fields.getMap().containsKey(currencyIscoCodeFieldName)) {
+      fields.add(currencyIscoCodeFieldName);
+    }
+    String recordQuery = 'SELECT ' + String.join(fields, ', ') + '\nFROM ' + sObjectType + '\nWHERE Id = :recordId';
+    return Database.query(recordQuery);
   }
 }

--- a/extra-tests/classes/RollupRelationshipFieldFinderTests.cls
+++ b/extra-tests/classes/RollupRelationshipFieldFinderTests.cls
@@ -2,10 +2,14 @@
 private class RollupRelationshipFieldFinderTests {
   static RollupControl__mdt control = new RollupControl__mdt(MaxLookupRowsBeforeBatching__c = 10000);
 
+  @TestSetup
+  static void setup() {
+    insert new Account(Name = RollupRelationshipFieldFinderTests.class.getName());
+  }
+
   @IsTest
   static void shouldFindParentRelationshipBetweenStandardObjects() {
-    Account parent = new Account(Name = 'Parent relationship between standard objects');
-    insert parent;
+    Account parent = [SELECT Id FROM Account];
 
     ContactPointAddress cpa = new ContactPointAddress(ParentId = parent.Id, Name = 'Child cpa');
     insert cpa;
@@ -40,8 +44,7 @@ private class RollupRelationshipFieldFinderTests {
 
   @IsTest
   static void shouldFindGrandparentRelationshipBetweenStandardObjects() {
-    Account parent = new Account(Name = 'Parent account looking up to User');
-    insert parent;
+    Account parent = [SELECT Id FROM Account];
 
     ContactPointAddress cpa = new ContactPointAddress(ParentId = parent.Id, Name = 'Child looking up to account');
     insert cpa;
@@ -66,8 +69,7 @@ private class RollupRelationshipFieldFinderTests {
 
   @IsTest
   static void shouldBailEarlyIfQueryCountExceedsControlCount() {
-    Account acc = new Account(Name = 'Parent to cpa');
-    insert acc;
+    Account acc = [SELECT Id FROM Account];
 
     ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Child cpa');
     control.MaxNumberOfQueries__c = 1;
@@ -90,7 +92,7 @@ private class RollupRelationshipFieldFinderTests {
     Account intermediateTwo = new Account(Name = 'Intermediate 2');
     insert new List<Account>{ intermediateOne, intermediateTwo };
 
-    List<Account> updatedAccounts = [SELECT Id, OwnerId, Name FROM Account];
+    List<Account> updatedAccounts = [SELECT Id, OwnerId, Name FROM Account WHERE NAME LIKE 'Intermediate%' LIMIT 2];
     if (updatedAccounts.size() == 2) {
       // don't run the rest of the test if the org has some kind of ownership assignment going on that would invalidate
       // the results
@@ -137,8 +139,7 @@ private class RollupRelationshipFieldFinderTests {
 
   @IsTest
   static void shouldReportReparentingCorrectlyForNulls() {
-    Account intermediateOne = new Account(Name = 'Intermediate 1');
-    insert new List<Account>{ intermediateOne };
+    Account intermediateOne = [SELECT Id FROM Account];
 
     ContactPointAddress cpa = new ContactPointAddress(ParentId = intermediateOne.Id, Name = 'Child reparented');
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{ cpa };
@@ -174,24 +175,24 @@ private class RollupRelationshipFieldFinderTests {
 
   @IsTest
   static void shouldReportReparentingCorrectlyForImmediateParent() {
-    Account parentOne = new Account(Name = 'Parent1');
+    Account parentOne = [SELECT Id FROM Account];
     Account parentTwo = new Account(Name = 'Parent2');
-    insert new List<Account>{ parentOne, parentTwo };
+    insert parentTwo;
 
     ContactPointAddress cpaOne = new ContactPointAddress(ParentId = parentOne.Id, Name = 'Child1');
     ContactPointAddress cpaTwo = new ContactPointAddress(ParentId = parentOne.Id, Name = 'Child2');
-    List<ContactPointAddress> opps = new List<ContactPointAddress>{ cpaOne, cpaTwo };
-    insert opps;
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{ cpaOne, cpaTwo };
+    insert cpas;
 
-    Map<Id, SObject> oldOpps = new Map<Id, SObject>{ cpaOne.Id => cpaOne, cpaTwo.Id => new ContactPointAddress(ParentId = parentTwo.Id) };
+    Map<Id, SObject> oldCpas = new Map<Id, SObject>{ cpaOne.Id => cpaOne, cpaTwo.Id => new ContactPointAddress(ParentId = parentTwo.Id) };
     RollupRelationshipFieldFinder finder = new RollupRelationshipFieldFinder(
       control,
       new Rollup__mdt(GrandparentRelationshipFieldPath__c = 'Name'),
       new Set<String>{ 'Name', 'Id' },
       Account.SObjectType,
-      oldOpps
+      oldCpas
     );
-    RollupRelationshipFieldFinder.Traversal traversal = finder.getParents(opps);
+    RollupRelationshipFieldFinder.Traversal traversal = finder.getParents(cpas);
 
     System.assertEquals(true, traversal.isUltimatelyReparented(cpaTwo, 'ParentId'));
     System.assertEquals(false, traversal.isUltimatelyReparented(cpaOne, 'ParentId'));
@@ -199,8 +200,7 @@ private class RollupRelationshipFieldFinderTests {
 
   @IsTest
   static void shouldTrackMultipleParents() {
-    Account parentOne = new Account(Name = 'SoloParent');
-    insert parentOne;
+    Account parentOne = [SELECT Id FROM Account];
 
     ContactPointAddress cpaOne = new ContactPointAddress(ParentId = parentOne.Id, Name = 'FirstParentedChild');
     ContactPointAddress cpaTwo = new ContactPointAddress(ParentId = parentOne.Id, Name = 'SecondParentedChild');
@@ -263,8 +263,7 @@ private class RollupRelationshipFieldFinderTests {
 
   @IsTest
   static void shouldTraverseAllTheWayUpWhenMetadataFlagIsEnabled() {
-    Account parentOne = new Account(Name = 'ultimate parent');
-    insert parentOne;
+    Account parentOne = [SELECT Id FROM Account];
     Account parentTwo = new Account(Name = 'child parent', ParentId = parentOne.Id);
     // also start another chain of relationships
     Account secondParent = new Account(Name = 'second child parent', ParentId = parentOne.Id);
@@ -304,5 +303,33 @@ private class RollupRelationshipFieldFinderTests {
     Account expectedAcc = (Account) RollupTestUtils.queryRecord(parentOne.Id);
     System.assertEquals(expectedAcc, traversal.retrieveParent(cpaOne.Id), 'Ultimate parent should have been used!');
     System.assertEquals(expectedAcc, traversal.retrieveParent(cpaTwo.Id), 'Ultimate parent should be found even if 5+ levels deep in hierarchy');
+  }
+
+  @IsTest
+  static void shouldWorkWithHierarchiesWhereLookupFieldDiffersFromHierarchy() {
+    Account hierarchyParent = [SELECT Id FROM Account];
+    Account parent = new Account(Name = 'child parent', ParentId = hierarchyParent.Id);
+    insert parent;
+
+    Contact con = new Contact(LastName = 'hierarchy child', AccountId = parent.Id);
+    List<Contact> cons = new List<Contact>{ con };
+    insert cons;
+
+    RollupRelationshipFieldFinder finder = new RollupRelationshipFieldFinder(
+      control,
+      new Rollup__mdt(
+        RollupToUltimateParent__c = true,
+        UltimateParentLookup__c = 'ParentId',
+        LookupFieldOnCalcItem__c = 'AccountId'
+      ),
+      new Set<String>{ 'Name', 'Id' },
+      Account.SObjectType,
+      new Map<Id, SObject>()
+    );
+
+    RollupRelationshipFieldFinder.Traversal traversal = finder.getParents(cons);
+    Account expectedAcc = [SELECT Id FROM Account WHERE Id = :hierarchyParent.Id];
+    Account retrievedAcc = (Account) traversal.retrieveParent(con.Id);
+    System.assertEquals(expectedAcc.Id, retrievedAcc.Id, 'Should correctly retrieve hierarchy');
   }
 }

--- a/extra-tests/classes/RollupTestUtils.cls
+++ b/extra-tests/classes/RollupTestUtils.cls
@@ -56,4 +56,36 @@ public class RollupTestUtils {
 
     return mock;
   }
+
+  /**
+   * Returns a record using dynamic SOQL to prevent CurrencyIsoCode from being strongly typed anywhere in the tests
+   */
+  public static SObject queryRecord(Id recordId) {
+    return queryRecord(recordId, new List<String>());
+  }
+
+  public static SObject queryRecord(Id recordId, List<String> fieldNames) {
+    return queryRecord(recordId, null, fieldNames);
+  }
+
+  public static SObject queryrecord(String fromObject, List<String> fieldNames) {
+    return queryRecord(null, fromObject, fieldNames);
+  }
+
+  private static SObject queryRecord(Id recordId, String fromObject, List<String> fieldNames) {
+    SObjectType sObjectType = recordId != null ? recordId.getSObjectType() : ((SObject) Type.forName(fromObject).newInstance()).getSObjectType();
+    String currencyIscoCodeFieldName = 'CurrencyIsoCode';
+    if (fieldNames.contains('Id') == false) {
+      fieldNames.add('Id');
+    }
+    if (fieldNames.contains('Name') == false) {
+      fieldNames.add('Name');
+    }
+    if (UserInfo.isMultiCurrencyOrganization() && sObjectType.getDescribe().fields.getMap().containsKey(currencyIscoCodeFieldName)) {
+      fieldNames.add(currencyIscoCodeFieldName);
+    }
+    String whereClause = recordId == null ? '' :  '\nWHERE Id = :recordId';
+    String recordQuery = 'SELECT ' + String.join(fieldNames, ', ') + '\nFROM ' + sObjectType + whereClause;
+    return Database.query(recordQuery);
+  }
 }

--- a/extra-tests/objects/Account/fields/MaxAmountRollupSummary__c.field-meta.xml
+++ b/extra-tests/objects/Account/fields/MaxAmountRollupSummary__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>MaxAmountRollupSummary__c</fullName>
+    <description>Rollup field of Opportunity.Amount, using standard Salesforce rollup summary field functionality</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Rollup field of Opportunity.Amount, using standard Salesforce rollup summary field functionality</inlineHelpText>
+    <label>Max Amount (Rollup Summary)</label>
+    <summarizedField>Opportunity.Amount</summarizedField>
+    <summaryForeignKey>Opportunity.AccountId</summaryForeignKey>
+    <summaryOperation>max</summaryOperation>
+    <type>Summary</type>
+</CustomField>

--- a/extra-tests/objects/Account/fields/MinAmountRollupSummary__c.field-meta.xml
+++ b/extra-tests/objects/Account/fields/MinAmountRollupSummary__c.field-meta.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>TotalAmountRollupSummary__c</fullName>
+    <fullName>MinAmountRollupSummary__c</fullName>
     <description>Rollup field of Opportunity.Amount, using standard Salesforce rollup summary field functionality</description>
     <externalId>false</externalId>
     <inlineHelpText>Rollup field of Opportunity.Amount, using standard Salesforce rollup summary field functionality</inlineHelpText>
-    <label>Total Amount (Rollup Summary)</label>
+    <label>Min Amount (Rollup Summary)</label>
     <summarizedField>Opportunity.Amount</summarizedField>
     <summaryForeignKey>Opportunity.AccountId</summaryForeignKey>
-    <summaryOperation>sum</summaryOperation>
+    <summaryOperation>min</summaryOperation>
     <type>Summary</type>
 </CustomField>

--- a/extra-tests/objects/Account/fields/SumAmountRollupSummary__c.field-meta.xml
+++ b/extra-tests/objects/Account/fields/SumAmountRollupSummary__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>SumAmountRollupSummary__c</fullName>
+    <description>Rollup field of Opportunity.Amount, using standard Salesforce rollup summary field functionality</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Rollup field of Opportunity.Amount, using standard Salesforce rollup summary field functionality</inlineHelpText>
+    <label>Sum Amount (Rollup Summary)</label>
+    <summarizedField>Opportunity.Amount</summarizedField>
+    <summaryForeignKey>Opportunity.AccountId</summaryForeignKey>
+    <summaryOperation>sum</summaryOperation>
+    <type>Summary</type>
+</CustomField>

--- a/extra-tests/objects/Account/fields/TotalAmountRollupSummary__c.field-meta.xml
+++ b/extra-tests/objects/Account/fields/TotalAmountRollupSummary__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>TotalAmountRollupSummary__c</fullName>
+    <description>Rollup field of Opportunity.Amount, using standard Salesforce rollup summary field functionality</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Rollup field of Opportunity.Amount, using standard Salesforce rollup summary field functionality</inlineHelpText>
+    <label>Total Amount (Rollup Summary)</label>
+    <summarizedField>Opportunity.Amount</summarizedField>
+    <summaryForeignKey>Opportunity.AccountId</summaryForeignKey>
+    <summaryOperation>sum</summaryOperation>
+    <type>Summary</type>
+</CustomField>

--- a/extra-tests/profiles/Admin.profile-meta.xml
+++ b/extra-tests/profiles/Admin.profile-meta.xml
@@ -77,6 +77,21 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Account.MaxAmountRollupSummary__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Account.MinAmountRollupSummary__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Account.SumAmountRollupSummary__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Application__c.Engagement_Score__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.2.42.0",
+  "version": "1.2.43.0",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -198,7 +198,7 @@ global without sharing virtual class Rollup {
     isDeferralAllowed = value;
   }
 
-  protected Rollup getAsyncRollup(
+  protected RollupAsyncProcessor getAsyncRollup(
     List<Rollup__mdt> rollupOperations,
     SObjectType sObjectType,
     List<SObject> calcItems,
@@ -2125,7 +2125,7 @@ global without sharing virtual class Rollup {
     return null;
   }
 
-  private static Rollup getRollup(
+  private static RollupAsyncProcessor getRollup(
     List<Rollup__mdt> rollupOperations,
     SObjectType sObjectType,
     List<SObject> calcItems,
@@ -2133,7 +2133,7 @@ global without sharing virtual class Rollup {
     Evaluator eval,
     InvocationPoint rollupInvokePoint
   ) {
-    Rollup rollupConductor = new RollupAsyncProcessor(rollupInvokePoint, calcItems, oldCalcItems);
+    RollupAsyncProcessor rollupConductor = new RollupAsyncProcessor(rollupInvokePoint, calcItems, oldCalcItems);
     if (rollupOperations.isEmpty() || calcItems.isEmpty()) {
       return rollupConductor;
     } else if (rollupOperations.size() == 1) {

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -40,7 +40,6 @@ global without sharing virtual class Rollup {
   protected Boolean isFullRecalc = false;
   protected Boolean isNoOp;
   protected Boolean isCDCUpdate = false;
-  protected RollupAsyncProcessor fullRecalcProcessor;
   protected Integer queryCount;
 
   /**
@@ -229,7 +228,9 @@ global without sharing virtual class Rollup {
 
   protected virtual Map<String, String> customizeToStringEntries(Map<String, String> props) {
     this.addToMap(props, 'Calc Items', this.calcItems?.size() > 10 ? (Object) '10 items or more ...' : (Object) this.calcItems);
-    this.addToMap(props, 'Old Calc Items', this.oldCalcItems?.size() > 10 ? (Object) '10 items or more ...' : (Object) this.oldCalcItems);
+    if (this.oldCalcItems?.isEmpty() == false) {
+      this.addToMap(props, 'Old Calc Items', this.oldCalcItems.size() > 10 ? (Object) '10 items or more ...' : (Object) this.oldCalcItems);
+    }
     this.addToMap(props, 'Rollup Metadata', this.metadata);
     this.addToMap(props, 'Rollup Control', this.rollupControl);
     this.addToMap(props, 'Query Count', this.queryCount);

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -141,6 +141,8 @@ global without sharing virtual class Rollup {
 
   public virtual class DMLHelper {
     public virtual void doUpdate(List<SObject> recordsToUpdate) {
+      recordsToUpdate.sort();
+      RollupLogger.Instance.log('updating the following records:', recordsToUpdate, LoggingLevel.FINE);
       Database.DMLOptions dmlOptions = new Database.DMLOptions();
       dmlOptions.AllowFieldTruncation = true;
       Database.update(recordsToUpdate, dmlOptions);
@@ -2014,7 +2016,6 @@ global without sharing virtual class Rollup {
       }
     }
     if (String.isNotBlank(potentialWhereClause)) {
-      // String whereClause = '' + potentialWhereClause + ' AND ';
       String whereClause = '(' + potentialWhereClause + ') AND ';
       wrapper.setQuery(whereClause + wrapper.getQuery());
     }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -12,6 +12,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
   protected final SObjectType calcItemType;
   protected Boolean isProcessed = false;
+  protected FullRecalcProcessor fullRecalcProcessor;
 
   private RollupRelationshipFieldFinder.Traversal traversal;
   private Map<SObjectType, Set<String>> lookupObjectToUniqueFieldNames;
@@ -30,6 +31,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     protected final List<Rollup__mdt> rollupInfo;
     protected final Set<Id> recordIds;
     protected final Set<Id> objIds = new Set<Id>(); // necessary; there's a bind variable in the query string
+    private final Set<String> previouslyProcessedParents = new Set<String>();
 
     public FullRecalcProcessor(String queryString, InvocationPoint invokePoint, List<Rollup__mdt> rollupInfo, SObjectType calcItemType, Set<Id> recordIds) {
       super(invokePoint);
@@ -48,6 +50,18 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       this.addToMap(props, 'Query String', this.queryString);
 
       return props;
+    }
+
+    private Boolean parentRollupFieldHasBeenReset(RollupAsyncProcessor processor, SObject parent) {
+      return this.previouslyProcessedParents.contains(this.getKey(processor, parent));
+    }
+
+    private void setProcessedParent(RollupAsyncProcessor processor, SObject parent) {
+      this.previouslyProcessedParents.add(this.getKey(processor, parent));
+    }
+
+    private String getKey(RollupAsyncProcessor processor, SObject parent) {
+      return String.valueOf(processor.opFieldOnLookupObject) + parent.Id;
     }
   }
 
@@ -278,8 +292,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     isRunningAsync = true;
     Boolean canEnqueue = Limits.getLimitQueueableJobs() > Limits.getQueueableJobs();
     RollupAsyncProcessor roll;
-    // deferred rollups delay the full batch recalc
-    // till all the others have gone
     if (this.rollups.size() == 1 && this.rollups[0] instanceof FullRecalcProcessor) {
       roll = this.rollups[0];
     } else if (this instanceof FullRecalcProcessor) {
@@ -409,9 +421,9 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
   protected void processDelegatedFullRecalcRollup(List<Rollup__mdt> rollupInfo, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
     isRunningAsync = true; // the first rollup can immediately start rolling up, instead of dispatching to a queueable / another batchable
-    Rollup roll = this.getAsyncRollup(rollupInfo, this.calcItemType, calcItems, oldCalcItems, null, this.invokePoint);
+    RollupAsyncProcessor roll = (RollupAsyncProcessor) this.getAsyncRollup(rollupInfo, this.calcItemType, calcItems, oldCalcItems, null, this.invokePoint);
     roll.isFullRecalc = true;
-    roll.fullRecalcProcessor = this;
+    roll.fullRecalcProcessor = (FullRecalcProcessor) this;
     roll.runCalc();
   }
 
@@ -438,9 +450,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       }
       Set<String> lookupKeys = lookupToCalcItems.keySet();
       String whereClause = '' + rollup.lookupFieldOnCalcItem + ' = :lookupKeys';
-      Map<Schema.SObjectType, Set<String>> localCalcToUniqueFieldNames = rollup.fullRecalcProcessor != null
+      Map<Schema.SObjectType, Set<String>> localCalcToUniqueFieldNames = rollup.fullRecalcProcessor != null && rollup.calcObjectToUniqueFieldNames != null
         ? rollup.calcObjectToUniqueFieldNames
         : this.calcObjectToUniqueFieldNames;
+
       String query = RollupQueryBuilder.Current.getQuery(
         rollup.calcItemType,
         new List<String>(localCalcToUniqueFieldNames.get(rollup.calcItemType)),
@@ -481,7 +494,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       RollupLogger.Instance.log('starting rollup for: ', roll, LoggingLevel.DEBUG);
       // for each iteration, ensure we're not operating beyond the bounds of our query limits
       if (hasExceededCurrentRollupLimits(roll.rollupControl)) {
-        RollupLogger.Instance.log('Deferring current rollup, past limits', LoggingLevel.DEBUG);
+        RollupLogger.Instance.log('deferring current rollup, past limits', LoggingLevel.DEBUG);
         this.deferredRollups.add(roll);
         continue;
       }
@@ -736,13 +749,17 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   private void resetLookupFieldsForNullOrFullRecalcs(SObject lookupItem, RollupAsyncProcessor rollup) {
-    // there's an edge case here which hasn't been a problem so far (but is worth being aware of):
-    // if multiple rollups operate on the same field on the parent item AND there are multiple full recalcs
-    // queued up in the same batched operation, this would accidentally reset the value back to the default
-    // between operations
-    if (lookupItem.get(rollup.opFieldOnLookupObject) == null || rollup.isFullRecalc) {
+    if (lookupItem.get(rollup.opFieldOnLookupObject) == null || this.isValidFullRecalcReset(rollup, lookupItem)) {
       lookupItem.put(rollup.opFieldOnLookupObject, RollupFieldInitializer.Current.getDefaultValue(rollup.opFieldOnLookupObject));
     }
+  }
+
+  private Boolean isValidFullRecalcReset(RollupAsyncProcessor rollup, SObject lookupItem) {
+    Boolean isValid = false;
+    if (rollup.isFullRecalc) {
+      isValid = rollup.fullRecalcProcessor?.parentRollupFieldHasBeenReset(rollup, lookupItem) != true;
+    }
+    return isValid;
   }
 
   private void ingestRollupControlData() {
@@ -1100,6 +1117,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       RollupLogger.Instance.log('updating record ...', LoggingLevel.FINE);
       updater.updateField(lookupRecord, newVal);
       recordsToUpdate.put(key, lookupRecord);
+      roll.fullRecalcProcessor?.setProcessedParent(roll,lookupRecord);
     }
     RollupLogger.Instance.log(logKey + ' record after rolling up: ', lookupRecord, LoggingLevel.DEBUG);
   }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -419,11 +419,11 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     return this.lookupItems;
   }
 
-  protected void processDelegatedFullRecalcRollup(List<Rollup__mdt> rollupInfo, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
+  protected void processDelegatedFullRecalcRollup(List<Rollup__mdt> rollupInfo, List<SObject> calcItems, Map<Id, SObject> oldCalcItems, FullRecalcProcessor fullRecalcProcessor) {
     isRunningAsync = true; // the first rollup can immediately start rolling up, instead of dispatching to a queueable / another batchable
-    RollupAsyncProcessor roll = (RollupAsyncProcessor) this.getAsyncRollup(rollupInfo, this.calcItemType, calcItems, oldCalcItems, null, this.invokePoint);
+    RollupAsyncProcessor roll = this.getAsyncRollup(rollupInfo, this.calcItemType, calcItems, oldCalcItems, null, this.invokePoint);
     roll.isFullRecalc = true;
-    roll.fullRecalcProcessor = (FullRecalcProcessor) this;
+    roll.fullRecalcProcessor = fullRecalcProcessor;
     roll.runCalc();
   }
 

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -906,7 +906,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
         // Check for changed values
         Object priorVal = lookupRecord.get(rollup.opFieldOnLookupObject);
-        Object newVal = this.getRollupVal(rollup, localCalcItems, priorVal, key, rollup.lookupFieldOnCalcItem);
+        Object newVal = this.calculateNewRollupVal(rollup, localCalcItems, lookupRecord, priorVal, key, rollup.lookupFieldOnCalcItem);
         this.conditionallyPerformUpdate(priorVal, newVal, lookupRecord, rollup, recordsToUpdate, updater, 'lookup');
       }
     }
@@ -1018,7 +1018,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     return oldCalcItem;
   }
 
-  private Object getRollupVal(RollupAsyncProcessor roll, List<SObject> calcItems, Object priorVal, String lookupRecordKey, SObjectField lookupKeyField) {
+  private Object calculateNewRollupVal(RollupAsyncProcessor roll, List<SObject> calcItems, SObject lookupRecord, Object priorVal, String lookupRecordKey, SObjectField lookupKeyField) {
     RollupCalculator rollupCalc = RollupCalculator.Factory.getCalculator(
       priorVal,
       roll.op,
@@ -1031,6 +1031,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     rollupCalc.setFullRecalc(roll.isFullRecalc);
     rollupCalc.setEvaluator(roll.eval);
     rollupCalc.setCDCUpdate(this.isCDCUpdate);
+    rollupCalc.setMultiCurrencyInfo(lookupRecord);
     rollupCalc.performRollup(calcItems, this.oldCalcItems);
     return rollupCalc.getReturnValue();
   }
@@ -1076,7 +1077,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         RollupLogger.Instance.log('reparenting operation: ', oldLookupsRollup, LoggingLevel.DEBUG);
 
         Object priorVal = lookupRecord.get(roll.opFieldOnLookupObject);
-        Object newVal = this.getRollupVal(oldLookupsRollup, reparentedCalcItems, priorVal, key, roll.lookupFieldOnCalcItem);
+        Object newVal = this.calculateNewRollupVal(oldLookupsRollup, reparentedCalcItems, lookupRecord, priorVal, key, roll.lookupFieldOnCalcItem);
 
         this.conditionallyPerformUpdate(priorVal, newVal, lookupRecord, roll, recordsToUpdate, updater, 'reparented');
       }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -101,6 +101,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     );
   }
 
+  // Conductor constructors - "outer" rollups that orchestrate the proceedings for inner rollups
   public RollupAsyncProcessor(InvocationPoint invokePoint) {
     super(invokePoint);
   }
@@ -113,11 +114,12 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     super(innerRollup.invokePoint, innerRollup.calcItems, innerRollup.oldCalcItems);
 
     this.rollups.addAll(innerRollup.rollups);
-    this.isNoOp = this.rollups.isEmpty() && innerRollup.metadata?.IsFullRecordSet__c == false;
+    this.isNoOp = this.rollups.isEmpty();
     this.isFullRecalc = innerRollup.isFullRecalc;
     this.isCDCUpdate = innerRollup.isCDCUpdate;
   }
 
+  // Inner rollup constructor - a rollup solely concerned with calculations
   public RollupAsyncProcessor(
     Set<Id> matchingCalcItemIds,
     SObjectField opFieldOnCalcItem,
@@ -473,6 +475,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     Map<String, SObject> updatedLookupRecords = new Map<String, SObject>();
     Map<SObjectType, RollupRelationshipFieldFinder.Traversal> grandparentRollups = new Map<SObjectType, RollupRelationshipFieldFinder.Traversal>();
     for (RollupAsyncProcessor roll : rollups) {
+      roll.isProcessed = true;
       CalcItemData data = new CalcItemData(this.calcItems, this.oldCalcItems);
       this.setupCalcItemData(roll);
       RollupLogger.Instance.log('starting rollup for: ', roll, LoggingLevel.DEBUG);
@@ -883,7 +886,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
 
     for (Integer index = lookupItems.size() - 1; index >= 0; index--) {
-      rollup.isProcessed = true;
       SObject lookupRecord = lookupItems[index];
       String key = (String) lookupRecord.get(rollup.lookupFieldOnLookupObject);
       if (calcItemsByLookupField.containsKey(key)) {
@@ -938,6 +940,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     } else if (roll instanceof FullRecalcProcessor) {
       for (RollupAsyncProcessor otherRollup : this.rollups) {
         if (roll.isProcessed == false && otherRollup != roll) {
+          RollupLogger.Instance.log('adding full recalc rollup as inner rollup:', otherRollup, LoggingLevel.DEBUG);
           roll.rollups.add(otherRollup);
         }
       }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -352,7 +352,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         return new List<SObject>();
       } else {
         List<SObject> localLookupItems;
-        if (String.isNotBlank(rollup.metadata.GrandparentRelationshipFieldPath__c)) {
+        if (String.isNotBlank(rollup.metadata.GrandparentRelationshipFieldPath__c) || rollup.metadata.RollupToUltimateParent__c) {
           localLookupItems = rollup.traversal.getAllParents();
           // winnow the list, which would otherwise occur because of specifically only querying for the objIds passed in
           for (Integer index = localLookupItems.size() - 1; index >= 0; index--) {
@@ -511,9 +511,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
 
     this.splitUpdates(updatedLookupRecords);
-
     this.getDML().doUpdate(updatedLookupRecords.values());
-
     this.processDeferredRollups();
   }
 

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -359,7 +359,9 @@ public without sharing abstract class RollupCalculator {
       String.isBlank(this.parentIsoCode) ||
       String.isBlank(calcItemIsoCode) ||
       calcItemIsoCode == this.parentIsoCode ||
-      skinnyCalcItem?.getPopulatedFieldsAsMap().containsKey(this.opFieldOnCalcItem.getDescribe().getName()) == true
+      skinnyCalcItem?.getPopulatedFieldsAsMap().containsKey(this.opFieldOnCalcItem.getDescribe().getName()) == true ||
+      CURRENCY_ISO_CODE_TO_CURRENCY.containsKey(calcItemIsoCode) == false ||
+      CURRENCY_ISO_CODE_TO_CURRENCY.containsKey(this.parentIsoCode) == false
     ) {
       return;
     }

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -1,10 +1,10 @@
 public without sharing abstract class RollupCalculator {
   private static final String CURRENCY_ISO_CODE_FIELD_NAME = 'CurrencyIsoCode';
 
-  private final Boolean isMultiCurrencyRollup;
 
   private Boolean isCDCUpdate = false;
   private Boolean isFirstTimeThrough = true;
+  private Boolean isMultiCurrencyRollup = false;
   private Boolean isRecursiveRecalc = false;
   private Boolean isFullRecalc = false;
 
@@ -117,7 +117,7 @@ public without sharing abstract class RollupCalculator {
       (String.isBlank(metadata.CalcItemWhereClause__c) ? '' : ' AND (' + metadata.CalcItemWhereClause__c + ')');
     this.isMultiCurrencyRollup =
       UserInfo.isMultiCurrencyOrganization() &&
-      (this.opFieldOnCalcItem.getDescribe().getType() == DisplayType.CURRENCY ||
+      (this.opFieldOnCalcItem?.getDescribe().getType() == DisplayType.CURRENCY ||
       this.opFieldOnLookupObject?.getDescribe().getType() == DisplayType.CURRENCY);
   }
   public virtual Object getReturnValue() {
@@ -365,12 +365,26 @@ public without sharing abstract class RollupCalculator {
       return;
     }
     // the worst possible scenario has occurred - the currencies differ and we haven't already populated the map
-    Decimal calcItemAmountInOrgCurrency = CURRENCY_ISO_CODE_TO_CURRENCY.get(calcItemIsoCode).ConversionRate / (Decimal) calcItem.get(this.opFieldOnCalcItem);
-    Decimal calcItemAmountInParentCurrency = CURRENCY_ISO_CODE_TO_CURRENCY.get(this.parentIsoCode).ConversionRate / calcItemAmountInOrgCurrency;
     skinnyCalcItem = skinnyCalcItem == null ? calcItem.clone(true, true, true, true) : skinnyCalcItem;
-    skinnyCalcItem.put(CURRENCY_ISO_CODE_FIELD_NAME, this.parentIsoCode);
-    skinnyCalcItem.put(this.opFieldOnCalcItem, calcItemAmountInParentCurrency);
+    this.convertToParentCurrency(calcItem, skinnyCalcItem, this.opFieldOnCalcItem, calcItemIsoCode);
+
+    SObjectField orderByFirstLastField = calcItem.getSObjectType().getDescribe().fields.getMap().get(this.metadata.OrderByFirstLast__c);
+    if (orderByFirstLastField != null && orderByFirstLastField != this.opFieldOnCalcItem) {
+      this.convertToParentCurrency(calcItem, skinnyCalcItem, orderByFirstLastField, calcItemIsoCode);
+    }
+
     TRANSFORMED_MULTICURRENCY_CALC_ITEMS.put(calcItem.Id, skinnyCalcItem);
+  }
+
+  private void convertToParentCurrency(SObject calcItem, SObject skinnyCalcItem, SObjectField fieldOnCalcItem, String calcItemIsoCode) {
+    if (fieldOnCalcItem.getDescribe().getType() != DisplayType.CURRENCY) {
+      return;
+    }
+
+    Decimal calcItemAmountInOrgCurrency = CURRENCY_ISO_CODE_TO_CURRENCY.get(calcItemIsoCode).ConversionRate / (Decimal) calcItem.get(fieldOnCalcItem);
+    Decimal calcItemAmountInParentCurrency = CURRENCY_ISO_CODE_TO_CURRENCY.get(this.parentIsoCode).ConversionRate / calcItemAmountInOrgCurrency;
+    skinnyCalcItem.put(CURRENCY_ISO_CODE_FIELD_NAME, this.parentIsoCode);
+    skinnyCalcItem.put(fieldOnCalcItem, calcItemAmountInParentCurrency);
   }
 
   private class CountDistinctRollupCalculator extends RollupCalculator {
@@ -1081,6 +1095,12 @@ public without sharing abstract class RollupCalculator {
         lookupKeyField
       );
       this.metadata.OrderByFirstLast__c = String.isNotBlank(metadata.OrderByFirstLast__c) ? metadata.OrderByFirstLast__c : metadata.RollupFieldOnCalcItem__c;
+      SObjectType calcItemSObjectType = ((SObject)Type.forName(this.metadata.CalcItem__c).newInstance()).getSObjectType();
+      SObjectField orderByFirstLastField = calcItemSObjectType.getDescribe().fields.getMap().get(this.metadata.OrderByFirstLast__c);
+      this.isMultiCurrencyRollup =
+        UserInfo.isMultiCurrencyOrganization() &&
+        orderByFirstLastField != null &&
+        orderByFirstLastField.getDescribe().getType() == DisplayType.CURRENCY;
     }
 
     public override void performRollup(List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -1,7 +1,6 @@
 public without sharing abstract class RollupCalculator {
   private static final String CURRENCY_ISO_CODE_FIELD_NAME = 'CurrencyIsoCode';
 
-
   private Boolean isCDCUpdate = false;
   private Boolean isFirstTimeThrough = true;
   private Boolean isMultiCurrencyRollup = false;
@@ -1095,12 +1094,9 @@ public without sharing abstract class RollupCalculator {
         lookupKeyField
       );
       this.metadata.OrderByFirstLast__c = String.isNotBlank(metadata.OrderByFirstLast__c) ? metadata.OrderByFirstLast__c : metadata.RollupFieldOnCalcItem__c;
-      SObjectType calcItemSObjectType = ((SObject)Type.forName(this.metadata.CalcItem__c).newInstance()).getSObjectType();
+      SObjectType calcItemSObjectType = ((SObject) Type.forName(this.metadata.CalcItem__c).newInstance()).getSObjectType();
       SObjectField orderByFirstLastField = calcItemSObjectType.getDescribe().fields.getMap().get(this.metadata.OrderByFirstLast__c);
-      this.isMultiCurrencyRollup =
-        UserInfo.isMultiCurrencyOrganization() &&
-        orderByFirstLastField != null &&
-        orderByFirstLastField.getDescribe().getType() == DisplayType.CURRENCY;
+      this.isMultiCurrencyRollup = UserInfo.isMultiCurrencyOrganization() && orderByFirstLastField?.getDescribe().getType() == DisplayType.CURRENCY;
     }
 
     public override void performRollup(List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -25,7 +25,7 @@ public without sharing abstract class RollupCalculator {
   @TestVisible
   private static Factory testFactory;
 
-  private static final Map<String, CurrencyInfo> CURRENCY_ISO_CODE_TO_CURRENCY = getCurrencyMap();
+  private static final Map<String, RollupCurrencyInfo> CURRENCY_ISO_CODE_TO_CURRENCY = RollupCurrencyInfo.getCurrencyMap();
   private static Map<Id, SObject> TRANSFORMED_MULTICURRENCY_CALC_ITEMS = new Map<Id, SObject>();
 
   public static Factory Factory {
@@ -1177,26 +1177,5 @@ public without sharing abstract class RollupCalculator {
 
       return this.isFirst ? returnVal : returnVal * -1;
     }
-  }
-
-  private class CurrencyInfo {
-    public String IsoCode { get; set; }
-    public Decimal ConversionRate { get; set; }
-    public Integer DecimalPlaces { get; set; }
-    public Boolean IsCorporate { get; set; }
-  }
-
-  private static Map<String, CurrencyInfo> getCurrencyMap() {
-    Map<String, CurrencyInfo> currencyInfoMap = new Map<String, CurrencyInfo>();
-    if (UserInfo.isMultiCurrencyOrganization() == false) {
-      return currencyInfoMap;
-    }
-
-    String query = 'SELECT IsoCode, ConversionRate, DecimalPlaces, IsCorporate FROM CurrencyType WHERE IsActive = TRUE';
-    List<CurrencyInfo> currencyTypes = (List<CurrencyInfo>) JSON.deserialize(JSON.serialize(Database.query(query)), List<CurrencyInfo>.class);
-    for (CurrencyInfo currencyType : currencyTypes) {
-      currencyInfoMap.put(currencyType.IsoCode, currencyType);
-    }
-    return currencyInfoMap;
   }
 }

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -115,7 +115,10 @@ public without sharing abstract class RollupCalculator {
       lookupRecordKey +
       '\'' +
       (String.isBlank(metadata.CalcItemWhereClause__c) ? '' : ' AND (' + metadata.CalcItemWhereClause__c + ')');
-    this.isMultiCurrencyRollup = UserInfo.isMultiCurrencyOrganization() && this.opFieldOnLookupObject?.getDescribe().getType() == DisplayType.CURRENCY;
+    this.isMultiCurrencyRollup =
+      UserInfo.isMultiCurrencyOrganization() &&
+      (this.opFieldOnCalcItem.getDescribe().getType() == DisplayType.CURRENCY ||
+      this.opFieldOnLookupObject?.getDescribe().getType() == DisplayType.CURRENCY);
   }
   public virtual Object getReturnValue() {
     return this.returnVal;

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -1,9 +1,12 @@
 public without sharing abstract class RollupCalculator {
+  private static final String CURRENCY_ISO_CODE_FIELD_NAME = 'CurrencyIsoCode';
+
+  private final Boolean isMultiCurrencyRollup;
+
   private Boolean isCDCUpdate = false;
   private Boolean isFirstTimeThrough = true;
   private Boolean isRecursiveRecalc = false;
   private Boolean isFullRecalc = false;
-  private Boolean isMultiCurrencyRollup;
 
   protected final SObjectField opFieldOnCalcItem;
   protected final SObjectField opFieldOnLookupObject;
@@ -112,7 +115,7 @@ public without sharing abstract class RollupCalculator {
       lookupRecordKey +
       '\'' +
       (String.isBlank(metadata.CalcItemWhereClause__c) ? '' : ' AND (' + metadata.CalcItemWhereClause__c + ')');
-    this.isMultiCurrencyRollup = UserInfo.isMultiCurrencyOrganization() && this.opFieldOnLookupObject.getDescribe().getType() == DisplayType.CURRENCY;
+    this.isMultiCurrencyRollup = UserInfo.isMultiCurrencyOrganization() && this.opFieldOnLookupObject?.getDescribe().getType() == DisplayType.CURRENCY;
   }
   public virtual Object getReturnValue() {
     return this.returnVal;
@@ -131,8 +134,8 @@ public without sharing abstract class RollupCalculator {
   }
 
   public void setMultiCurrencyInfo(SObject parentRecord) {
-    if (parentRecord.getPopulatedFieldsAsMap().containsKey('CurrencyIsoCode')) {
-      this.parentIsoCode = (String) parentRecord.get('CurrencyIsoCode');
+    if (parentRecord.getPopulatedFieldsAsMap().containsKey(CURRENCY_ISO_CODE_FIELD_NAME)) {
+      this.parentIsoCode = (String) parentRecord.get(CURRENCY_ISO_CODE_FIELD_NAME);
     }
   }
 
@@ -344,24 +347,25 @@ public without sharing abstract class RollupCalculator {
   }
 
   private void transformForMultiCurrencyOrgs(SObject calcItem) {
-    if (this.isMultiCurrencyRollup == false || calcItem.getSObjectType().getDescribe().fields.getMap().containsKey('CurrencyIsoCode') == false) {
+    if (this.isMultiCurrencyRollup == false || calcItem.getSObjectType().getDescribe().fields.getMap().containsKey(CURRENCY_ISO_CODE_FIELD_NAME) == false) {
       return;
     }
 
-    String calcItemIsoCode = (String) calcItem.get('CurrencyIsoCode');
+    String calcItemIsoCode = (String) calcItem.get(CURRENCY_ISO_CODE_FIELD_NAME);
     SObject skinnyCalcItem = TRANSFORMED_MULTICURRENCY_CALC_ITEMS.get(calcItem.Id);
     if (
+      String.isBlank(this.parentIsoCode) ||
+      String.isBlank(calcItemIsoCode) ||
       calcItemIsoCode == this.parentIsoCode ||
-      skinnyCalcItem?.getPopulatedFieldsAsMap().containsKey(this.opFieldOnCalcItem.getDescribe().getName()) == true)
-     {
+      skinnyCalcItem?.getPopulatedFieldsAsMap().containsKey(this.opFieldOnCalcItem.getDescribe().getName()) == true
+    ) {
       return;
     }
     // the worst possible scenario has occurred - the currencies differ and we haven't already populated the map
     Decimal calcItemAmountInOrgCurrency = CURRENCY_ISO_CODE_TO_CURRENCY.get(calcItemIsoCode).ConversionRate / (Decimal) calcItem.get(this.opFieldOnCalcItem);
     Decimal calcItemAmountInParentCurrency = CURRENCY_ISO_CODE_TO_CURRENCY.get(this.parentIsoCode).ConversionRate / calcItemAmountInOrgCurrency;
-    // skinnyCalcItem = skinnyCalcItem == null ? calcItem.getSObjectType().newSObject(calcItem.Id) : skinnyCalcItem;
     skinnyCalcItem = skinnyCalcItem == null ? calcItem.clone(true, true, true, true) : skinnyCalcItem;
-    skinnyCalcItem.put('CurrencyIsoCode', this.parentIsoCode);
+    skinnyCalcItem.put(CURRENCY_ISO_CODE_FIELD_NAME, this.parentIsoCode);
     skinnyCalcItem.put(this.opFieldOnCalcItem, calcItemAmountInParentCurrency);
     TRANSFORMED_MULTICURRENCY_CALC_ITEMS.put(calcItem.Id, skinnyCalcItem);
   }

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -3,6 +3,7 @@ public without sharing abstract class RollupCalculator {
   private Boolean isFirstTimeThrough = true;
   private Boolean isRecursiveRecalc = false;
   private Boolean isFullRecalc = false;
+  private Boolean isMultiCurrencyRollup;
 
   protected final SObjectField opFieldOnCalcItem;
   protected final SObjectField opFieldOnLookupObject;
@@ -17,9 +18,13 @@ public without sharing abstract class RollupCalculator {
   protected Object returnVal;
   protected Boolean isLastItem = false;
   protected Boolean shouldTriggerFullRecalc;
+  protected String parentIsoCode;
 
   @TestVisible
   private static Factory testFactory;
+
+  private static final Map<String, CurrencyInfo> CURRENCY_ISO_CODE_TO_CURRENCY = getCurrencyMap();
+  private static Map<Id, SObject> TRANSFORMED_MULTICURRENCY_CALC_ITEMS = new Map<Id, SObject>();
 
   public static Factory Factory {
     get {
@@ -107,6 +112,7 @@ public without sharing abstract class RollupCalculator {
       lookupRecordKey +
       '\'' +
       (String.isBlank(metadata.CalcItemWhereClause__c) ? '' : ' AND (' + metadata.CalcItemWhereClause__c + ')');
+    this.isMultiCurrencyRollup = UserInfo.isMultiCurrencyOrganization() && this.opFieldOnLookupObject.getDescribe().getType() == DisplayType.CURRENCY;
   }
   public virtual Object getReturnValue() {
     return this.returnVal;
@@ -122,6 +128,12 @@ public without sharing abstract class RollupCalculator {
 
   public void setFullRecalc(Boolean isFullRecalc) {
     this.isFullRecalc = isFullRecalc;
+  }
+
+  public void setMultiCurrencyInfo(SObject parentRecord) {
+    if (parentRecord.getPopulatedFieldsAsMap().containsKey('CurrencyIsoCode')) {
+      this.parentIsoCode = (String) parentRecord.get('CurrencyIsoCode');
+    }
   }
 
   public virtual void performRollup(List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
@@ -255,10 +267,12 @@ public without sharing abstract class RollupCalculator {
     for (SObject item : temporaryItems) {
       SObject potentialOldItem = oldCalcItems.containsKey(item.Id) ? oldCalcItems.get(item.Id) : item;
       if (this.eval?.matches(item) != false) {
-        items.add(item);
+        this.transformForMultiCurrencyOrgs(item);
+        items.add(this.getTransformedCalcItem(item));
       } else if (this.op == Rollup.Op.UPDATE_COUNT && this.eval?.matches(item) == false && this.eval?.matches(potentialOldItem) == true) {
         // TODO - handle old item matching, new item not matching situation for (other non-full recalc) operations
-        items.add(item);
+        this.transformForMultiCurrencyOrgs(item);
+        items.add(this.getTransformedCalcItem(item));
       }
     }
 
@@ -278,6 +292,10 @@ public without sharing abstract class RollupCalculator {
 
   protected Boolean isReparented(SObject calcItem, SObject oldCalcItem) {
     return calcItem.get(this.lookupKeyField) != oldCalcItem.get(this.lookupKeyField);
+  }
+
+  protected SObject getTransformedCalcItem(SObject calcItem) {
+    return TRANSFORMED_MULTICURRENCY_CALC_ITEMS.containsKey(calcItem.Id) ? TRANSFORMED_MULTICURRENCY_CALC_ITEMS.get(calcItem.Id) : calcItem;
   }
 
   protected Object performBaseCalculation(Rollup.Op op, Set<Id> objIds, SObjectType sObjectType) {
@@ -305,6 +323,7 @@ public without sharing abstract class RollupCalculator {
           this.lookupRecordKey,
           this.lookupKeyField
         );
+        calc.parentIsoCode = this.parentIsoCode;
         calc.performRollup(allOtherItems, new Map<Id, SObject>());
         this.returnVal = calc.getReturnValue();
       }
@@ -322,6 +341,29 @@ public without sharing abstract class RollupCalculator {
       results = Database.query(query);
     }
     return results;
+  }
+
+  private void transformForMultiCurrencyOrgs(SObject calcItem) {
+    if (this.isMultiCurrencyRollup == false || calcItem.getSObjectType().getDescribe().fields.getMap().containsKey('CurrencyIsoCode') == false) {
+      return;
+    }
+
+    String calcItemIsoCode = (String) calcItem.get('CurrencyIsoCode');
+    SObject skinnyCalcItem = TRANSFORMED_MULTICURRENCY_CALC_ITEMS.get(calcItem.Id);
+    if (
+      calcItemIsoCode == this.parentIsoCode ||
+      skinnyCalcItem?.getPopulatedFieldsAsMap().containsKey(this.opFieldOnCalcItem.getDescribe().getName()) == true)
+     {
+      return;
+    }
+    // the worst possible scenario has occurred - the currencies differ and we haven't already populated the map
+    Decimal calcItemAmountInOrgCurrency = CURRENCY_ISO_CODE_TO_CURRENCY.get(calcItemIsoCode).ConversionRate / (Decimal) calcItem.get(this.opFieldOnCalcItem);
+    Decimal calcItemAmountInParentCurrency = CURRENCY_ISO_CODE_TO_CURRENCY.get(this.parentIsoCode).ConversionRate / calcItemAmountInOrgCurrency;
+    // skinnyCalcItem = skinnyCalcItem == null ? calcItem.getSObjectType().newSObject(calcItem.Id) : skinnyCalcItem;
+    skinnyCalcItem = skinnyCalcItem == null ? calcItem.clone(true, true, true, true) : skinnyCalcItem;
+    skinnyCalcItem.put('CurrencyIsoCode', this.parentIsoCode);
+    skinnyCalcItem.put(this.opFieldOnCalcItem, calcItemAmountInParentCurrency);
+    TRANSFORMED_MULTICURRENCY_CALC_ITEMS.put(calcItem.Id, skinnyCalcItem);
   }
 
   private class CountDistinctRollupCalculator extends RollupCalculator {
@@ -1112,5 +1154,26 @@ public without sharing abstract class RollupCalculator {
 
       return this.isFirst ? returnVal : returnVal * -1;
     }
+  }
+
+  private class CurrencyInfo {
+    public String IsoCode { get; set; }
+    public Decimal ConversionRate { get; set; }
+    public Integer DecimalPlaces { get; set; }
+    public Boolean IsCorporate { get; set; }
+  }
+
+  private static Map<String, CurrencyInfo> getCurrencyMap() {
+    Map<String, CurrencyInfo> currencyInfoMap = new Map<String, CurrencyInfo>();
+    if (UserInfo.isMultiCurrencyOrganization() == false) {
+      return currencyInfoMap;
+    }
+
+    String query = 'SELECT IsoCode, ConversionRate, DecimalPlaces, IsCorporate FROM CurrencyType WHERE IsActive = TRUE';
+    List<CurrencyInfo> currencyTypes = (List<CurrencyInfo>) JSON.deserialize(JSON.serialize(Database.query(query)), List<CurrencyInfo>.class);
+    for (CurrencyInfo currencyType : currencyTypes) {
+      currencyInfoMap.put(currencyType.IsoCode, currencyType);
+    }
+    return currencyInfoMap;
   }
 }

--- a/rollup/core/classes/RollupCurrencyInfo.cls
+++ b/rollup/core/classes/RollupCurrencyInfo.cls
@@ -1,0 +1,21 @@
+public class RollupCurrencyInfo {
+
+  public String IsoCode { get; set; }
+  public Decimal ConversionRate { get; set; }
+  public Integer DecimalPlaces { get; set; }
+  public Boolean IsCorporate { get; set; }
+
+  public static Map<String, RollupCurrencyInfo> getCurrencyMap() {
+    Map<String, RollupCurrencyInfo> currencyInfoMap = new Map<String, RollupCurrencyInfo>();
+    if (UserInfo.isMultiCurrencyOrganization() == false) {
+      return currencyInfoMap;
+    }
+
+    String query = 'SELECT IsoCode, ConversionRate, DecimalPlaces, IsCorporate FROM CurrencyType WHERE IsActive = TRUE';
+    List<RollupCurrencyInfo> currencyTypes = (List<RollupCurrencyInfo>) JSON.deserialize(JSON.serialize(Database.query(query)), List<RollupCurrencyInfo>.class);
+    for (RollupCurrencyInfo currencyType : currencyTypes) {
+      currencyInfoMap.put(currencyType.IsoCode, currencyType);
+    }
+    return currencyInfoMap;
+  }
+}

--- a/rollup/core/classes/RollupCurrencyInfo.cls-meta.xml
+++ b/rollup/core/classes/RollupCurrencyInfo.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+	<apiVersion>52.0</apiVersion>
+	<status>Active</status>
+</ApexClass>

--- a/rollup/core/classes/RollupDeferredFullRecalcProcessor.cls
+++ b/rollup/core/classes/RollupDeferredFullRecalcProcessor.cls
@@ -33,7 +33,8 @@ public class RollupDeferredFullRecalcProcessor extends RollupAsyncProcessor.Full
       this.invokePoint
     );
     processor.isFullRecalc = true;
-    for (Rollup innerRoll : processor.rollups) {
+    for (RollupAsyncProcessor innerRoll : processor.rollups) {
+      innerRoll.fullRecalcProcessor = this;
       innerRoll.isFullRecalc = true;
       innerRoll.calcItems = localCalcItems;
     }

--- a/rollup/core/classes/RollupDeferredFullRecalcProcessor.cls
+++ b/rollup/core/classes/RollupDeferredFullRecalcProcessor.cls
@@ -24,7 +24,7 @@ public class RollupDeferredFullRecalcProcessor extends RollupAsyncProcessor.Full
   private RollupAsyncProcessor getProcessor() {
     this.isProcessed = true;
     List<SObject> localCalcItems = Database.query(this.queryString);
-    RollupAsyncProcessor processor = (RollupAsyncProcessor) this.getAsyncRollup(
+    RollupAsyncProcessor processor = this.getAsyncRollup(
       this.rollupInfo,
       this.calcItemType,
       localCalcItems,

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -38,6 +38,8 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
 
   public abstract Boolean matches(Object calcItem);
 
+  public abstract override String toString();
+
   public static WhereFieldEvaluator getWhereEval(String calcItemWhereClause, SObjectType calcItemType) {
     String key = calcItemWhereClause + calcItemType;
     WhereFieldEvaluator eval;
@@ -89,6 +91,10 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
     public override Boolean matches(Object calcItem) {
       return true;
     }
+
+    public override String toString() {
+      return AlwaysTrueEvaluator.class.getName();
+    }
   }
 
   private class CombinedEvaluator extends RollupEvaluator {
@@ -101,7 +107,13 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
     }
 
     public override Boolean matches(Object calcItem) {
-      return this.firstEval.matches(calcItem) && this.secondEval.matches(calcItem);
+      Boolean matches = this.firstEval.matches(calcItem) && this.secondEval.matches(calcItem);
+      addLog(this, matches, calcItem, LoggingLevel.FINER);
+      return matches;
+    }
+
+    public override String toString() {
+      return CombinedEvaluator.class.getName() + '\nFirst eval: ' + this.firstEval.toString() + '\nSecond eval: ' + this.secondEval.toString();
     }
   }
 
@@ -126,8 +138,12 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
           }
         }
       }
-      addFinestLog(SObjectChangedFieldEvaluator.class, matches, calcItem);
+      addLog(this, matches, calcItem, LoggingLevel.FINER);
       return matches;
+    }
+
+    public override String toString() {
+      return SObjectChangedFieldEvaluator.class.getName() + '\nChanged fields: ' + changedFieldNames;
     }
   }
 
@@ -151,6 +167,10 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       this.createConditions(calcItemSObjectType);
       this.validRelationshipNames = this.getValidRelationshipNames(calcItemSObjectType);
       RollupLogger.Instance.log('Where clause for eval: ' + this.whereClause, LoggingLevel.FINER);
+    }
+
+    public override String toString() {
+      return WhereFieldEvaluator.class.getName() + '\nWhere clause: ' + this.originalWhereClause;
     }
 
     public List<String> getWhereClauses() {
@@ -195,9 +215,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
     }
 
     public override Boolean matches(Object calcItem) {
-      Boolean matches = this.innerMatches(calcItem);
-      addFinestLog(WhereFieldEvaluator.class, matches, calcItem);
-      return matches;
+      return this.innerMatches(calcItem);
     }
 
     private Boolean innerMatches(Object calcItem) {
@@ -205,6 +223,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       if (matches) {
         for (ConditionalGrouping conditionalGrouping : this.conditionalGroupings) {
           Boolean hasInnerMatch = conditionalGrouping.equals(calcItem);
+          addLog(conditionalGrouping, hasInnerMatch, calcItem, LoggingLevel.FINEST);
           if (hasInnerMatch && conditionalGrouping.isOrConditional()) {
             matches = true;
           } else if (conditionalGrouping.isOrConditional() == false) {
@@ -358,7 +377,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       List<WhereFieldCondition> conditions = new List<WhereFieldCondition>();
       localClause = localClause.trim();
       String fieldName = localClause.substring(0, localClause.indexOf(' '));
-      localClause = localClause.replace(fieldName, '').trim();
+      localClause = localClause.removeStart(fieldName).trim();
       String criteria = localClause.substring(0, localClause.indexOf(' ')).trim();
       String value = this.getValue(localClause.substringAfter(criteria));
 
@@ -430,6 +449,10 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
     }
 
     protected abstract Boolean conditionallyEquals(Object calcItem);
+
+    public override String toString() {
+      return ConditionalGrouping.class.getName() + '\nIs Or Conditional: ' + this.isOrConditional() + '\nInner conditions: ' + this.innerConditions;
+    }
   }
 
   private class OrConditionalGrouping extends ConditionalGrouping {
@@ -709,6 +732,10 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       }
     }
 
+    public override String toString() {
+      return RecursiveUpdateEvaluator.class.getName() + ' tracking ' + OPERATION_TO_RECURSION_TRACKER.size() + ' potentially recursive operations';
+    }
+
     // at some point, it's possible that this will be revisited, but for now recursion detection
     // for grandparent / ultimate parent rollups is not supported
     public override Boolean matches(Object item) {
@@ -729,14 +756,14 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
           matches = false;
         }
       }
-      addFinestLog(RecursiveUpdateEvaluator.class, matches, item);
+      addLog(this, matches, item, LoggingLevel.FINER);
 
       return matches;
     }
   }
 
-  private static void addFinestLog(Type clazz, Boolean matches, Object item) {
-    RollupLogger.Instance.log(clazz.getName() + ' matches? ' + matches + ' for: ' + item, LoggingLevel.FINEST);
+  private static void addLog(Object clazz, Boolean matches, Object item, LoggingLevel logLevel) {
+    RollupLogger.Instance.log(clazz + '\nmatches? ' + matches + ' for: ' + item, logLevel);
   }
 
   @TestVisible

--- a/rollup/core/classes/RollupFlowBulkProcessor.cls
+++ b/rollup/core/classes/RollupFlowBulkProcessor.cls
@@ -12,7 +12,7 @@ global without sharing class RollupFlowBulkProcessor {
     global String rollupContext;
     // Shared between this and Rollup.FlowInput
     @InvocableVariable(label='Defer processing?')
-    global Boolean deferProcessing = true;
+    global Boolean deferProcessing;
     @InvocableVariable(label='Calc Item Type When Rollup Started From Parent')
     global String calcItemTypeWhenRollupStartedFromParent;
     // Optional properties that can override the CMDT values
@@ -43,7 +43,7 @@ global without sharing class RollupFlowBulkProcessor {
     )
     global Boolean isFullRecordSet;
     @InvocableVariable(label='Is Rollup Started From Parent' description='If the calc records are the parent records, set this to true')
-    global Boolean isRollupStartedFromParent = false;
+    global Boolean isRollupStartedFromParent;
     @InvocableVariable(label='Order By (First/Last)' description='First/Last order by field')
     global String orderByFirstLast;
 
@@ -51,12 +51,12 @@ global without sharing class RollupFlowBulkProcessor {
       label='Should rollup to ultimate hierarchy parent'
       description='Used in conjunction with Ultimate Parent Field to drive hierarchical parent rollups'
     )
-    global Boolean rollupToUltimateParent = false;
+    global Boolean rollupToUltimateParent;
     @InvocableVariable(
       label='Should run sync?'
       description='Runs rollup calculations synchronously when set to true'
     )
-    global Boolean shouldRunSync = false;
+    global Boolean shouldRunSync;
     @InvocableVariable(label='SOQL Where Clause To Exclude Calc Items' description='If provided, excludes records based on a valid SOQL where clause')
     global String calcItemWhereClause;
     @InvocableVariable(label='Ultimate Parent Field' description='The lookup field in hierarchy rollups')
@@ -115,8 +115,8 @@ global without sharing class RollupFlowBulkProcessor {
             input.rollupContext = flowInput.rollupContext;
             input.recordsToRollup = flowInput.recordsToRollup;
             input.oldRecordsToRollup = flowInput.oldRecordsToRollup;
-            input.deferProcessing = flowInput.deferProcessing;
-            input.shouldRunSync = flowInput.shouldRunSync;
+            input.deferProcessing = flowInput.deferProcessing != null ? flowInput.deferProcessing : true;
+            input.shouldRunSync = flowInput.shouldRunSync != null ? flowInput.shouldRunSync : false;
             input.calcItemTypeWhenRollupStartedFromParent = flowInput.calcItemTypeWhenRollupStartedFromParent;
             rollupFlowInputs.add(input);
 

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -28,7 +28,7 @@ public virtual class RollupFullBatchRecalculator extends RollupAsyncProcessor.Fu
      * being batched, even if the inner class is just extending the functionality of its
      * parent class
      */
-    this.processDelegatedFullRecalcRollup(this.rollupInfo, calcItems, new Map<Id, SObject>());
+    this.processDelegatedFullRecalcRollup(this.rollupInfo, calcItems, new Map<Id, SObject>(), this);
     RollupLogger.Instance.save();
   }
 

--- a/rollup/core/classes/RollupQueryBuilder.cls
+++ b/rollup/core/classes/RollupQueryBuilder.cls
@@ -19,6 +19,10 @@ public without sharing class RollupQueryBuilder {
     Map<String, SObjectField> baseFields = sObjectToken.fields.getMap();
     Set<String> lowerCaseFieldNames = new Set<String>();
 
+    if (UserInfo.isMultiCurrencyOrganization() && uniqueQueryFieldNames.contains('Count()') == false) {
+      uniqueQueryFieldNames.add('CurrencyIsoCode');
+    }
+
     for (Integer index = uniqueQueryFieldNames.size() - 1; index >= 0; index--) {
       String uniqueFieldName = uniqueQueryFieldNames[index];
       if (String.isBlank(uniqueFieldName)) {

--- a/rollup/core/classes/RollupQueryBuilder.cls
+++ b/rollup/core/classes/RollupQueryBuilder.cls
@@ -5,6 +5,8 @@ public without sharing class RollupQueryBuilder {
   public static final RollupQueryBuilder Current = new RollupQueryBuilder();
   public static final Integer SENTINEL_COUNT_VALUE = -1;
 
+  private static final String CURRENCY_ISO_CODE_FIELD_NAME = 'CurrencyIsoCode';
+
   /**
    * @return String `queryString` - returns a query string with "objIds" expected as a bind variable
    */
@@ -18,10 +20,6 @@ public without sharing class RollupQueryBuilder {
     DescribeSObjectResult sObjectToken = sObjectType.getDescribe();
     Map<String, SObjectField> baseFields = sObjectToken.fields.getMap();
     Set<String> lowerCaseFieldNames = new Set<String>();
-
-    if (UserInfo.isMultiCurrencyOrganization() && uniqueQueryFieldNames.contains('Count()') == false) {
-      uniqueQueryFieldNames.add('CurrencyIsoCode');
-    }
 
     for (Integer index = uniqueQueryFieldNames.size() - 1; index >= 0; index--) {
       String uniqueFieldName = uniqueQueryFieldNames[index];
@@ -54,6 +52,26 @@ public without sharing class RollupQueryBuilder {
       ) {
         uniqueQueryFieldNames[index] = uniqueFieldName;
       }
+    }
+
+    Boolean hasAggregateFunction = false;
+    for (String uniqueQueryFieldName : uniqueQueryFieldNames) {
+      // This is definitely not the most intuitive way to do this, but need to determine if the query
+      // will be a regular query vs an aggregated query - all aggregate functions use '()', so checking
+      // for '(' is a quick & lazy way to check without making larger changes to how RollupQueryBuilder works
+      // (but it's very goofy & could definitely be improved)
+      if (uniqueQueryFieldName?.contains('(')) {
+        hasAggregateFunction = true;
+        break;
+      }
+    }
+    if (
+      hasAggregateFunction == false &&
+      uniqueQueryFieldNames.contains(CURRENCY_ISO_CODE_FIELD_NAME) == false &&
+      UserInfo.isMultiCurrencyOrganization() &&
+      sObjectToken.fields.getMap().containsKey(CURRENCY_ISO_CODE_FIELD_NAME)
+    ) {
+      uniqueQueryFieldNames.add(CURRENCY_ISO_CODE_FIELD_NAME);
     }
 
     optionalWhereClause = this.adjustWhereClauseForPolymorphicFields(sObjectType, uniqueQueryFieldNames, optionalWhereClause);

--- a/rollup/core/classes/RollupQueryBuilder.cls
+++ b/rollup/core/classes/RollupQueryBuilder.cls
@@ -54,25 +54,7 @@ public without sharing class RollupQueryBuilder {
       }
     }
 
-    Boolean hasAggregateFunction = false;
-    for (String uniqueQueryFieldName : uniqueQueryFieldNames) {
-      // This is definitely not the most intuitive way to do this, but need to determine if the query
-      // will be a regular query vs an aggregated query - all aggregate functions use '()', so checking
-      // for '(' is a quick & lazy way to check without making larger changes to how RollupQueryBuilder works
-      // (but it's very goofy & could definitely be improved)
-      if (uniqueQueryFieldName?.contains('(')) {
-        hasAggregateFunction = true;
-        break;
-      }
-    }
-    if (
-      hasAggregateFunction == false &&
-      uniqueQueryFieldNames.contains(CURRENCY_ISO_CODE_FIELD_NAME) == false &&
-      UserInfo.isMultiCurrencyOrganization() &&
-      sObjectToken.fields.getMap().containsKey(CURRENCY_ISO_CODE_FIELD_NAME)
-    ) {
-      uniqueQueryFieldNames.add(CURRENCY_ISO_CODE_FIELD_NAME);
-    }
+    this.addCurrencyIsoCodeForMultiCurrencyOrgs(uniqueQueryFieldNames, sObjectToken);
 
     optionalWhereClause = this.adjustWhereClauseForPolymorphicFields(sObjectType, uniqueQueryFieldNames, optionalWhereClause);
 
@@ -155,5 +137,28 @@ public without sharing class RollupQueryBuilder {
 
   private Boolean hasPolymorphicOwnerClause(String whereClause) {
     return whereClause?.contains('.Owner') == true;
+  }
+
+  private void addCurrencyIsoCodeForMultiCurrencyOrgs(List<String> uniqueQueryFieldNames, DescribeSObjectResult sObjectToken) {
+    if (
+      UserInfo.isMultiCurrencyOrganization() &&
+      uniqueQueryFieldNames.contains(CURRENCY_ISO_CODE_FIELD_NAME) == false &&
+      sObjectToken.fields.getMap().containsKey(CURRENCY_ISO_CODE_FIELD_NAME)
+    ) {
+      Boolean hasAggregateFunction = false;
+      for (String uniqueQueryFieldName : uniqueQueryFieldNames) {
+        // This is definitely not the most intuitive way to do this, but need to determine if the query
+        // will be a regular query vs an aggregated query - all aggregate functions use '()', so checking
+        // for '(' is a quick & lazy way to check without making larger changes to how RollupQueryBuilder works
+        // (but it's very goofy & could definitely be improved)
+        if (uniqueQueryFieldName?.contains('(')) {
+          hasAggregateFunction = true;
+          break;
+        }
+      }
+      if (hasAggregateFunction == false) {
+        uniqueQueryFieldNames.add(CURRENCY_ISO_CODE_FIELD_NAME);
+      }
+    }
   }
 }

--- a/rollup/core/classes/RollupRelationshipFieldFinder.cls
+++ b/rollup/core/classes/RollupRelationshipFieldFinder.cls
@@ -261,6 +261,9 @@ public without sharing class RollupRelationshipFieldFinder {
 
   private SObject getPotentialUltimateParent(SObject childRecord) {
     Map<String, Schema.SObjectField> fieldMap = childRecord.getSObjectType().getDescribe().fields.getMap();
+    this.currentRelationshipName = this.relationshipParts.size() == 1
+      ? this.relationshipParts[0]
+      : this.currentRelationshipName;
     SObjectField lookupField = this.getField(fieldMap, this.currentRelationshipName);
     String relationshipName = lookupField.getDescribe().getRelationshipName();
     if (childRecord.get(this.metadata.UltimateParentLookup__c) != null && childRecord.getPopulatedFieldsAsMap().containsKey(relationshipName)) {
@@ -494,7 +497,15 @@ public without sharing class RollupRelationshipFieldFinder {
     }
   }
 
-  private List<SObject> performQuery(SObjectType sObjectType, List<String> queryFields, String lookupfield, String equality, Set<Id> objIds, String whereClause, List<SObject> records) {
+  private List<SObject> performQuery(
+    SObjectType sObjectType,
+    List<String> queryFields,
+    String lookupfield,
+    String equality,
+    Set<Id> objIds,
+    String whereClause,
+    List<SObject> records
+  ) {
     return Database.query(RollupQueryBuilder.Current.getQuery(sObjectType, queryFields, lookupfield, equality, whereClause));
   }
 

--- a/rollup/core/classes/RollupRelationshipFieldFinder.cls
+++ b/rollup/core/classes/RollupRelationshipFieldFinder.cls
@@ -52,6 +52,7 @@ public without sharing class RollupRelationshipFieldFinder {
     private Boolean isFinished = false;
     private Boolean isAbortedEarly = false;
 
+    private final Map<Id, SObject> finalParentIdToRecords = new Map<Id, SObject>();
     private final Map<Id, SObject> lookupIdToFinalRecords = new Map<Id, SObject>();
     private Map<Id, List<Id>> lookupIdMap = new Map<Id, List<Id>>();
     private final Map<Id, List<Id>> hierarchy = new Map<Id, List<Id>>();
@@ -166,6 +167,7 @@ public without sharing class RollupRelationshipFieldFinder {
     }
 
     if (baseSObjectType == this.ultimateParent && this.isFinishedWithHierarchyTraversal(records)) {
+      this.retrieveAdditionalHierarchyRecords(records, this.traversal.hierarchy.keySet());
       this.prepFinishedObject(records);
       return this.traversal;
     } else {
@@ -228,9 +230,8 @@ public without sharing class RollupRelationshipFieldFinder {
   private void prepFinishedObject(List<SObject> records) {
     this.traversal.isFinished = true;
     this.populateFinalRecordsMapping(records);
-    this.traversal.isFinished = true;
     this.relationshipParts = this.originalParts; // reset to initial state in case outer method is re-called
-    this.traversal.lookupIdMap = new Map<Id, List<Id>>(); // try to spare the heap
+    this.traversal.lookupIdMap.clear(); // try to spare the heap
   }
 
   private Boolean isFinishedWithHierarchyTraversal(List<SObject> records) {
@@ -409,7 +410,7 @@ public without sharing class RollupRelationshipFieldFinder {
         this.traversal.lookupIdMap.put(lookupId, new List<Id>{ recordId });
       }
 
-      if (this.isFirstRun) {
+      if (this.isFirstRun && field != null) {
         // we need to keep track of potentially reparented lookups to aid with the note below
         if (this.oldRecords.containsKey(recordId)) {
           Id oldLookupId = (Id) this.oldRecords.get(recordId).get(field);
@@ -423,12 +424,14 @@ public without sharing class RollupRelationshipFieldFinder {
         // track the hierarchy of objects to help in determining whether or not something
         // has ultimately been reparented
         // for example:
-        // * Object 1 -> Parent 1 -> Grandparent 1 could be updated to
-        // * Object 1 -> Parent 2 -> Grandparent 1
+        // * Child 1 -> Parent 1 -> Grandparent 1 could be updated to
+        // * Child 1 -> Parent 2 -> Grandparent 1
         // this would "traditionally" be a reparenting situation, but if we are skipping
         // the intermediate objects for a rollup and the end result is the same, we need
         // to avoid reporting false positives like this one
         this.traversal.hierarchy.get(recordId).add(lookupId);
+      } else {
+        this.traversal.hierarchy.put(recordId, new List<Id>{ lookupId });
       }
     }
   }
@@ -451,12 +454,87 @@ public without sharing class RollupRelationshipFieldFinder {
     }
   }
 
+  private void retrieveAdditionalHierarchyRecords(List<SObject> records, Set<Id> objIds) {
+    String whereClause = 'Id != :records';
+    if (this.metadata.RollupToUltimateParent__c == false) {
+      return;
+    } else if (records.isEmpty()) {
+      List<SObject> otherMatchingParentRecords = this.performQuery(
+        this.ultimateParent,
+        new List<String>{ this.metadata.UltimateParentLookup__c, 'Id' },
+        this.metadata.UltimateParentLookup__c,
+        '=',
+        objIds,
+        whereClause,
+        records
+      );
+      if (otherMatchingParentRecords.isEmpty() == false) {
+        this.retrieveAdditionalHierarchyRecords(otherMatchingParentRecords, objIds);
+      }
+    } else {
+      Set<Id> additionalParentIds = new Set<Id>();
+      for (SObject otherMatchingParent : records) {
+        additionalParentIds.add(otherMatchingParent.Id);
+        this.trackTraversalIds(otherMatchingParent.Id, (Id) otherMatchingParent.get(this.metadata.UltimateParentLookup__c), null, additionalParentIds);
+      }
+      List<SObject> otherPotentialParents = this.performQuery(
+        this.ultimateParent,
+        new List<String>{ this.metadata.UltimateParentLookup__c, 'Id' },
+        this.metadata.UltimateParentLookup__c,
+        '=',
+        additionalParentIds,
+        whereClause,
+        records
+      );
+      if (otherPotentialParents.isEmpty()) {
+        this.retrieveAdditionalCalcItems();
+      } else {
+        this.retrieveAdditionalHierarchyRecords(otherPotentialParents, additionalParentIds);
+      }
+    }
+  }
+
+  private List<SObject> performQuery(SObjectType sObjectType, List<String> queryFields, String lookupfield, String equality, Set<Id> objIds, String whereClause, List<SObject> records) {
+    return Database.query(RollupQueryBuilder.Current.getQuery(sObjectType, queryFields, lookupfield, equality, whereClause));
+  }
+
+  private void retrieveAdditionalCalcItems() {
+    if (this.records?.isEmpty() == false) {
+      SObjectType childType = this.records[0].getSObjectType();
+      Set<String> queryFields = new Set<String>{
+        this.metadata.LookupFieldOnCalcItem__c,
+        this.metadata.RollupFieldOnCalcItem__c,
+        this.metadata.OrderByFirstLast__c,
+        this.metadata.UltimateParentLookup__c
+      };
+      queryFields.addAll(RollupEvaluator.getWhereEval(this.metadata.CalcItemWhereClause__c, childType).getQueryFields());
+      String query = RollupQueryBuilder.Current.getQuery(childType, new List<String>(queryFields), this.metadata.LookupFieldOnCalcItem__c, '=');
+      query += '\nAND Id != :records';
+      Set<Id> objIds = this.traversal.hierarchy.keySet();
+      List<SObject> additionalCalcItems = Database.query(query);
+      this.records.addAll(additionalCalcItems);
+      for (SObject additionalCalcItem : additionalCalcItems) {
+        Id parentId = (Id) additionalCalcItem.get(this.metadata.LookupFieldOnCalcItem__c);
+        if (this.traversal.hierarchy.containsKey(parentId)) {
+          List<Id> potentialLinkedLookupIds = this.traversal.hierarchy.get(parentId);
+          for (Id potentialLinkedLookupId : potentialLinkedLookupIds) {
+            if (potentialLinkedLookupId != parentId && this.traversal.finalParentIdToRecords.containsKey(potentialLinkedLookupId)) {
+              SObject ultimateParentRecord = this.traversal.finalParentIdToRecords.get(potentialLinkedLookupId);
+              this.traversal.lookupIdToFinalRecords.put(additionalCalcItem.Id, ultimateParentRecord);
+            }
+          }
+        }
+      }
+    }
+  }
+
   private void populateFinalRecordsMapping(List<SObject> records) {
     for (SObject record : records) {
       Set<Id> descendantIds = this.getDescendantIds(record.Id, new Set<Id>());
       for (Id descendantId : descendantIds) {
         if (descendantId != record.Id) {
           this.traversal.lookupIdToFinalRecords.put(descendantId, record);
+          this.traversal.finalParentIdToRecords.put(record.Id, record);
         }
       }
     }

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -55,6 +55,9 @@ if($scratchOrgAllotment -gt 0) {
       throw $1
     }
     $userNameHasBeenSet = $true
+    # Multi-currency prep
+    Write-Output 'Importing multi-currency config data to scratch org ...'
+    sfdx force:data:tree:import -f ./config/data/CurrencyTypes.json
     # Deploy
     Write-Output 'Pushing source to scratch org ...'
     sfdx force:source:push

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -2,10 +2,10 @@
     "packageDirectories": [
         {
             "default": true,
-            "package": "apex-rollup",
+            "package": "Apex Rollup",
             "path": "rollup",
-            "versionNumber": "1.2.42.0",
-            "versionDescription": "Further REFRESH improvements, rollup logging optimizations",
+            "versionNumber": "1.2.43.0",
+            "versionDescription": "Multi-currency rollups, bugfixes",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
                 "path": "extra-tests"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -71,6 +71,6 @@
         "apex-rollup@1.2.40-0": "04t6g000008ShFvAAK",
         "apex-rollup@1.2.41-0": "04t6g000008ShJEAA0",
         "apex-rollup@1.2.42-0": "04t6g000008ShMNAA0",
-        "apex-rollup@1.2.43-0": "04t6g000008ShPCAA0"
+        "apex-rollup@1.2.43-0": "04t6g000008ShPMAA0"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -70,6 +70,7 @@
         "apex-rollup@1.2.39-0": "04t6g000008ShAVAA0",
         "apex-rollup@1.2.40-0": "04t6g000008ShFvAAK",
         "apex-rollup@1.2.41-0": "04t6g000008ShJEAA0",
-        "apex-rollup@1.2.42-0": "04t6g000008ShMNAA0"
+        "apex-rollup@1.2.42-0": "04t6g000008ShMNAA0",
+        "apex-rollup@1.2.43-0": "04t6g000008ShPCAA0"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -2,7 +2,7 @@
     "packageDirectories": [
         {
             "default": true,
-            "package": "Apex Rollup",
+            "package": "apex-rollup",
             "path": "rollup",
             "versionNumber": "1.2.43.0",
             "versionDescription": "Multi-currency rollups, bugfixes",


### PR DESCRIPTION
* @jongpie led the charge on fixing #156 by introducing basic multi-currency support - all orgs that don't make use of advanced currency management in conjunction with `DatedConversionRate` can now perform multi-currency rollups successfully (see the "Multi-Currency Orgs" section of the README for further info
* fixed #158 by properly referring to `FlowBulkProcessor` default properties
* fixed #159 by properly handling hierarchical rollups that don't make use of the Grandparent Relationship Field Path field
* fixed an issue in `RollupEvaluator` where if the value being evaluated had some text that matched its field name, part of the value could get stripped away - resulting in both false positives and false negatives!
* fixed #155 & #160 by tracking which parent-level fields have already been reset as part of a full recalculation
* tweaked the logging in `RollupEvaluator` - now, at the `FINEST` logging level, you can get extremely granular insight into how where clauses match on records; at the `FINER` level, you'll see high-level match details for a record, including which evaluators were used to perform the matching logic