### PR TITLE
V1.3.5 - Rollup Logging & Eval bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShhSAAS">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShhXAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShhSAAS">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShhXAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShgeAAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShhIAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShgeAAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShhIAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShhIAAS">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShhNAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShhIAAS">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShhNAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShhNAAS">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShhSAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShhNAAS">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShhSAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShbnAAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShgeAAC">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShbnAAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShgeAAC">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupEvaluatorTests.cls
+++ b/extra-tests/classes/RollupEvaluatorTests.cls
@@ -945,4 +945,15 @@ private class RollupEvaluatorTests {
 
     System.assertEquals(false, eval.matches(new ContactPointAddress(Name = 'oneName')));
   }
+
+  @IsTest
+  static void shouldWorkWithCarriageReturnsAndLineBreaks() {
+    Rollup.defaultControl = new RollupControl__mdt(IsRollupLoggingEnabled__c = true);
+    String whereClause = 'Name = \'someValue\' AND (PreferenceRank = 1 \r\n OR PreferenceRank = 2 \r\n OR PreferenceRank = 3)';
+
+    RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, ContactPointAddress.SObjectType);
+
+    System.assertEquals(true, eval.matches(new ContactPointAddress(Name = 'someValue', PreferenceRank = 1)));
+    System.assertEquals(false, eval.matches(new ContactPointAddress(Name = 'someValue', PreferenceRank = 0)), 'cpa should not match');
+  }
 }

--- a/extra-tests/classes/RollupEvaluatorTests.cls
+++ b/extra-tests/classes/RollupEvaluatorTests.cls
@@ -929,8 +929,26 @@ private class RollupEvaluatorTests {
   }
 
   @IsTest
-  static void shouldCorrectlyFormatInQuery() {
+  static void shouldCorrectlyFormatInQueryWithinEquality() {
     String whereClause = 'StageName IN (\'firstName\', \'secondName\')';
+
+    RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, Opportunity.SObjectType);
+
+    System.assertEquals(whereClause, eval.getSafeQuery());
+  }
+
+  @IsTest
+  static void shouldCorrectlyFormatInQueryWithinValue() {
+    String whereClause = 'StageName != \'Gift in Kind\'';
+
+    RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, Opportunity.SObjectType);
+
+    System.assertEquals(whereClause, eval.getSafeQuery());
+  }
+
+  @IsTest
+  static void shouldCorrectlyFormatCapitalizedInQueryWithinValue() {
+    String whereClause = 'StageName != \'Gift In Kind\'';
 
     RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, Opportunity.SObjectType);
 

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -10,6 +10,7 @@ private class RollupTests {
   static Rollup.Op rollupOp;
   static Boolean calcMockWasCalled = false;
 
+  @SuppressWarnings('apex-assist')
   @TestSetup
   static void setup() {
     // in the event that rollups are running in the org, we want to avoid triggering any operations while performing setup DML
@@ -194,7 +195,9 @@ private class RollupTests {
     Account acc = [SELECT Id FROM Account];
     insert new ContactPointAddress(Name = 'Test Count Distinct Insert', ParentId = acc.Id);
 
-    RollupTestUtils.DMLMock mock = RollupTestUtils.loadAccountIdMock(new List<ContactPointAddress>{ new ContactPointAddress(Name = 'Test Count Distinct Insert Two') });
+    RollupTestUtils.DMLMock mock = RollupTestUtils.loadAccountIdMock(
+      new List<ContactPointAddress>{ new ContactPointAddress(Name = 'Test Count Distinct Insert Two') }
+    );
     Rollup.apexContext = TriggerOperation.AFTER_INSERT;
 
     Test.startTest();
@@ -434,7 +437,9 @@ private class RollupTests {
   // the other tests pertaining to this are in RollupEvaluatorTests
   @IsTest
   static void shouldFilterCalcItemsBasedOnWhereClauseCmdtFieldEquals() {
-    RollupTestUtils.DMLMock mock = RollupTestUtils.loadAccountIdMock(new List<ContactPointAddress>{ new ContactPointAddress(Name = 'RollupZ'), new ContactPointAddress(Name = 'RollupZZ') });
+    RollupTestUtils.DMLMock mock = RollupTestUtils.loadAccountIdMock(
+      new List<ContactPointAddress>{ new ContactPointAddress(Name = 'RollupZ'), new ContactPointAddress(Name = 'RollupZZ') }
+    );
     Rollup.rollupMetadata = new List<Rollup__mdt>{
       new Rollup__mdt(
         RollupFieldOnCalcItem__c = 'Name',
@@ -508,7 +513,9 @@ private class RollupTests {
     acc.AnnualRevenue = 50;
     update acc;
 
-    RollupTestUtils.DMLMock mock = RollupTestUtils.loadMock(new List<ContactPointAddress>{ new ContactPointAddress(Name = 'RollupZ', ParentId = acc.Id, PreferenceRank = 50) });
+    RollupTestUtils.DMLMock mock = RollupTestUtils.loadMock(
+      new List<ContactPointAddress>{ new ContactPointAddress(Name = 'RollupZ', ParentId = acc.Id, PreferenceRank = 50) }
+    );
 
     Rollup.rollupMetadata = new List<Rollup__mdt>{
       new Rollup__mdt(
@@ -600,7 +607,9 @@ private class RollupTests {
 
   @IsTest
   static void shouldBatchThreeOperations() {
-    RollupTestUtils.DMLMock mock = RollupTestUtils.loadAccountIdMock(new List<ContactPointAddress>{ new ContactPointAddress(PreferenceRank = 100, Name = 'My test name') });
+    RollupTestUtils.DMLMock mock = RollupTestUtils.loadAccountIdMock(
+      new List<ContactPointAddress>{ new ContactPointAddress(PreferenceRank = 100, Name = 'My test name') }
+    );
     Rollup.apexContext = TriggerOperation.AFTER_INSERT;
 
     Test.startTest();
@@ -2781,6 +2790,26 @@ private class RollupTests {
   }
 
   @IsTest
+  static void shouldCountOnNonIdField() {
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{ new ContactPointAddress(Name = 'Test') };
+    RollupTestUtils.DMLMock mock = RollupTestUtils.loadAccountIdMock(cpas);
+    List<Rollup.FlowInput> flowInputs = RollupTestUtils.prepareFlowTest(cpas, 'INSERT', 'COUNT');
+    flowInputs[0].rollupFieldOnCalcItem = 'Name';
+
+    Test.startTest();
+    List<Rollup.FlowOutput> flowOutputs = Rollup.performRollup(flowInputs);
+    Test.stopTest();
+
+    System.assertEquals(1, flowOutputs.size(), 'Flow outputs were not provided');
+    System.assertEquals('SUCCESS', flowOutputs[0].message);
+    System.assertEquals(true, flowOutputs[0].isSuccess);
+
+    System.assertEquals(1, mock.Records.size(), 'COUNT AFTER_INSERT from flow did not update accounts');
+    Account updatedAcc = (Account) mock.Records[0];
+    System.assertEquals(1, updatedAcc.AnnualRevenue);
+  }
+
+  @IsTest
   static void shouldOverrideNumberBasedDefaultBasedOnMetadataForFlow() {
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{ new ContactPointAddress(PreferenceRank = 1000) };
     RollupTestUtils.DMLMock mock = RollupTestUtils.loadAccountIdMock(cpas);
@@ -3037,7 +3066,6 @@ private class RollupTests {
     Account oldAcc = new Account(AnnualRevenue = 25, Name = 'AnotherRollupTest');
     insert oldAcc;
 
-
     ContactPointAddress cpa = new ContactPointAddress(Id = RollupTestUtils.createId(ContactPointAddress.SObjectType), PreferenceRank = 50, ParentId = acc.Id);
     RollupTestUtils.DMLMock mock = RollupTestUtils.loadMock(new List<ContactPointAddress>{ cpa });
     Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
@@ -3176,7 +3204,6 @@ private class RollupTests {
 
     Account oldAcc = new Account(AnnualRevenue = 50, Name = 'AnotherRollupTest');
     insert oldAcc;
-
 
     ContactPointAddress cpa = new ContactPointAddress(Id = RollupTestUtils.createId(ContactPointAddress.SObjectType), PreferenceRank = 50, ParentId = acc.Id);
     ContactPointAddress reparentedCpa = new ContactPointAddress(

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  '**/lwc/*.js': filenames => `eslint ${filenames.join(' ')} --fix`,
+  '*.{cls,cmp,component,css,html,js,json,md,page,trigger,yaml,yml}': filenames => filenames.map(filename => `prettier --write '${filename}'`),
+  '*.{cls,trigger}': () => 'sfdx scanner:run --pmdconfig config/pmd-ruleset.xml --engine pmd --severity-threshold 3 --target .'
+};

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   '**/lwc/*.js': filenames => `eslint ${filenames.join(' ')} --fix`,
   '*.{cls,cmp,component,css,html,js,json,md,page,trigger,yaml,yml}': filenames => filenames.map(filename => `prettier --write '${filename}'`),
-  '*.{cls,trigger}': () => 'sfdx scanner:run --pmdconfig config/pmd-ruleset.xml --engine pmd --severity-threshold 3 --target .'
+  '*.{cls,trigger}': () => 'npm run scan'
 };

--- a/package.json
+++ b/package.json
@@ -8,11 +8,6 @@
   },
   "author": "james.simone",
   "license": "MIT",
-  "lint-staged": {
-    "*.js": "eslint **/lwc/** --fix",
-    "*.{cls,cmp,component,css,html,js,json,md,page,trigger,yaml,yml}": "prettier --write",
-    "*.{cls,trigger}": "sfdx scanner:run --pmdconfig config/pmd-ruleset.xml --engine pmd --severity-threshold 3 --target"
-  },
   "devDependencies": {
     "@babel/core": "latest",
     "@babel/eslint-parser": "latest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/plugins/CustomObjectRollupLogger/README.md
+++ b/plugins/CustomObjectRollupLogger/README.md
@@ -1,11 +1,11 @@
 # Custom Object Rollup Logger
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShT9AAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Shh3AAC">
   <img alt="Deploy to Salesforce"
        src="../../media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShT9AAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Shh3AAC">
   <img alt="Deploy to Salesforce Sandbox"
        src="../../media/deploy-package-to-sandbox.png">
 </a>

--- a/plugins/CustomObjectRollupLogger/objects/RollupLog__c/listViews/All.listView-meta.xml
+++ b/plugins/CustomObjectRollupLogger/objects/RollupLog__c/listViews/All.listView-meta.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ListView xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>All</fullName>
+    <columns>NAME</columns>
+    <columns>CREATEDBY_USER</columns>
+    <columns>CREATED_DATE</columns>
+    <columns>ErrorWouldHaveBeenThrown__c</columns>
+    <columns>LoggedBy__c</columns>
+    <columns>NumberOfLogEntries__c</columns>
     <filterScope>Everything</filterScope>
     <label>All</label>
 </ListView>

--- a/plugins/NebulaLogger/classes/RollupNebulaLoggerAdapter.cls
+++ b/plugins/NebulaLogger/classes/RollupNebulaLoggerAdapter.cls
@@ -1,5 +1,5 @@
+@SuppressWarnings('apex-assist')
 public class RollupNebulaLoggerAdapter extends RollupLogger {
-
   public override void log(String logString, LoggingLevel logLevel) {
     Logger.newEntry(logLevel, logString);
   }

--- a/plugins/NebulaLogger/tests/RollupNebulaLoggerAdapterTest.cls
+++ b/plugins/NebulaLogger/tests/RollupNebulaLoggerAdapterTest.cls
@@ -1,5 +1,6 @@
 @IsTest
 private class RollupNebulaLoggerAdapterTest {
+  @SuppressWarnings('apex-assist')
   @IsTest
   static void shouldLogToNebula() {
     LoggerSettings__c settings = new LoggerSettings__c(IsEnabled__c = true);

--- a/plugins/RollupCallback/classes/RollupDispatch.cls
+++ b/plugins/RollupCallback/classes/RollupDispatch.cls
@@ -4,6 +4,7 @@ public class RollupDispatch implements RollupSObjectUpdater.IDispatcher {
   @TestVisible
   private static String platformEventOverride;
 
+  @SuppressWarnings('apex-assist')
   private static String PLATFORM_EVENT_BOOLEAN_STRING {
     get {
       if (PLATFORM_EVENT_BOOLEAN_STRING == null && platformEventOverride != null) {
@@ -25,9 +26,7 @@ public class RollupDispatch implements RollupSObjectUpdater.IDispatcher {
         updatedRecordIds.add(record.Id);
       }
 
-      RollupCallbackEvent__e callbackEvent = new RollupCallbackEvent__e(
-        RecordIds__c = String.join(updatedRecordIds, ',')
-      );
+      RollupCallbackEvent__e callbackEvent = new RollupCallbackEvent__e(RecordIds__c = String.join(updatedRecordIds, ','));
       EventBus.publish(callbackEvent);
     }
   }

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -157,7 +157,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
     private final Set<String> splitWheres = new Set<String>();
 
     public WhereFieldEvaluator(String whereClause, SObjectType calcItemSObjectType) {
-      whereClause = whereClause == null ? '' : whereClause;
+      whereClause = whereClause == null ? '' : whereClause.replaceAll('(\n|\r|\t)', '');
       this.originalWhereClause = whereClause;
 
       if (String.isNotBlank(whereClause)) {
@@ -231,11 +231,12 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
     private Boolean innerMatches(Object calcItem) {
       Boolean matches = calcItem instanceof SObject;
       if (matches) {
-        for (ConditionalGrouping conditionalGrouping : this.conditionalGroupings) {
+        for (Integer index = 0; index < this.conditionalGroupings.size(); index++) {
+          ConditionalGrouping conditionalGrouping = this.conditionalGroupings[index];
           Boolean hasInnerMatch = conditionalGrouping.equals(calcItem);
           addLog(conditionalGrouping, hasInnerMatch, calcItem, LoggingLevel.FINEST);
-          if (hasInnerMatch && conditionalGrouping.isOrConditional()) {
-            matches = true;
+          if (conditionalGrouping.isOrConditional()) {
+            matches = index == 0 ? hasInnerMatch : hasInnerMatch || matches;
           } else if (conditionalGrouping.isOrConditional() == false) {
             matches = matches && hasInnerMatch;
           }
@@ -373,9 +374,9 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       Boolean isOr = false;
       Boolean isFirstConditional = fullString.indexOf(conditionalStatement) == 0;
       if (isFirstConditional == false) {
-        Integer whereWeAreInTheFullString = fullString.indexOf(conditionalStatement) + conditionalStatement.length();
+        Integer whereWeAreInTheFullString = fullString.indexOf(conditionalStatement);
         // 5 is enough to encapsulate " or " with spaces
-        Integer clauseStartingIndex = whereWeAreInTheFullString - (conditionalStatement.length() + 5);
+        Integer clauseStartingIndex = whereWeAreInTheFullString - 5;
         if (clauseStartingIndex > 0) {
           isOr = fullString.substring(clauseStartingIndex, whereWeAreInTheFullString).containsIgnoreCase(' or ');
         }
@@ -543,7 +544,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       }
     }
 
-    @SuppressWarnings('PMD.OverrideBothEqualsAndHashCode, PMD.EmptyIfStmt')
+    @SuppressWarnings('PMD.OverrideBothEqualsAndHashCode')
     public Boolean equals(Object o) {
       SObject item = (SObject) o;
       Boolean isEqual = true;
@@ -564,9 +565,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
           // like/not like have to be handled separately because it's the storedValue
           // that gets tested against, not the other way around
           isEqual = false;
-          if (storedValue == null) {
-            // do nothing
-          } else {
+          if (storedValue != null) {
             for (String val : this.values) {
               isEqual = storedValue.contains(val);
               if (isEqual) {

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -55,7 +55,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
   }
 
   public static Rollup.Evaluator getEvaluator(Rollup.Evaluator eval, Rollup__mdt metadata, Map<Id, SObject> oldCalcItems, SObjectType sObjectType) {
-    List<Rollup.Evaluator> evals = new List<Rollup.Evaluator>{ eval == null ? ALWAYS_TRUE_SINGLETON : eval };
+    List<Rollup.Evaluator> evals = eval == null ? new List<Rollup.Evaluator>() : new List<Rollup.Evaluator>{ eval };
 
     if (String.isNotBlank(metadata.CalcItemWhereClause__c)) {
       evals.add(getWhereEval(metadata.CalcItemWhereClause__c, sObjectType));
@@ -65,6 +65,9 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
     }
     if (metadata.RollupOperation__c?.contains('UPDATE') == true) {
       evals.add(new RecursiveUpdateEvaluator(metadata));
+    }
+    if (evals.isEmpty()) {
+      evals.add(ALWAYS_TRUE_SINGLETON);
     }
 
     return getCombinedEvals(evals);
@@ -194,6 +197,15 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
         ) {
           completelySplitClauses[1] = completelySplitClauses[1] == '!=' ? 'NOT IN' : 'IN';
           startingPoint = startingPoint.replace(whereClausePart, String.join(completelySplitClauses, ' '));
+        } else if (completelySplitClauses.size() >= 3 && this.originalWhereClause.indexOf(whereClausePart) == -1) {
+          for (String replacementKey : CONDITION_MAP.keySet()) {
+            String replacementVal = CONDITION_MAP.get(replacementKey);
+            String potentialReplacement = whereClausePart.replace(replacementVal, replacementKey);
+            if (this.originalWhereClause.indexOf(potentialReplacement) >= 0) {
+              startingPoint = startingPoint.replace(whereClausePart, potentialReplacement);
+              break;
+            }
+          }
         }
       }
       return startingPoint;

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -186,7 +186,12 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
         if (completelySplitClauses.size() >= 3 && completelySplitClauses[1] == '!like') {
           String supplementalClause = '(NOT ' + completelySplitClauses[0] + ' LIKE ' + completelySplitClauses[2] + ')';
           startingPoint = startingPoint.replace(whereClausePart, supplementalClause);
-        } else if (completelySplitClauses.size() >= 3 && completelySplitClauses[1].contains('=') && completelySplitClauses[2].startsWith('(') && completelySplitClauses[completelySplitClauses.size() - 1].endsWith(')')) {
+        } else if (
+          completelySplitClauses.size() >= 3 &&
+          completelySplitClauses[1].contains('=') &&
+          completelySplitClauses[2].startsWith('(') &&
+          completelySplitClauses[completelySplitClauses.size() - 1].endsWith(')')
+        ) {
           completelySplitClauses[1] = completelySplitClauses[1] == '!=' ? 'NOT IN' : 'IN';
           startingPoint = startingPoint.replace(whereClausePart, String.join(completelySplitClauses, ' '));
         }
@@ -770,7 +775,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
   }
 
   private static void addLog(Object clazz, Boolean matches, Object item, LoggingLevel logLevel) {
-    RollupLogger.Instance.log(clazz + '\nmatches? ' + matches + ' for: ' + item, logLevel);
+    RollupLogger.Instance.log(clazz + '\nMatches? ' + matches + ' for: ' + item, logLevel);
   }
 
   private static String getCurrentTransactionId() {

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -12,7 +12,7 @@ public without sharing virtual class RollupLogger extends Rollup implements ILog
     this.currentLoggingLevel = this.getLogLevel();
   }
 
-  private static RollupLogger SELF {
+  private static final RollupLogger SELF {
     get {
       if (SELF == null) {
         SELF = new RollupLogger();
@@ -22,7 +22,7 @@ public without sharing virtual class RollupLogger extends Rollup implements ILog
     set;
   }
 
-  public static ILogger Instance {
+  public static final ILogger Instance {
     get {
       if (Instance == null) {
         Instance = getRollupLogger();

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -159,9 +159,9 @@ public without sharing virtual class RollupLogger extends Rollup implements ILog
         );
         rollLogger = SELF;
       }
-      if (loggingPlugins.isEmpty() == false) {
-        rollLogger = new CombinedLogger(rollLogger, combineLoggers(loggingPlugins));
-      }
+    }
+    if (loggingPlugins.isEmpty() == false) {
+      rollLogger = new CombinedLogger(rollLogger, combineLoggers(loggingPlugins));
     }
 
     return rollLogger;

--- a/rollup/core/classes/RollupSObjectUpdater.cls
+++ b/rollup/core/classes/RollupSObjectUpdater.cls
@@ -65,6 +65,10 @@ public without sharing virtual class RollupSObjectUpdater {
         potentialRollupDispatchers.add(pluginParameterMock);
       }
 
+      if (potentialRollupDispatchers.isEmpty()) {
+        return;
+      }
+
       List<IDispatcher> dispatchers = new List<IDispatcher>();
       for (RollupPluginParameter__mdt pluginParameter : potentialRollupDispatchers) {
         this.fillDispatcher(dispatchers, pluginParameter.Value__c);

--- a/rollup/core/classes/RollupSObjectUpdater.cls
+++ b/rollup/core/classes/RollupSObjectUpdater.cls
@@ -42,7 +42,7 @@ public without sharing virtual class RollupSObjectUpdater {
         record.put(this.fieldToken, ((Datetime) value).dateGmt());
       }
       when 'Decimal to Integer' {
-        record.put(this.fieldToken, ((Decimal)value).intValue());
+        record.put(this.fieldToken, ((Decimal) value).intValue());
       }
       when else {
         // this switch statement can be expanded as necessary to deal with other problems

--- a/scripts/build-and-promote-package.ps1
+++ b/scripts/build-and-promote-package.ps1
@@ -107,11 +107,10 @@ if($currentBranch -eq "main") {
   # main is a push-protected branch; only create new package versions as part of PRs against main
   Write-Output "Creating new package version"
 
-  sfdx force:package:version:create -d $sfdxProjectJson.packageDirectories[0].path -x -w 30 -c
+  $packageVersionCreateResult = sfdx force:package:version:create -d $sfdxProjectJson.packageDirectories[0].path -x -w 30 -c --json | ConvertFrom-Json
   git add ./sfdx-project.json
 
-  # Now that sfdx-project.json has been updated, grab the latest package version
-  $currentPackageVersionId = Get-Latest-Package-Id $currentPackageVersion $priorPackageVersionNumber
+  $currentPackageVersionId = $packageVersionCreateResult.result.SubscriberPackageVersionId
 
   Write-Output "New package version: $currentPackageVersionId"
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,7 +5,7 @@
             "package": "apex-rollup",
             "path": "rollup",
             "versionNumber": "1.3.5.0",
-            "versionDescription": "Internal bookkeeping updates",
+            "versionDescription": "Internal bookkeeping updates, fixes for combined Rollup loggers, bugfixes for Rollup Evaluator",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
                 "path": "extra-tests"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -91,6 +91,6 @@
         "apex-rollup@1.3.2-0": "04t6g000008ShapAAC",
         "apex-rollup@1.3.3-0": "04t6g000008ShbnAAC",
         "apex-rollup@1.3.4-0": "04t6g000008ShgeAAC",
-        "apex-rollup@1.3.5-0": "04t6g000008ShhDAAS"
+        "apex-rollup@1.3.5-0": "04t6g000008ShhIAAS"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -90,6 +90,7 @@
         "apex-rollup@1.3.1-0": "04t6g000008ShZ8AAK",
         "apex-rollup@1.3.2-0": "04t6g000008ShapAAC",
         "apex-rollup@1.3.3-0": "04t6g000008ShbnAAC",
-        "apex-rollup@1.3.4-0": "04t6g000008ShgeAAC"
+        "apex-rollup@1.3.4-0": "04t6g000008ShgeAAC",
+        "apex-rollup@1.3.5-0": "04t6g000008ShhDAAS"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -19,8 +19,8 @@
                     "package": "apex-rollup@1.3.0-0"
                 }
             ],
-            "versionNumber": "0.0.6.0",
-            "versionDescription": "Deprecated RollupLoggerPlugin__mdt in favor of RollupPlugin__mdt",
+            "versionNumber": "0.0.7.0",
+            "versionDescription": "Updating All List View to include sensible fields for viewing logs",
             "default": false,
             "unpackagedMetadata": {
                 "path": "plugins/CustomObjectRollupLogger/tests"
@@ -70,8 +70,8 @@
     "packageAliases": {
         "apex-rollup": "0Ho6g000000TNcOCAW",
         "Apex Rollup - Custom Logger": "0Ho6g000000Gn8ZCAS",
-        "Apex Rollup - Custom Logger@0.0.5-0": "04t6g000008ShAfAAK",
         "Apex Rollup - Custom Logger@0.0.6-0": "04t6g000008ShT9AAK",
+        "Apex Rollup - Custom Logger@0.0.7-0": "04t6g000008Shh3AAC",
         "Apex Rollup - Nebula Logger": "0Ho6g000000Gn8PCAS",
         "Apex Rollup - Nebula Logger@0.0.2-0": "04t6g000008Sh8yAAC",
         "Apex Rollup - Nebula Logger@0.0.3-0": "04t6g000008ShTEAA0",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -91,6 +91,6 @@
         "apex-rollup@1.3.2-0": "04t6g000008ShapAAC",
         "apex-rollup@1.3.3-0": "04t6g000008ShbnAAC",
         "apex-rollup@1.3.4-0": "04t6g000008ShgeAAC",
-        "apex-rollup@1.3.5-0": "04t6g000008ShhSAAS"
+        "apex-rollup@1.3.5-0": "04t6g000008ShhXAAS"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionNumber": "1.3.4.0",
-            "versionDescription": "Multi-currency bugfix for RollupParentResetProcessor",
+            "versionNumber": "1.3.5.0",
+            "versionDescription": "Internal bookkeeping updates",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
                 "path": "extra-tests"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -91,6 +91,6 @@
         "apex-rollup@1.3.2-0": "04t6g000008ShapAAC",
         "apex-rollup@1.3.3-0": "04t6g000008ShbnAAC",
         "apex-rollup@1.3.4-0": "04t6g000008ShgeAAC",
-        "apex-rollup@1.3.5-0": "04t6g000008ShhIAAS"
+        "apex-rollup@1.3.5-0": "04t6g000008ShhNAAS"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -91,6 +91,6 @@
         "apex-rollup@1.3.2-0": "04t6g000008ShapAAC",
         "apex-rollup@1.3.3-0": "04t6g000008ShbnAAC",
         "apex-rollup@1.3.4-0": "04t6g000008ShgeAAC",
-        "apex-rollup@1.3.5-0": "04t6g000008ShhNAAS"
+        "apex-rollup@1.3.5-0": "04t6g000008ShhSAAS"
     }
 }


### PR DESCRIPTION
* some internal bookkeeping to reduce signal-to-noise ratio on PMD false-positives issued by `apex-assist` (the joys of working with dependent packages, some might say)
* Fixed pre-commit hook to properly work with `sfdx-scanner`
* Fixed #170 by stripping line breaks/tabs/carriage returns from evaluation messages
* Fixed #171 by properly handling the queried list of rollup loggers to combine when the first entry in the list is the included Apex Debug logger
* Fixes an issue reported by Katherine West where some where clauses with `in` ... within ... the value of a field were not being queried correctly