### PR TITLE
V1.3.8 - Schedulable Class Updates & Full Recalculation Adjustments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
         run: npm run test:lwc
 
       - name: 'Upload code coverage for LWC to Codecov.io'
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: LWC
@@ -91,7 +91,7 @@ jobs:
 
       # Upload Apex code coverage data
       - name: 'Upload Apex code coverage for Apex to Codecov.io'
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: Apex

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Si16AAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Si24AAC">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Si16AAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Si24AAC">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Rollup Code Coverage](https://codecov.io/gh/jamessimone/apex-rollup/branch/main/graph/badge.svg)](https://codecov.io/gh/jamessimone/apex-rollup)
 [![License](https://img.shields.io/npm/l/scanner.svg)](https://github.com/jamessimone/apex-rollup/blob/main/package.json)
 
-Create fast, scalable custom rollups driven by Custom Metadata in your Salesforce org with `Rollup`. As seen on [Replacing DLRS With Custom Rollup](https://www.jamessimone.net/blog/joys-of-apex/replacing-dlrs-with-custom-rollup/) - if you are looking to replace DLRS with Apex Rollup, [we have a whole migration section for you](#replacing-dlrs)!
+Create fast, scalable custom rollups driven by Custom Metadata in your Salesforce org with `Rollup`. As seen on [Replacing DLRS With Custom Rollup](https://www.jamessimone.net/blog/joys-of-apex/replacing-dlrs-with-custom-rollup/) and on [Unofficial SF](https://unofficialsf.com/from-james-simone-create-powerful-rollups-in-your-flows-with-a-single-perform-rollup-action/) - if you are looking to replace DLRS with Apex Rollup, [we have a whole migration section for you](#replacing-dlrs)!
 
 ## Features
 
@@ -21,12 +21,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Si03AAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Si16AAC">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Si03AAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Si16AAC">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>
@@ -38,7 +38,7 @@ Don't miss the [links to install the Rollup plugins!](#rollup-plugins)
 
 ## Setup
 
-As of [v1.2.2](https://github.com/jamessimone/apex-rollup/releases/tag/v1.2.2), `Rollup` now ships with a custom hierarchy setting, `Rollup Settings`, which you will have to create an Org Wide Default entry for by going to:
+As of [v1.2.2](https://github.com/jamessimone/apex-rollup/releases/tag/v1.2.2), `Rollup` ships with a custom hierarchy setting, `Rollup Settings`, which you will have to create an Org Wide Default entry for by going to:
 
 1. Setup
 2. Custom Settings

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -732,6 +732,27 @@ private class RollupFullRecalcTests {
   }
 
   @IsTest
+  static void shouldNotBlowUpOnMassiveQuery() {
+    String endOfWhereClause = '2'.repeat(100001);
+    Rollup__mdt meta = new Rollup__mdt(
+      CalcItem__c = 'ContactPointAddress',
+      RollupFieldOnCalcItem__c = 'PreferenceRank',
+      LookupFieldOnCalcItem__c = 'ParentId',
+      LookupFieldOnLookupObject__c = 'Id',
+      RollupFieldOnLookupObject__c = 'AnnualRevenue',
+      LookupObject__c = 'Account',
+      RollupOperation__c = 'SUM',
+      CalcItemWhereClause__c = 'PreferenceRank = ' + endOfWhereClause
+    );
+
+    Test.startTest();
+    Rollup.performFullRecalculation(meta);
+    Test.stopTest();
+
+    System.assert(true, 'Should make it here without exception being thrown');
+  }
+
+  @IsTest
   static void shouldNotAddToExistingAmountForFullRecalc() {
     Account acc = [SELECT Id FROM Account];
     acc.AnnualRevenue = 60;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -36,13 +36,17 @@
     "aura"
   ],
   "scripts": {
+    "create:package:rollup": "sfdx force:package:version:create --package \"apex-rollup\" -w 20 -x -c",
+    "create:package:nebula:adapter": "sfdx force:package:version:create --package \"Apex Rollup - Nebula Logger\" -w 20 -x -c",
+    "create:package:logger": "sfdx force:package:version:create --package \"Apex Rollup - Custom Logger\" -w 20 -x -c",
+    "create:package:callback": "sfdx force:package:version:create --package \"Apex Rollup - Rollup Callback\" -w 20 -x -c",
     "husky:pre-commit": "lint-staged",
     "lint:verify": "eslint **/lwc/**",
     "prepare": "husky install",
+    "prettier": "prettier",
     "scan": "sfdx scanner:run --pmdconfig config/pmd-ruleset.xml --target . --engine pmd --severity-threshold 3",
     "test": "npm run test:apex && npm run test:lwc",
     "test:apex": "sh ./scripts/runLocalTests.sh",
-    "test:lwc": "sfdx-lwc-jest --coverage --skipApiVersionCheck",
-    "prettier": "prettier"
+    "test:lwc": "sfdx-lwc-jest --coverage --skipApiVersionCheck"
   }
 }

--- a/plugins/CustomObjectRollupLogger/README.md
+++ b/plugins/CustomObjectRollupLogger/README.md
@@ -1,11 +1,11 @@
 # Custom Object Rollup Logger
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShzjAAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Si1GAAS">
   <img alt="Deploy to Salesforce"
        src="../../media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShzjAAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Si1GAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="../../media/deploy-package-to-sandbox.png">
 </a>
@@ -24,8 +24,9 @@ A utility class, `RollupLogBatchPurger` is included. By scheduling this class, y
 
 ```java
 // example cronSchedule string for running the purger every day at 7 AM:
-// 0 0 7 ? * *
-Id jobId = RollupLogBatchPurger.schedule(String jobName, String cronSchedule)
+String cronSchedule = '0 0 7 ? * *';
+String jobName = 'Rollup Custom Logger Batch Purger';
+Id jobId = RollupLogBatchPurger.schedule(jobName, cronSchedule);
 // the "jobId" returned is associated with the CronTrigger object
 // which represents a scheduled job
 ```

--- a/plugins/CustomObjectRollupLogger/classes/RollupCustomObjectLogger.cls
+++ b/plugins/CustomObjectRollupLogger/classes/RollupCustomObjectLogger.cls
@@ -6,11 +6,14 @@ public class RollupCustomObjectLogger extends RollupLogger {
     super();
   }
 
-  public override void log(String logString, LoggingLevel logLevel) {
-    if (this.getLogLevel().ordinal() > logLevel.ordinal()) {
-      return; // it's a no-op
-    }
-    else if (logString.length() >= MAX_LENGTH) {
+  public override void save() {
+    EventBus.publish(this.rollupLogEvents);
+    this.rollupLogEvents.clear();
+  }
+
+  protected override void innerLog(String logString, Object logObject, LoggingLevel logLevel) {
+    logString = logString + '\n' + this.getLogStringFromObject(logObject);
+    if (logString.length() >= MAX_LENGTH) {
       // normally we could do this with the AllowFieldTruncation property on Database.DMLOptions
       // but even though you can add DMLOptions to platform event objects, they don't seem to do anything -
       // and if any of the field's text lengths is exceeded, the platform event just silently fails to trigger - neat!
@@ -23,16 +26,6 @@ public class RollupCustomObjectLogger extends RollupLogger {
       TransactionId__c = Request.getCurrent().getRequestId()
     );
     this.rollupLogEvents.add(logEvent);
-  }
-
-  public override void log(String logString, Object logObject, LoggingLevel logLevel) {
-    String fullLogString = logString + '\n' + this.getLogStringFromObject(logObject);
-    this.log(fullLogString, logLevel);
-  }
-
-  public override void save() {
-    EventBus.publish(this.rollupLogEvents);
-    this.rollupLogEvents.clear();
   }
 
   protected override RollupPluginParameter__mdt getLoggingLevelParameter() {

--- a/plugins/CustomObjectRollupLogger/classes/RollupLogBatchPurger.cls
+++ b/plugins/CustomObjectRollupLogger/classes/RollupLogBatchPurger.cls
@@ -1,10 +1,12 @@
 global without sharing class RollupLogBatchPurger implements Database.Batchable<SObject>, Database.Stateful {
   private Integer recordCount = 0;
+  private Boolean hasDeletedOrphanedLogs = false;
 
   global static Id schedule(String jobName, String cronSchedule) {
-    return System.schedule(jobName, cronSchedule, new PurgerSchedulable(RollupLogControl.BatchSize));
+    return System.schedule(jobName, cronSchedule, new RollupPurgerSchedulable());
   }
 
+  @SuppressWarnings('PMD.UnusedLocalVariable')
   public Database.QueryLocator start(Database.BatchableContext bc) {
     Date daysBeforeOffset = System.today().addDays(-RollupLogControl.Offset);
     return Database.getQueryLocator([SELECT Id, RollupLog__c FROM RollupLogEntry__c WHERE CreatedDate <= :daysBeforeOffset ORDER BY RollupLog__c]);
@@ -15,18 +17,17 @@ global without sharing class RollupLogBatchPurger implements Database.Batchable<
     // even if EVERY log entry has a separate log parent
     // we should never exceed the max DML row limit of 10k
     this.recordCount += logEntries.size();
-    Set<Id> rollupLogIds = new Set<Id>();
+    Set<RollupLog__c> distinctRollupLogs = new Set<RollupLog__c>();
 
     for (RollupLogEntry__c logEntry : logEntries) {
-      rollupLogIds.add(logEntry.RollupLog__c);
+      distinctRollupLogs.add(new RollupLog__c(Id = logEntry.RollupLog__c));
     }
     delete logEntries;
 
-    List<RollupLog__c> parentLogs = [SELECT Id FROM RollupLog__c WHERE Id = :rollupLogIds];
     // it's possible, even with ordering by RollupLog__c, that some log entries with the same parent log
     // will end up in different batches. Assume that this delete will succeed once all child RollupLogEntry__c
     // have been deleted in successive batches, but that the first (several) of these deletes might fail
-    List<Database.DeleteResult> deleteResults = Database.delete(parentLogs, false);
+    List<Database.DeleteResult> deleteResults = Database.delete(new List<RollupLog__c>(distinctRollupLogs), false);
     for (Database.DeleteResult dr : deleteResults) {
       if (dr.isSuccess()) {
         this.recordCount++;
@@ -35,19 +36,15 @@ global without sharing class RollupLogBatchPurger implements Database.Batchable<
   }
 
   public void finish(Database.BatchableContext bc) {
-    RollupLogger.Instance.log('RollupLogBatchPurger finished after having deleted ' + this.recordCount + ' rollup logs', LoggingLevel.DEBUG);
+    RollupLogger.Instance.log('RollupLogBatchPurger finishing up after having deleted ' + this.recordCount + ' rollup logs', LoggingLevel.DEBUG);
+
+    String orphanedLogsQuery = 'SELECT Count() FROM RollupLog__c WHERE NumberOfLogEntries__c = 0 AND IsDeleted = false';
+    if (Database.countQuery(orphanedLogsQuery) > 0 && this.hasDeletedOrphanedLogs == false) {
+      orphanedLogsQuery = orphanedLogsQuery.replace('Count()', 'Id');
+      this.hasDeletedOrphanedLogs = true;
+      RollupLogger.Instance.log('Deleting orphaned logs ...', LoggingLevel.DEBUG);
+      delete Database.query(orphanedLogsQuery);
+    }
     RollupLogger.Instance.save();
-  }
-
-  private without sharing class PurgerSchedulable implements Schedulable {
-    private final Integer batchSize;
-
-    public PurgerSchedulable(Integer batchSize) {
-      this.batchSize = batchSize;
-    }
-
-    public void execute(SchedulableContext sc) {
-      Database.executeBatch(new RollupLogBatchPurger(), this.batchSize);
-    }
   }
 }

--- a/plugins/CustomObjectRollupLogger/classes/RollupPurgerSchedulable.cls
+++ b/plugins/CustomObjectRollupLogger/classes/RollupPurgerSchedulable.cls
@@ -1,0 +1,11 @@
+public without sharing class RollupPurgerSchedulable implements System.Schedulable {
+  private final Integer batchSize;
+
+  public RollupPurgerSchedulable() {
+    this.batchSize = RollupLogControl.BatchSize;
+  }
+
+  public void execute(SchedulableContext sc) {
+    Database.executeBatch(new RollupLogBatchPurger(), this.batchSize);
+  }
+}

--- a/plugins/CustomObjectRollupLogger/classes/RollupPurgerSchedulable.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/classes/RollupPurgerSchedulable.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>53.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/plugins/CustomObjectRollupLogger/profiles/Admin.profile-meta.xml
+++ b/plugins/CustomObjectRollupLogger/profiles/Admin.profile-meta.xml
@@ -1,5 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Profile xmlns="http://soap.sforce.com/2006/04/metadata">
+    <classAccesses>
+        <apexClass>RollupCustomObjectLogger</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>RollupLogBatchPurger</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>RollupLogControl</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>RollupLogEventHandler</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>RollupPurgerSchedulable</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
     <fieldPermissions>
         <editable>false</editable>
         <field>RollupLog__c.ErrorWouldHaveBeenThrown__c</field>

--- a/plugins/CustomObjectRollupLogger/tests/RollupCustomObjectLoggerTests.cls
+++ b/plugins/CustomObjectRollupLogger/tests/RollupCustomObjectLoggerTests.cls
@@ -2,6 +2,7 @@
 private class RollupCustomObjectLoggerTests {
   @IsTest
   static void shouldSaveToRollupLog() {
+    Rollup.defaultControl = new RollupControl__mdt(IsRollupLoggingEnabled__c = true);
     RollupCustomObjectLogger rollupCustomLogger = new RollupCustomObjectLogger();
     rollupCustomLogger.log('Test log', LoggingLevel.DEBUG);
     rollupCustomLogger.log('Second test log with record', new Account(), LoggingLevel.ERROR);
@@ -30,6 +31,7 @@ private class RollupCustomObjectLoggerTests {
 
   @IsTest
   static void shouldTruncateTooLongLogMessage() {
+    Rollup.defaultControl = new RollupControl__mdt(IsRollupLoggingEnabled__c = true);
     // if the message is too long for the platform event to fire - it simply won't fire!
     // this test is to ensure a RollupLogEntry__c is created
     RollupCustomObjectLogger rollupCustomLogger = new RollupCustomObjectLogger();
@@ -47,6 +49,7 @@ private class RollupCustomObjectLoggerTests {
 
   @IsTest
   static void shouldNotLogBelowSpecifiedLoggingLevel() {
+    Rollup.defaultControl = new RollupControl__mdt(IsRollupLoggingEnabled__c = true);
     // override whatever's included in the CMDT to ensure we arrive at this value deterministically
     RollupLogger.loggingLevelMock = new RollupPluginParameter__mdt(Value__c = LoggingLevel.DEBUG.name());
 

--- a/plugins/CustomObjectRollupLogger/tests/RollupLogBatchPurgerTests.cls
+++ b/plugins/CustomObjectRollupLogger/tests/RollupLogBatchPurgerTests.cls
@@ -5,12 +5,11 @@ private class RollupLogBatchPurgerTests {
   @IsTest
   static void shouldDeleteLogEntriesAndLogs() {
     RollupLog__c log = new RollupLog__c(TransactionId__c = 'something');
-    insert log;
+    RollupLog__c logWithoutChildren = new RollupLog__c(TransactionId__c = 'something-else');
+    List<RollupLog__c> logs = new List<RollupLog__c>{ log, logWithoutChildren };
+    insert logs;
 
-    RollupLogEntry__c entry = new RollupLogEntry__c(
-      LoggingLevel__c = 'DEBUG',
-      RollupLog__c = log.Id
-    );
+    RollupLogEntry__c entry = new RollupLogEntry__c(LoggingLevel__c = 'DEBUG', RollupLog__c = log.Id);
     insert entry;
     // UTC time can lead to some weird Datetime issues with adding simply a single day
     // Let's go with 2 to make things completely solid
@@ -22,15 +21,15 @@ private class RollupLogBatchPurgerTests {
 
     List<RollupLogEntry__c> existingEntries = [SELECT Id FROM RollupLogEntry__c WHERE Id = :entry.Id];
     System.assertEquals(0, existingEntries.size(), 'Entry should have been deleted');
-    List<RollupLog__c> existingLogs = [SELECT Id FROM RollupLog__c WHERE Id = :log.Id];
-    System.assertEquals(0, existingLogs.size(), 'Log should have been deleted');
+    List<RollupLog__c> existingLogs = [SELECT Id, TransactionId__c FROM RollupLog__c WHERE Id = :logs];
+    System.assertEquals(0, existingLogs.size(), 'Logs should have been deleted: ' + existingLogs);
   }
 
   @IsTest
   static void shouldScheduleSuccessfully() {
-    Id scheduleId = RollupLogBatchPurger.schedule('Test purge log schedule ' + System.now().getTime() , '0 0 0 * * ?');
+    Id scheduleId = RollupLogBatchPurger.schedule('Test purge log schedule ' + System.now().getTime(), '0 0 0 * * ?');
 
-    CronTrigger scheduledJob = [SELECT Id FROM CronTrigger WHERE Id =: scheduleId];
+    CronTrigger scheduledJob = [SELECT Id FROM CronTrigger WHERE Id = :scheduleId];
     System.assertNotEquals(null, scheduledJob);
   }
 }

--- a/plugins/NebulaLogger/README.md
+++ b/plugins/NebulaLogger/README.md
@@ -1,11 +1,11 @@
 # Nebula Logger Plugin for Apex Rollup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShzoAAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Si1BAAS">
   <img alt="Deploy to Salesforce"
        src="../../media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ShzoAAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Si1BAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="../../media/deploy-package-to-sandbox.png">
 </a>

--- a/plugins/NebulaLogger/classes/RollupNebulaLoggerAdapter.cls
+++ b/plugins/NebulaLogger/classes/RollupNebulaLoggerAdapter.cls
@@ -1,15 +1,11 @@
 @SuppressWarnings('apex-assist')
 public class RollupNebulaLoggerAdapter extends RollupLogger {
-  public override void log(String logString, LoggingLevel logLevel) {
-    Logger.newEntry(logLevel, logString);
-  }
-
-  public override void log(String logString, Object logObject, LoggingLevel logLevel) {
-    String formattedLogObject = this.getLogStringFromObject(logObject);
-    this.log(logString + '\n' + formattedLogObject, logLevel);
-  }
-
   public override void save() {
     Logger.saveLog();
+  }
+
+  protected override void innerLog(String logString, Object logObject, LoggingLevel logLevel) {
+    logString = logString + '\n' + this.getLogStringFromObject(logObject);
+    Logger.newEntry(logLevel, logString);
   }
 }

--- a/plugins/NebulaLogger/tests/RollupNebulaLoggerAdapterTest.cls
+++ b/plugins/NebulaLogger/tests/RollupNebulaLoggerAdapterTest.cls
@@ -3,11 +3,13 @@ private class RollupNebulaLoggerAdapterTest {
   @SuppressWarnings('apex-assist')
   @IsTest
   static void shouldLogToNebula() {
+    Rollup.defaultControl = new RollupControl__mdt(IsRollupLoggingEnabled__c = true);
     LoggerSettings__c settings = new LoggerSettings__c(IsEnabled__c = true);
     upsert settings;
 
+    String testString = 'Test String';
     RollupNebulaLoggerAdapter adapter = new RollupNebulaLoggerAdapter();
-    adapter.log('Test string', new Account(), LoggingLevel.DEBUG);
+    adapter.log(testString, new Account(), LoggingLevel.DEBUG);
 
     Test.startTest();
     adapter.save();
@@ -16,6 +18,9 @@ private class RollupNebulaLoggerAdapterTest {
     // For Nebula Logger, we aren't opinionated (at present) about how the log
     // chooses to represent itself. Nebula Logger handles all of the formatting
     // of log entries and creation of Log__c records. If a log is created, we're golden
-    System.assertEquals(1, [SELECT COUNT() FROM Log__c]);
+    List<Log__c> logs = [SELECT Id, (SELECT Message__c FROM LogEntries__r) FROM Log__c];
+    System.assertEquals(1, logs.size(), 'Log should have been created');
+    System.assertEquals(1, logs[0].LogEntries__r.size(), 'Log entry should have been created');
+    System.assertEquals(true, logs[0].LogEntries__r[0].Message__c.contains(testString), 'Log message should contain test string');
   }
 }

--- a/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.html
+++ b/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.html
@@ -10,11 +10,11 @@
       <div class="slds-grid slds-grid_vertical slds-gutters_small slds-grid_align-center" role="list">
         <template if:true={isCMDTRecalc}>
           <lightning-combobox
-          name="Select Calc Item"
-          label="Select Calc Item"
-          value={selectedMetadata}
-          options={rollupMetadataOptions}
-          onchange={handleComboChange}
+            name="Select Calc Item"
+            label="Select Calc Item"
+            value={selectedMetadata}
+            options={rollupMetadataOptions}
+            onchange={handleComboChange}
           ></lightning-combobox>
           <template if:true={selectedMetadataCMDTRecords}>
             <lightning-datatable
@@ -119,6 +119,7 @@
             oncommit={handleChange}
           >
           </lightning-input>
+          <lightning-helptext content="If including a SOQL where clause, do not start with 'WHERE'- this is added automatically"></lightning-helptext>
           <lightning-textarea
             class="slds-col slds-form-element slds-form-element_horizontal"
             onchange={handleChange}

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -112,32 +112,6 @@ global without sharing virtual class Rollup {
     set;
   }
 
-  public static final Map<String, Op> opNameToOp {
-    get {
-      if (opNameToOp == null) {
-        opNameToOp = new Map<String, Op>();
-        for (Op operation : Op.values()) {
-          opNameToOp.put(operation.name(), operation);
-        }
-      }
-      return opNameToOp;
-    }
-    set;
-  }
-
-  public static final Map<String, InvocationPoint> invokeNameToInvokePoint {
-    get {
-      if (invokeNameToInvokePoint == null) {
-        invokeNameToInvokePoint = new Map<String, InvocationPoint>();
-        for (InvocationPoint invocation : InvocationPoint.values()) {
-          invokeNameToInvokePoint.put(invocation.name(), invocation);
-        }
-      }
-      return invokeNameToInvokePoint;
-    }
-    set;
-  }
-
   @SuppressWarnings('PMD.UnusedLocalVariable')
   public enum Op {
     SUM,
@@ -364,7 +338,7 @@ global without sharing virtual class Rollup {
   @AuraEnabled
   global static String performBulkFullRecalc(List<Rollup__mdt> matchingMetadata, String invokePointName) {
     RollupLogger.Instance.log('bulk full recalc called with data:', matchingMetadata, LoggingLevel.DEBUG);
-    InvocationPoint localInvokePoint = invokeNameToInvokePoint.get(invokePointName);
+    InvocationPoint localInvokePoint = InvocationPoint.valueOf(invokePointName);
 
     Integer amountOfCalcItems = 0;
     Set<String> objIds = new Set<String>(); // will always be present as a bind var, below
@@ -2238,7 +2212,7 @@ global without sharing virtual class Rollup {
     DescribeSObjectResult describeForSObject = sObjectType.getDescribe();
 
     for (Rollup__mdt rollupMetadata : rollupOperations) {
-      Op rollupOp = opNameToOp.get(rollupMetadata.RollupOperation__c.toUpperCase());
+      Op rollupOp = Op.valueOf(rollupMetadata.RollupOperation__c);
       SObjectField rollupFieldOnCalcItem = getSObjectFieldByName(describeForSObject, rollupMetadata.RollupFieldOnCalcItem__c);
       SObjectField calcLookupField = getSObjectFieldByName(describeForSObject, rollupMetadata.LookupFieldOnCalcItem__c);
 

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1815,7 +1815,9 @@ global without sharing virtual class Rollup {
       if (typeToWrappedMeta.containsKey(fullRecalcMeta.calcItemType) == false) {
         wrappedMeta = new RollupMetadata();
         wrappedMeta.recordCount = 0;
-        wrappedMeta.whereClause = fullRecalcMeta.wrapper.getQuery();
+        if (fullRecalcMetas.size() == 1) {
+          wrappedMeta.whereClause = fullRecalcMeta.wrapper.getQuery();
+        }
       } else {
         wrappedMeta = typeToWrappedMeta.get(fullRecalcMeta.calcItemType);
       }
@@ -1826,7 +1828,7 @@ global without sharing virtual class Rollup {
           new List<String>{ 'Count()' },
           fullRecalcMeta.meta.LookupFieldOnLookupObject__c,
           '!=',
-          fullRecalcMeta.wrapper.getQuery()
+          wrappedMeta.whereClause
         );
         Integer localCount = getCountFromDb(countQuery, new Set<String>(), fullRecalcMeta.wrapper.recordIds);
         wrappedMeta.recordCount = localCount == RollupQueryBuilder.SENTINEL_COUNT_VALUE ? localCount : wrappedMeta.recordCount + localCount;
@@ -1834,9 +1836,14 @@ global without sharing virtual class Rollup {
       typeToWrappedMeta.put(fullRecalcMeta.calcItemType, wrappedMeta);
     }
 
+    final Integer maxQueryLength = 100000;
     List<Rollup> fullRecalcRollups = new List<Rollup>();
     for (SObjectType calcType : typeToWrappedMeta.keySet()) {
       RollupMetadata wrappedMeta = typeToWrappedMeta.get(calcType);
+      if (wrappedMeta.whereClause?.length() >= maxQueryLength) {
+        wrappedMeta.whereClause = '';
+        wrappedMeta.recordCount = RollupQueryBuilder.SENTINEL_COUNT_VALUE;
+      }
       String queryString = RollupQueryBuilder.Current.getQuery(calcType, new List<String>(wrappedMeta.queryFields), 'Id', '!=', wrappedMeta.whereClause);
       Rollup fullRecalc = buildFullRecalcRollup(wrappedMeta.metadata, wrappedMeta.recordCount, queryString, wrappedMeta.recordIds, calcType, invokePoint);
       fullRecalc.isNoOp = wrappedMeta.recordCount == 0;
@@ -1860,11 +1867,11 @@ global without sharing virtual class Rollup {
     if (
       wrappedMeta.whereClause.contains(':recordIds') == false &&
       wrappedMeta.recordIds.isEmpty() == false &&
-      String.isBlank(fullRecalcMeta.meta.GrandparentRelationshipFieldPath__c)
-    ) {
       // TODO - it would be nice to support the singular recalc button with grandparent rollups
       // but doing so requires that we validate the query ahead of time (to remove errors with trying to filter on
       // polymorphic fields). as it stands, this guard clause is a little TOO safe
+      String.isBlank(fullRecalcMeta.meta.GrandparentRelationshipFieldPath__c)
+    ) {
       String additionalClause = (String.isNotBlank(wrappedMeta.whereClause) ? ' AND ' : '') + fullRecalcMeta.meta.LookupFieldOnCalcItem__c + ' = :recordIds';
       wrappedMeta.whereClause += additionalClause;
     }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -677,7 +677,22 @@ global without sharing virtual class Rollup {
   }
 
   global static Id schedule(String jobName, String cronExp, String query, String rollupObjectName, Evaluator eval) {
-    RollupSchedulable scheduledRollup = new RollupSchedulable(query, rollupObjectName, eval);
+    List<SObject> localCalcItems;
+    try {
+      localCalcItems = Database.query(query);
+    } catch (QueryException ex) {
+      throw new QueryException('There\'s a problem with your query: ' + ex.getMessage() + '\n' + ex.getStackTraceString());
+    }
+    SObjectType calcItemType = localCalcItems.getSObjectType();
+    Rollup roll = getRollup(
+      getRollupMetadataBySObject(calcItemType),
+      calcItemType,
+      localCalcItems,
+      new Map<Id, SObject>(),
+      eval,
+      InvocationPoint.FROM_SCHEDULED
+    );
+    RollupSchedulable scheduledRollup = new RollupSchedulable(roll);
     return System.schedule(jobName, cronExp, scheduledRollup);
   }
 
@@ -2548,28 +2563,5 @@ global without sharing virtual class Rollup {
       }
     }
     return results;
-  }
-
-  private without sharing class RollupSchedulable implements System.Schedulable {
-    private final String query;
-    private final SObjectType rollupObject;
-    private final Evaluator eval;
-
-    public RollupSchedulable(String query, String rollupObjectName, Evaluator eval) {
-      this.query = query;
-      this.rollupObject = getSObjectFromName(rollupObjectName).getSObjectType();
-      this.eval = eval;
-      try {
-        Database.query(this.query);
-      } catch (QueryException ex) {
-        throw new QueryException('There\'s a problem with your query: ' + ex.getMessage() + '\n' + ex.getStackTraceString());
-      }
-    }
-
-    public void execute(SchedulableContext sc) {
-      List<Rollup__mdt> metadata = getRollupMetadataBySObject(this.rollupObject);
-      List<SObject> calcItems = Database.query(this.query);
-      getRollup(metadata, calcItems.getSObjectType(), calcItems, new Map<Id, SObject>(calcItems), this.eval, InvocationPoint.FROM_SCHEDULED).runCalc();
-    }
   }
 }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -1122,7 +1122,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
         String currentOp = getBaseOperationName(roll.op.name());
         String deleteOpName = 'DELETE_' + currentOp;
-        Op deleteOp = opNameToOp.get(deleteOpName);
+        Op deleteOp = Rollup.Op.valueOf(deleteOpName);
 
         // by default this returns a "batched" (set) of rollups; we
         // just want the first (and only) inner rollup to perform the pseudo-delete

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -1120,12 +1120,8 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
           continue;
         }
 
-        String currentOp = getBaseOperationName(roll.op.name());
-        String deleteOpName = 'DELETE_' + currentOp;
-        Op deleteOp = Rollup.Op.valueOf(deleteOpName);
+        Op deleteOp = Rollup.Op.valueOf('DELETE_' + getBaseOperationName(roll.op.name()));
 
-        // by default this returns a "batched" (set) of rollups; we
-        // just want the first (and only) inner rollup to perform the pseudo-delete
         RollupAsyncProcessor oldLookupsRollup = getProcessor(
           new FilterResults(),
           roll.opFieldOnCalcItem,
@@ -1139,6 +1135,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
           this.rollupControl,
           roll.metadata
         );
+        oldLookupsRollup.calcItems = reparentedCalcItems;
 
         RollupLogger.Instance.log('reparenting operation:', oldLookupsRollup, LoggingLevel.DEBUG);
 

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -313,7 +313,7 @@ public without sharing abstract class RollupCalculator {
         // break out of recursion if there's nothing to calculate
         this.returnVal = null;
       } else {
-        Rollup.Op baseOp = Rollup.opNameToOp.get(Rollup.getBaseOperationName(op.name()));
+        Rollup.Op baseOp = Rollup.Op.valueOf(Rollup.getBaseOperationName(op.name()));
         RollupCalculator calc = Factory.getCalculator(
           this.returnVal,
           baseOp,

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -92,13 +92,12 @@ public without sharing virtual class RollupLogger extends Rollup implements ILog
   }
 
   protected LoggingLevel getLogLevel() {
-    LoggingLevel toReturn = FALLBACK_LOGGING_LEVEL;
+    LoggingLevel toReturn;
     String logLevelNameToSearch = this.loggingLevelPluginParameter != null ? this.loggingLevelPluginParameter.Value__c : toReturn.name();
-    for (LoggingLevel logLevel : System.LoggingLevel.values()) {
-      if (logLevel.name().equalsIgnoreCase(logLevelNameToSearch)) {
-        toReturn = logLevel;
-        break;
-      }
+    try {
+      toReturn = LoggingLevel.valueOf(logLevelNameToSearch);
+    } catch (Exception ex) {
+      toReturn = FALLBACK_LOGGING_LEVEL;
     }
     return toReturn;
   }

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -42,30 +42,35 @@ public without sharing virtual class RollupLogger extends Rollup implements ILog
     this.log(logString, null, logLevel);
   }
 
-  @SuppressWarnings('PMD.AvoidDebugStatements')
-  public virtual void log(String logString, Object logObject, LoggingLevel logLevel) {
+  public void log(String logString, Object logObject, LoggingLevel logLevel) {
     if (this.rollupControl?.IsRollupLoggingEnabled__c == true && logLevel.ordinal() >= this.currentLoggingLevel.ordinal()) {
-      String appended = this.getLogStringFromObject(logObject);
-      List<String> messages = new List<String>{ logString };
-      if (String.isNotBlank(appended)) {
-        messages.add(appended);
-      }
-      // not all Rollup-generated exceptions come with stacktraces - this is a known issue, where using "new DMLException().getStackTraceString()"
-      // works to re-create the stacktrace for all of the calling code. we'll prune away any mentions to this class to keep the log size down
-      List<String> innerStacktraces = new DMLException().getStackTraceString().split('\n');
-      while (
-        innerStacktraces.isEmpty() == false &&
-        (innerStacktraces.get(0).contains('Class.RollupLogger.log') || innerStacktraces.get(0).contains('Class.RollupLogger.CombinedLogger.log'))
-      ) {
-        innerStacktraces.remove(0);
-      }
-      messages.add(String.join(innerStacktraces, '\n'));
-      System.debug(logLevel, 'Rollup: ' + String.join(messages, '\n') + '\n');
+      this.innerLog(logString, logObject, logLevel);
     }
   }
 
   public virtual void save() {
     // this is a no-op by default; sub-classes can opt in if they need to perform DML
+  }
+
+  @SuppressWarnings('PMD.AvoidDebugStatements')
+  protected virtual void innerLog(String logString, Object logObject, LoggingLevel logLevel) {
+    String appended = this.getLogStringFromObject(logObject);
+    List<String> messages = new List<String>{ logString };
+    if (String.isNotBlank(appended)) {
+      messages.add(appended);
+    }
+    // not all Rollup-generated exceptions come with stacktraces - this is a known issue, where using "new DMLException().getStackTraceString()"
+    // works to re-create the stacktrace for all of the calling code. we'll prune away any mentions to this class to keep the log size down
+    List<String> innerStacktraces = new DMLException().getStackTraceString().split('\n');
+    while (
+      innerStacktraces.isEmpty() == false &&
+      (innerStacktraces.get(0).contains('Class.RollupLogger.log') || innerStacktraces.get(0).contains('Class.RollupLogger.CombinedLogger.log')) ||
+      innerStacktraces.get(0).contains('Class.RollupLogger.innerLog')
+    ) {
+      innerStacktraces.remove(0);
+    }
+    messages.add(String.join(innerStacktraces, '\n'));
+    System.debug(logLevel, 'Rollup: ' + String.join(messages, '\n') + '\n');
   }
 
   private RollupPluginParameter__mdt loggingLevelPluginParameter {

--- a/rollup/core/classes/RollupParentResetProcessor.cls
+++ b/rollup/core/classes/RollupParentResetProcessor.cls
@@ -24,6 +24,7 @@ public inherited sharing class RollupParentResetProcessor extends RollupFullBatc
   ) {
     super(getRefinedQueryString(queryString, matchingMeta), invokePoint, matchingMeta, calcItemType, recordIds);
     this.overridesRunCalc = true;
+    this.isNoOp = false;
   }
 
   public override String runCalc() {

--- a/rollup/core/classes/RollupQueryBuilder.cls
+++ b/rollup/core/classes/RollupQueryBuilder.cls
@@ -115,7 +115,7 @@ public without sharing class RollupQueryBuilder {
         List<String> fieldParts = fieldName.split('\\.');
         String whoOrWhat = fieldParts.remove(0);
         String indexer = whoOrWhat + '.Type = \'';
-        String relationshipName = optionalWhereClause.substring(optionalWhereClause.indexOf(indexer) + indexer.length()).substringBeforeLast('\'');
+        String relationshipName = optionalWhereClause.substring(optionalWhereClause.indexOf(indexer) + indexer.length()).substringBefore('\'');
         String typeOfField = String.join(fieldParts, '.');
 
         uniqueQueryFieldNames.add('TYPEOF ' + whoOrWhat + ' WHEN ' + relationshipName + ' THEN ' + typeOfField + ' END');

--- a/rollup/core/classes/RollupSchedulable.cls
+++ b/rollup/core/classes/RollupSchedulable.cls
@@ -1,0 +1,11 @@
+public without sharing class RollupSchedulable implements System.Schedulable {
+  private final Rollup roll;
+
+  public RollupSchedulable(Rollup roll) {
+    this.roll = roll;
+  }
+
+  public void execute(SchedulableContext sc) {
+    this.roll.runCalc();
+  }
+}

--- a/rollup/core/classes/RollupSchedulable.cls-meta.xml
+++ b/rollup/core/classes/RollupSchedulable.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>53.0</apiVersion>
+  <status>Active</status>
+</ApexClass>

--- a/rollup/core/profiles/Admin.profile-meta.xml
+++ b/rollup/core/profiles/Admin.profile-meta.xml
@@ -77,6 +77,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>RollupSchedulable</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>RollupSObjectUpdater</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,7 +5,7 @@
             "package": "apex-rollup",
             "path": "rollup",
             "versionNumber": "1.3.8.0",
-            "versionDescription": "Adds parent-level filtering via Calc Item Where Clause support to Apex Rollup, fixed full recalc issue reported by jcart, fixed a Grandparent rollup bug reported by Ryan Gramer",
+            "versionDescription": "Fix Schedulable rollup classes, rollup loggers now respect Is Rollup Logging Enabled, fix some broken query formatting",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
                 "path": "extra-tests"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionNumber": "1.3.7.0",
+            "versionNumber": "1.3.8.0",
             "versionDescription": "Adds parent-level filtering via Calc Item Where Clause support to Apex Rollup, fixed full recalc issue reported by jcart, fixed a Grandparent rollup bug reported by Ryan Gramer",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -16,11 +16,11 @@
             "path": "plugins/CustomObjectRollupLogger",
             "dependencies": [
                 {
-                    "package": "apex-rollup@1.3.0-0"
+                    "package": "apex-rollup@1.3.8-0"
                 }
             ],
-            "versionNumber": "0.0.8.0",
-            "versionDescription": "Upgrading to Winter22",
+            "versionNumber": "0.0.9.0",
+            "versionDescription": "Only log when Is Rollup Logging is enabled",
             "default": false,
             "unpackagedMetadata": {
                 "path": "plugins/CustomObjectRollupLogger/tests"
@@ -31,14 +31,14 @@
             "path": "plugins/NebulaLogger",
             "dependencies": [
                 {
-                    "package": "apex-rollup@1.3.0-0"
+                    "package": "apex-rollup@1.3.8-0"
                 },
                 {
                     "package": "Nebula Logger - Unlocked Package@4.5.2-0-plugin-framework-enhancements"
                 }
             ],
-            "versionNumber": "0.0.4.0",
-            "versionDescription": "Upgrading to Winter22",
+            "versionNumber": "0.0.5.0",
+            "versionDescription": "Only log when Is Rollup Logging is enabled",
             "default": false,
             "unpackagedMetadata": {
                 "path": "plugins/NebulaLogger/tests"
@@ -70,19 +70,15 @@
     "packageAliases": {
         "apex-rollup": "0Ho6g000000TNcOCAW",
         "Apex Rollup - Custom Logger": "0Ho6g000000Gn8ZCAS",
-        "Apex Rollup - Custom Logger@0.0.7-0": "04t6g000008Shh3AAC",
         "Apex Rollup - Custom Logger@0.0.8-0": "04t6g000008ShzjAAC",
+        "Apex Rollup - Custom Logger@0.0.9-0": "04t6g000008Si1GAAS",
         "Apex Rollup - Nebula Logger": "0Ho6g000000Gn8PCAS",
-        "Apex Rollup - Nebula Logger@0.0.3-0": "04t6g000008ShTEAA0",
         "Apex Rollup - Nebula Logger@0.0.4-0": "04t6g000008ShzoAAC",
+        "Apex Rollup - Nebula Logger@0.0.5-0": "04t6g000008Si1BAAS",
         "Nebula Logger - Unlocked Package@4.5.2-0-plugin-framework-enhancements": "04t5Y0000027FNaQAM",
         "Apex Rollup - Rollup Callback": "0Ho6g000000GnA1CAK",
         "Apex Rollup - Rollup Callback@0.0.1-0": "04t6g000008ShTJAA0",
         "Apex Rollup - Rollup Callback@0.0.2-0": "04t6g000008ShztAAC",
-        "apex-rollup@1.2.40-0": "04t6g000008ShFvAAK",
-        "apex-rollup@1.2.41-0": "04t6g000008ShJEAA0",
-        "apex-rollup@1.2.42-0": "04t6g000008ShMNAA0",
-        "apex-rollup@1.2.43-0": "04t6g000008ShPMAA0",
         "apex-rollup@1.3.0-0": "04t6g000008ShUCAA0",
         "apex-rollup@1.3.1-0": "04t6g000008ShZ8AAK",
         "apex-rollup@1.3.2-0": "04t6g000008ShapAAC",
@@ -90,6 +86,7 @@
         "apex-rollup@1.3.4-0": "04t6g000008ShgeAAC",
         "apex-rollup@1.3.5-0": "04t6g000008ShhXAAS",
         "apex-rollup@1.3.6-0": "04t6g000008Shn7AAC",
-        "apex-rollup@1.3.7-0": "04t6g000008Si03AAC"
+        "apex-rollup@1.3.7-0": "04t6g000008Si03AAC",
+        "apex-rollup@1.3.8-0": "04t6g000008Si16AAC"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -87,6 +87,6 @@
         "apex-rollup@1.3.5-0": "04t6g000008ShhXAAS",
         "apex-rollup@1.3.6-0": "04t6g000008Shn7AAC",
         "apex-rollup@1.3.7-0": "04t6g000008Si03AAC",
-        "apex-rollup@1.3.8-0": "04t6g000008Si16AAC"
+        "apex-rollup@1.3.8-0": "04t6g000008Si24AAC"
     }
 }


### PR DESCRIPTION
* Added helptext for singular (text-based) full recalc app screen so that users don't accidentally start their SOQL where clause (when applicable) with `WHERE`
* Further Winter '22 cleanup making use of the new `Enum.valueOf()` methods
* Upgraded Codecov plugin to v2 to avoid upcoming deprecation
* Fixed an issue reported by Katherine West where schedulable rollup classes wouldn't ... run
* Fixed an issue reported by Katherine West and jcart with some full recalculation code paths