### PR TITLE
V1.3.11 - Full Recalc Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiHeAAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiHjAAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiHeAAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiHjAAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiG7AAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiHeAAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiG7AAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiHeAAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/CustomMetadataDrivenTests.cls
+++ b/extra-tests/classes/CustomMetadataDrivenTests.cls
@@ -120,4 +120,27 @@ private class CustomMetadataDrivenTests {
     System.assertEquals(secondChild.Name, updatedGreatGrandparent.Name, 'CONCAT_DISTINCT and reparenting should have worked');
     System.assertEquals(child.Name, updatedGreatGrandparentTwo.Name, 'CONCAT_DISTINCT and reparenting should have worked again');
   }
+
+  @IsTest
+  static void shouldWorkForParentLevelWhereClausesFromTrigger() {
+    // relies on extra-tests\customMetadata\Rollup.ParentWhereClauseFromTrigger.md-meta.xml
+    Rollup.defaultControl = new RollupControl__mdt(
+      ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.Synchronous,
+      IsRollupLoggingEnabled__c = true,
+      ReplaceCalcItemsAsyncWhenOverCount__c = 2
+    );
+    ParentApplication__c parentApp = new ParentApplication__c(Name = 'Parent');
+    insert parentApp;
+
+    Application__c app = new Application__c(Picklist__c = 'Standard', ParentApplication__c = parentApp.Id);
+    insert app;
+
+    parentApp = [SELECT Name FROM ParentApplication__c];
+    System.assertEquals(app.Picklist__c, parentApp.Name);
+
+    app.Picklist__c = 'Something with and in the name';
+    update app;
+
+    System.assert(true, 'Should make it here (validate update works with Trigger.oldMap)');
+  }
 }

--- a/extra-tests/classes/RollupCalculatorTests.cls
+++ b/extra-tests/classes/RollupCalculatorTests.cls
@@ -526,6 +526,32 @@ private class RollupCalculatorTests {
   }
 
   @IsTest
+  static void shouldProperlyRemoveCountDistinctOnUpdateIfOldItemMatchesAndNewOneDoesNot() {
+    Account acc = [SELECT Id FROM Account];
+    Opportunity opp = new Opportunity(AccountId = acc.Id, CloseDate = System.today(), StageName = 'Hi', Name = 'Count Distinct', Amount = 5);
+    insert opp;
+
+    Opportunity newerOpp = opp.clone(true, true);
+    newerOpp.Amount = 0;
+
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      1,
+      Rollup.Op.UPDATE_COUNT_DISTINCT,
+      Opportunity.Id,
+      Account.AnnualRevenue,
+      new Rollup__mdt(CalcItem__c = 'Opportunity'),
+      acc.Id,
+      Opportunity.AccountId
+    );
+    calc.setEvaluator(new RollupEvaluator.WhereFieldEvaluator('Amount > 0', Opportunity.SObjectType));
+    Map<Id, Opportunity> oldOppMap = new Map<Id, Opportunity>{ opp.Id => opp };
+
+    calc.performRollup(new List<Opportunity>{ newerOpp }, oldOppMap);
+
+    System.assertEquals(0, calc.getReturnValue());
+  }
+
+  @IsTest
   static void shouldReturnCountIfRollupValueUnchangedButEvalStatusHas() {
     RollupCalculator calc = RollupCalculator.Factory.getCalculator(
       0,
@@ -632,6 +658,32 @@ private class RollupCalculatorTests {
     System.assertEquals(2, calc.getReturnValue(), 'Sum should be returned if item was previously excluded but now isn\t!');
   }
 
+  @IsTest
+  static void shouldProperlyRemoveSumOnUpdateIfOldItemMatchesAndNewOneDoesNot() {
+    Account acc = [SELECT Id FROM Account];
+    Opportunity opp = new Opportunity(AccountId = acc.Id, CloseDate = System.today(), StageName = 'Hi', Name = 'Count Distinct', Amount = 5);
+    insert opp;
+
+    Opportunity newerOpp = opp.clone(true, true);
+    newerOpp.Amount = 0;
+
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      5,
+      Rollup.Op.UPDATE_SUM,
+      Opportunity.Amount,
+      Account.AnnualRevenue,
+      new Rollup__mdt(CalcItem__c = 'Opportunity'),
+      acc.Id,
+      Opportunity.AccountId
+    );
+    calc.setEvaluator(new RollupEvaluator.WhereFieldEvaluator('Amount > 0', Opportunity.SObjectType));
+    Map<Id, Opportunity> oldOppMap = new Map<Id, Opportunity>{ opp.Id => opp };
+
+    calc.performRollup(new List<Opportunity>{ newerOpp }, oldOppMap);
+
+    System.assertEquals(0, calc.getReturnValue());
+  }
+
   // CONCAT tests
 
   @IsTest
@@ -653,6 +705,27 @@ private class RollupCalculatorTests {
     calc.performRollup(new List<Opportunity>{ opp }, new Map<Id, SObject>());
 
     System.assertEquals(null, calc.getReturnValue());
+  }
+
+  @IsTest
+  static void shouldProperlyRemoveConcatOnUpdateIfOldItemMatchesAndNewOneDoesNot() {
+    Opportunity opp = new Opportunity(AccountId = '0011g00003VDGbF002', Id = '0066g00003VDGbF001', Name = 'CDC', Amount = 0);
+
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      'GISS, CDC',
+      Rollup.Op.UPDATE_CONCAT,
+      Opportunity.Name,
+      Account.Name,
+      new Rollup__mdt(CalcItem__c = 'Opportunity'),
+      '0011g00003VDGbF002',
+      Opportunity.AccountId
+    );
+    calc.setEvaluator(new RollupEvaluator.WhereFieldEvaluator('Amount > 0', Opportunity.SObjectType));
+    Map<Id, Opportunity> oldOppMap = new Map<Id, Opportunity>{ opp.Id => new Opportunity(Amount = 5, Name = 'CDC') };
+
+    calc.performRollup(new List<Opportunity>{ opp }, oldOppMap);
+
+    System.assertEquals('GISS', calc.getReturnValue());
   }
 
   @IsTest
@@ -715,6 +788,51 @@ private class RollupCalculatorTests {
     calc.performRollup(new List<Opportunity>{ opp, secondOpp }, new Map<Id, SObject>());
 
     System.assertEquals('2017, 2018, 2019, 2020, 2021', calc.getReturnValue());
+  }
+
+  @IsTest
+  static void shouldProperlyRemoveConcatDistinctOnUpdateIfOldItemMatchesAndNewOneDoesNot() {
+    String accountId = '0011g00003VDGbF002';
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      'CDC, GISS',
+      Rollup.Op.UPDATE_CONCAT_DISTINCT,
+      Opportunity.Name,
+      Account.Name,
+      new Rollup__mdt(),
+      accountId,
+      Opportunity.AccountId
+    );
+    calc.setEvaluator(new RollupEvaluator.WhereFieldEvaluator('Amount > 0', Opportunity.SObjectType));
+    Opportunity opp = new Opportunity(Amount = 0, Id = '0066g00003VDGbF001', Name = 'CDC', AccountId = accountId);
+    Map<Id, Opportunity> oldOppMap = new Map<Id, Opportunity>{ opp.Id => new Opportunity(Amount = 5, Name = 'CDC') };
+
+    calc.performRollup(new List<Opportunity>{ opp }, oldOppMap);
+
+    System.assertEquals('GISS', calc.getReturnValue());
+  }
+
+  @IsTest
+  static void shouldNotRemoveValuesOnConcatDistinctDeleteIfItemDoesNotMatch() {
+    Account acc = [SELECT Id FROM Account];
+
+    insert new Opportunity(AccountId = acc.Id, StageName = 'hi', CloseDate = System.today(), Name = 'Delete');
+
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      'CDC, Delete',
+      Rollup.Op.DELETE_CONCAT_DISTINCT,
+      Opportunity.Name,
+      Account.Name,
+      new Rollup__mdt(CalcItem__c = 'Opportunity'),
+      acc.Id,
+      Opportunity.AccountId
+    );
+    calc.setEvaluator(new RollupEvaluator.WhereFieldEvaluator('Amount > 0', Opportunity.SObjectType));
+
+    Opportunity opp = new Opportunity(Amount = 0, Id = '0066g00003VDGbF001', Name = 'CDC', AccountId = acc.Id);
+
+    calc.performRollup(new List<Opportunity>{ opp }, new Map<Id, Opportunity>());
+
+    System.assertEquals('Delete', calc.getReturnValue());
   }
 
   @IsTest
@@ -907,6 +1025,62 @@ private class RollupCalculatorTests {
     calc.performRollup(new List<Task>{ t }, new Map<Id, SObject>{ t.Id => new Task(ActivityDate = today) });
 
     System.assertEquals(t.ActivityDate, calc.getReturnValue(), 'Should be nulled out if no matching maximum');
+  }
+
+  @IsTest
+  static void shouldProperlyUpdateMinOnUpdateIfOldItemMatchesAndNewOneDoesNot() {
+    Account acc = [SELECT Id FROM Account];
+    Opportunity opp = new Opportunity(AccountId = acc.Id, CloseDate = System.today(), StageName = 'Hi', Name = 'Count Distinct', Amount = 5);
+    Opportunity newMin = opp.clone();
+    newMin.Amount = 3;
+    insert new List<Opportunity>{ opp, newMin };
+
+    Opportunity newerOpp = opp.clone(true, true);
+    newerOpp.Amount = 0;
+
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      5,
+      Rollup.Op.UPDATE_MIN,
+      Opportunity.Amount,
+      Account.AnnualRevenue,
+      new Rollup__mdt(CalcItem__c = 'Opportunity'),
+      acc.Id,
+      Opportunity.AccountId
+    );
+    calc.setEvaluator(new RollupEvaluator.WhereFieldEvaluator('Amount > 0', Opportunity.SObjectType));
+    Map<Id, Opportunity> oldOppMap = new Map<Id, Opportunity>{ opp.Id => opp };
+
+    calc.performRollup(new List<Opportunity>{ newerOpp }, oldOppMap);
+
+    System.assertEquals(3, calc.getReturnValue());
+  }
+
+  @IsTest
+  static void shouldProperlyUpdateMaxOnUpdateIfOldItemMatchesAndNewOneDoesNot() {
+    Account acc = [SELECT Id FROM Account];
+    Opportunity opp = new Opportunity(AccountId = acc.Id, CloseDate = System.today(), StageName = 'Hi', Name = 'Count Distinct', Amount = 5);
+    Opportunity newMax = opp.clone();
+    newMax.Amount = 7;
+    insert new List<Opportunity>{ opp, newMax };
+
+    Opportunity newerOpp = opp.clone(true, true);
+    newerOpp.Amount = 0;
+
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      5,
+      Rollup.Op.UPDATE_MAX,
+      Opportunity.Amount,
+      Account.AnnualRevenue,
+      new Rollup__mdt(CalcItem__c = 'Opportunity'),
+      acc.Id,
+      Opportunity.AccountId
+    );
+    calc.setEvaluator(new RollupEvaluator.WhereFieldEvaluator('Amount > 0', Opportunity.SObjectType));
+    Map<Id, Opportunity> oldOppMap = new Map<Id, Opportunity>{ opp.Id => opp };
+
+    calc.performRollup(new List<Opportunity>{ newerOpp }, oldOppMap);
+
+    System.assertEquals(7, calc.getReturnValue());
   }
 
   // Base recalculation tests

--- a/extra-tests/classes/RollupEvaluatorTests.cls
+++ b/extra-tests/classes/RollupEvaluatorTests.cls
@@ -1030,21 +1030,6 @@ private class RollupEvaluatorTests {
   }
 
   @IsTest
-  static void shouldThrowExceptionWhenRelationshipNameInvalid() {
-    String whereClause = 'Relationship__r.Waterloo__c = \'something\'';
-    RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, Opportunity.SObjectType);
-    Exception ex;
-    try {
-      eval.matches(new Opportunity());
-    } catch (SObjectException e) {
-      ex = e;
-    }
-
-    System.assertNotEquals(null, ex, 'Exception should have been thrown');
-    System.assertEquals('Invalid field Waterloo__c for Opportunity', ex.getMessage());
-  }
-
-  @IsTest
   static void shouldStripAwayRelationshipNameWhenParentClauseAndTypeMatchesParent() {
     String whereClause = 'Account.AnnualRevenue = 5';
     RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, Account.SObjectType);
@@ -1053,5 +1038,12 @@ private class RollupEvaluatorTests {
     whereClause = 'RollupParent__r.NumberField__c = 1';
     eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, RollupParent__c.SObjectType);
     System.assertEquals(true, eval.matches(new RollupParent__c(NumberField__c = 1)));
+  }
+
+  @IsTest
+  static void shouldNotBlowUpOnRelationshipNameForDifferentParent() {
+    String whereClause = 'Asset.AssetLevel = 1';
+    RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, Account.SObjectType);
+    System.assertEquals(true, eval.matches(new Account()));
   }
 }

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -25,7 +25,7 @@ private class RollupFullRecalcTests {
     );
     List<RollupAsyncProcessor> processors = new List<RollupAsyncProcessor>{
       actualProcessor,
-      new RollupDeferredFullRecalcProcessor(null, null, null, null, null),
+      new RollupDeferredFullRecalcProcessor(new List<Rollup__mdt>(), null, null, null, null),
       actualProcessor
     };
     processors.sort();

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -111,6 +111,7 @@ private class RollupIntegrationTests {
 
   @IsTest
   static void shouldProperlyAverageWithSpecialFieldNamesAndFilteredItems() {
+    Rollup.onlyUseMockMetadata = true;
     ParentApplication__c parentApp = new ParentApplication__c(Name = 'Hi');
     insert parentApp;
 

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -1660,7 +1660,7 @@ private class RollupIntegrationTests {
   static void shouldResetParentFieldsWhenItemsNoLongerMatch() {
     Rollup.defaultControl = new RollupControl__mdt(ShouldAbortRun__c = true, IsRollupLoggingEnabled__c = true, ReplaceCalcItemsAsyncWhenOverCount__c = 1);
     Account acc = [SELECT Id, Name FROM Account];
-    acc.AnnualRevenue = 6176191911.0;
+    acc.AnnualRevenue = 1.0;
     acc.NumberOfEmployees = 1;
     update acc;
 
@@ -1696,7 +1696,7 @@ private class RollupIntegrationTests {
 
     Account updatedAccount = [SELECT AnnualRevenue, NumberOfEmployees, Phone FROM Account];
     System.assertEquals(0, updatedAccount.NumberOfEmployees, 'COUNT should be cleared now that calc item no longer matches');
-    System.assertEquals(null, updatedAccount.AnnualRevenue, 'SUM should be cleared now that calc item no longer matches');
+    System.assertEquals(0, updatedAccount.AnnualRevenue, 'SUM should be cleared now that calc item no longer matches');
     System.assertEquals(cons[0].Phone, updatedAccount.Phone, 'MAX should not be cleared since calc item matches');
   }
 

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -1140,33 +1140,6 @@ private class RollupTests {
   }
 
   @IsTest
-  static void shouldShortCircuitOnConcatDistinctDeleteEvenIfDeletedCalcItemDoesNotMatch() {
-    Account acc = [SELECT Id, Name FROM Account];
-    String originalAccountName = acc.Name;
-    String somethingElse = 'Something else';
-    acc.Name = acc.Name + ', ' + somethingElse;
-    update acc;
-
-    ContactPointAddress cpa = new ContactPointAddress(Name = originalAccountName, ParentId = acc.Id, PreferenceRank = 0);
-    ContactPointAddress toDelete = new ContactPointAddress(Name = originalAccountName, ParentId = acc.Id, PreferenceRank = 1);
-    ContactPointAddress toDeleteTwo = new ContactPointAddress(Name = somethingElse, ParentId = acc.Id, PreferenceRank = 1);
-    List<ContactPointAddress> cpas = new List<ContactPointAddress>{ cpa, toDelete, toDeleteTwo };
-    insert cpas;
-
-    RollupTestUtils.DMLMock mock = RollupTestUtils.loadMock(new List<ContactPointAddress>{ toDelete, toDeleteTwo });
-    Rollup.apexContext = TriggerOperation.BEFORE_DELETE;
-    Rollup.Evaluator eval = RollupEvaluator.getWhereEval('PreferenceRank != 1', ContactPointAddress.SObjectType);
-
-    Test.startTest();
-    Rollup.concatDistinctFromApex(ContactPointAddress.Name, ContactPointAddress.ParentId, Account.Id, Account.Name, Account.SObjectType, null, eval).runCalc();
-    Test.stopTest();
-
-    System.assertEquals(1, mock.Records.size(), 'Account should be updated CONCAT_DISTINCT delete');
-    Account updatedAcc = (Account) mock.Records[0];
-    System.assertEquals(originalAccountName, updatedAcc.Name);
-  }
-
-  @IsTest
   static void shouldMaxOnStringsOnInsert() {
     List<ContactPointAddress> testCpas = new List<ContactPointAddress>{ new ContactPointAddress(Name = 'A'), new ContactPointAddress(Name = 'Z') };
 

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -1140,6 +1140,33 @@ private class RollupTests {
   }
 
   @IsTest
+  static void shouldShortCircuitOnConcatDistinctDeleteEvenIfDeletedCalcItemDoesNotMatch() {
+    Account acc = [SELECT Id, Name FROM Account];
+    String originalAccountName = acc.Name;
+    String somethingElse = 'Something else';
+    acc.Name = acc.Name + ', ' + somethingElse;
+    update acc;
+
+    ContactPointAddress cpa = new ContactPointAddress(Name = originalAccountName, ParentId = acc.Id, PreferenceRank = 0);
+    ContactPointAddress toDelete = new ContactPointAddress(Name = originalAccountName, ParentId = acc.Id, PreferenceRank = 1);
+    ContactPointAddress toDeleteTwo = new ContactPointAddress(Name = somethingElse, ParentId = acc.Id, PreferenceRank = 1);
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{ cpa, toDelete, toDeleteTwo };
+    insert cpas;
+
+    RollupTestUtils.DMLMock mock = RollupTestUtils.loadMock(new List<ContactPointAddress>{ toDelete, toDeleteTwo });
+    Rollup.apexContext = TriggerOperation.BEFORE_DELETE;
+    Rollup.Evaluator eval = RollupEvaluator.getWhereEval('PreferenceRank != 1', ContactPointAddress.SObjectType);
+
+    Test.startTest();
+    Rollup.concatDistinctFromApex(ContactPointAddress.Name, ContactPointAddress.ParentId, Account.Id, Account.Name, Account.SObjectType, null, eval).runCalc();
+    Test.stopTest();
+
+    System.assertEquals(1, mock.Records.size(), 'Account should be updated CONCAT_DISTINCT delete');
+    Account updatedAcc = (Account) mock.Records[0];
+    System.assertEquals(originalAccountName, updatedAcc.Name);
+  }
+
+  @IsTest
   static void shouldMaxOnStringsOnInsert() {
     List<ContactPointAddress> testCpas = new List<ContactPointAddress>{ new ContactPointAddress(Name = 'A'), new ContactPointAddress(Name = 'Z') };
 
@@ -2400,10 +2427,10 @@ private class RollupTests {
   @IsTest
   static void shouldUpdateProperlyAfterSaveIfCurrentItemWouldBeExcludedButOldItemWouldNotSum() {
     Account acc = [SELECT Id, AnnualRevenue FROM Account];
-    acc.AnnualRevenue = 2;
+    acc.AnnualRevenue = 18;
     update acc;
 
-    ContactPointAddress cpa = new ContactPointAddress(PreferenceRank = 0, Name = 'Sum non-match', ParentId = acc.Id);
+    ContactPointAddress cpa = new ContactPointAddress(PreferenceRank = 2, Name = 'Sum non-match', ParentId = acc.Id);
     ContactPointAddress matchingCpa = new ContactPointAddress(PreferenceRank = 15, Name = 'sum match', ParentId = acc.Id);
     insert new List<ContactPointAddress>{ cpa, matchingCpa };
 
@@ -2412,7 +2439,7 @@ private class RollupTests {
 
     List<Rollup.FlowInput> flowInputs = RollupTestUtils.prepareFlowTest(cpas, 'UPDATE', 'SUM');
     flowInputs[0].oldRecordsToRollup = new List<ContactPointAddress>{
-      new ContactPointAddress(ParentId = cpas[0].ParentId, Id = cpas[0].Id, PreferenceRank = acc.AnnualRevenue.intValue())
+      new ContactPointAddress(ParentId = cpas[0].ParentId, Id = cpas[0].Id, PreferenceRank = 3)
     };
     flowInputs[0].calcItemWhereClause = 'PreferenceRank != ' + cpa.PreferenceRank;
 
@@ -2441,7 +2468,7 @@ private class RollupTests {
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{ cpa };
     RollupTestUtils.DMLMock mock = RollupTestUtils.loadMock(cpas);
 
-    List<Rollup.FlowInput> flowInputs = RollupTestUtils.prepareFlowTest(cpas, 'UPDATE', 'SUM');
+    List<Rollup.FlowInput> flowInputs = RollupTestUtils.prepareFlowTest(cpas, 'UPDATE', 'FIRST');
     flowInputs[0].oldRecordsToRollup = new List<ContactPointAddress>{
       new ContactPointAddress(ParentId = cpas[0].ParentId, Id = cpas[0].Id, PreferenceRank = acc.AnnualRevenue.intValue())
     };
@@ -2455,9 +2482,9 @@ private class RollupTests {
     System.assertEquals('SUCCESS', flowOutputs[0].message);
     System.assertEquals(true, flowOutputs[0].isSuccess);
 
-    System.assertEquals(1, mock.Records.size(), 'SUM AFTER_UPDATE from flow did not update accounts');
+    System.assertEquals(1, mock.Records.size(), 'FIRST AFTER_UPDATE from flow did not update accounts');
     Account updatedAcc = (Account) mock.Records[0];
-    System.assertEquals(null, updatedAcc.AnnualRevenue, 'SUM AFTER_UPDATE from flow should get nulled out if no other matching items');
+    System.assertEquals(null, updatedAcc.AnnualRevenue, 'FIRST AFTER_UPDATE from flow should get nulled out if no other matching items');
   }
 
   @IsTest

--- a/extra-tests/customMetadata/Rollup.ParentWhereClauseFromTrigger.md-meta.xml
+++ b/extra-tests/customMetadata/Rollup.ParentWhereClauseFromTrigger.md-meta.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>ParentWhereClauseFromTrigger</label>
+    <protected>false</protected>
+    <values>
+        <field>CalcItemWhereClause__c</field>
+        <value xsi:type="xsd:string">ParentApplication__r.Name = &apos;Parent&apos;</value>
+    </values>
+    <values>
+        <field>CalcItem__c</field>
+        <value xsi:type="xsd:string">Application__c</value>
+    </values>
+    <values>
+        <field>ChangedFieldsOnCalcItem__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ConcatDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultNumberValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultStringValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GrandparentRelationshipFieldPath__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>IsFullRecordSet__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsRollupStartedFromParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>LookupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">ParentApplication__c</value>
+    </values>
+    <values>
+        <field>LookupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">Id</value>
+    </values>
+    <values>
+        <field>LookupObject__c</field>
+        <value xsi:type="xsd:string">ParentApplication__c</value>
+    </values>
+    <values>
+        <field>OrderByFirstLast__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>RollupControl__c</field>
+        <value xsi:type="xsd:string">Org_Defaults</value>
+    </values>
+    <values>
+        <field>RollupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">Picklist__c</value>
+    </values>
+    <values>
+        <field>RollupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">Name</value>
+    </values>
+    <values>
+        <field>RollupOperation__c</field>
+        <value xsi:type="xsd:string">FIRST</value>
+    </values>
+    <values>
+        <field>RollupToUltimateParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>SplitConcatDelimiterOnCalcItem__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>UltimateParentLookup__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -254,8 +254,13 @@ global without sharing virtual class Rollup {
     return baseString.removeEnd('\n');
   }
 
-  public virtual void resetFlags() {
-    isDeferralAllowed = true;
+  public virtual String runCalc() {
+    RollupLogger.Instance.log('no-op', LoggingLevel.DEBUG);
+    return 'Not implemented';
+  }
+
+  protected RollupControl__mdt getSpecificControl(Id rollupControlId) {
+    return getSingleControlOrDefault(RollupControl__mdt.Id, rollupControlId, specificControl);
   }
 
   protected List<Rollup> getCachedRollups() {
@@ -287,11 +292,6 @@ global without sharing virtual class Rollup {
 
   protected RollupSObjectUpdater getDML() {
     return DML;
-  }
-
-  public virtual String runCalc() {
-    RollupLogger.Instance.log('no-op', LoggingLevel.DEBUG);
-    return 'Not implemented';
   }
 
   protected virtual String getHashedContents() {

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -2379,14 +2379,14 @@ global without sharing virtual class Rollup {
       return records;
     }
 
-    return Trigger.isDelete ? Trigger.old : Trigger.new;
+    return (Trigger.isDelete ? Trigger.old : Trigger.new.clone()).deepClone(true, true, true);
   }
 
   private static Map<Id, SObject> getOldTriggerRecordsMap() {
     if (oldRecordsMap != null) {
       return oldRecordsMap;
     } else if (Trigger.oldMap != null) {
-      return Trigger.oldMap;
+      return Trigger.oldMap.deepClone();
     }
 
     return new Map<Id, SObject>();

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -16,7 +16,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   private Map<SObjectType, Set<String>> lookupObjectToUniqueFieldNames;
   private Map<SObjectType, Set<String>> calcObjectToUniqueFieldNames;
   private List<SObject> lookupItems;
-  private Map<String, List<SObject>> cachedFullRecalcs;
   private Integer stackDepth = 0;
 
   private static Boolean isRunningAsync = false;
@@ -26,6 +25,16 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   private enum CollectionType {
     DICTIONARY,
     ITERABLE
+  }
+
+  private final Map<String, List<SObject>> cachedFullRecalcs {
+    get {
+      if (cachedFullRecalcs == null) {
+        cachedFullRecalcs = new Map<String, List<SObject>>();
+      }
+      return cachedFullRecalcs;
+    }
+    set;
   }
 
   private final List<RollupAsyncProcessor> deferredRollups {
@@ -496,7 +505,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
     String key = rollup.calcItemType.getDescribe().getName();
     List<SObject> additionalCalcItems;
-    if (this.cachedFullRecalcs?.containsKey(key) == true) {
+    if (this.cachedFullRecalcs.containsKey(key)) {
       additionalCalcItems = this.cachedFullRecalcs.get(key);
     } else {
       Set<String> objIds = new Set<String>();
@@ -511,9 +520,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       }
 
       if (objIds.isEmpty() == false) {
-        if (this.cachedFullRecalcs == null) {
-          this.cachedFullRecalcs = new Map<String, List<SObject>>();
-        }
         Set<String> lookupKeys = lookupToCalcItems.keySet();
         String whereClause = '' + rollup.lookupFieldOnCalcItem + ' = :lookupKeys';
         Map<Schema.SObjectType, Set<String>> localCalcToUniqueFieldNames = rollup.fullRecalcProcessor != null &&

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -54,6 +54,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       this.queryString = queryString;
       this.rollupInfo = rollupInfo;
       this.recordIds = recordIds;
+      this.overrideRollupControl();
     }
 
     protected override Map<String, String> customizeToStringEntries(Map<String, String> props) {
@@ -75,6 +76,15 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
     private String getKey(RollupAsyncProcessor processor, SObject parent) {
       return String.valueOf(processor.opFieldOnLookupObject) + parent.Id;
+    }
+
+    private void overrideRollupControl() {
+      for (Rollup__mdt meta : this.rollupInfo) {
+        if (meta.RollupControl__c != null) {
+          RollupControl__mdt specificControl = this.getSpecificControl(meta.RollupControl__c);
+          this.overrideParentRollupControlValues(specificControl);
+        }
+      }
     }
   }
 
@@ -301,13 +311,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
     RollupLogger.Instance.save();
     return rollupProcessId;
-  }
-
-  public override void resetFlags() {
-    super.resetFlags();
-    isRunningAsync = false;
-    shouldRunAsBatch = false;
-    stackDepth = 0;
   }
 
   protected virtual override String getTypeName() {
@@ -882,7 +885,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   private void ingestRollupControlData(List<RollupAsyncProcessor> syncRollups) {
-    Double minBatchSize = this.rollupControl.BatchChunkSize__c;
     for (Integer index = this.rollups.size() - 1; index >= 0; index--) {
       RollupAsyncProcessor rollup = this.rollups[index];
       rollup.isFullRecalc = rollup.isFullRecalc || this.isFullRecalc;
@@ -904,21 +906,24 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         this.getCachedRollups().add(rollup);
       }
 
-      // you can increase the default limits, but it would be too messy to try to rank the individual rollup operations in a batched context
-      if (rollup.rollupControl.BatchChunkSize__c < this.rollupControl.BatchChunkSize__c) {
-        minBatchSize = rollup.rollupControl.BatchChunkSize__c;
-      }
-      if (rollup.rollupControl.MaxLookupRowsBeforeBatching__c > this.rollupControl.MaxLookupRowsBeforeBatching__c) {
-        this.rollupControl.MaxLookupRowsBeforeBatching__c = rollup.rollupControl.MaxLookupRowsBeforeBatching__c;
-      }
-      if (rollup.rollupControl.ShouldRunAs__c != this.rollupControl.ShouldRunAs__c) {
-        this.rollupControl.ShouldRunAs__c = rollup.rollupControl.ShouldRunAs__c;
-      }
-      if (rollup.rollupControl.MaxParentRowsUpdatedAtOnce__c == null) {
-        rollup.rollupControl.MaxParentRowsUpdatedAtOnce__c = this.rollupControl.MaxParentRowsUpdatedAtOnce__c;
-      }
+      this.overrideParentRollupControlValues(rollup.rollupControl);
     }
-    this.rollupControl.BatchChunkSize__c = minBatchSize;
+  }
+
+  private void overrideParentRollupControlValues(RollupControl__mdt specificControl) {
+    // override section - most updates go from a rollup specific control -> this.rollupControl
+    if (specificControl.BatchChunkSize__c < this.rollupControl.BatchChunkSize__c) {
+      this.rollupControl.BatchChunkSize__c = specificControl.BatchChunkSize__c;
+    }
+    if (specificControl.MaxLookupRowsBeforeBatching__c > this.rollupControl.MaxLookupRowsBeforeBatching__c) {
+      this.rollupControl.MaxLookupRowsBeforeBatching__c = specificControl.MaxLookupRowsBeforeBatching__c;
+    }
+    if (specificControl.ShouldRunAs__c != this.rollupControl.ShouldRunAs__c) {
+      this.rollupControl.ShouldRunAs__c = specificControl.ShouldRunAs__c;
+    }
+    if (specificControl.MaxParentRowsUpdatedAtOnce__c == null) {
+      specificControl.MaxParentRowsUpdatedAtOnce__c = this.rollupControl.MaxParentRowsUpdatedAtOnce__c;
+    }
   }
 
   private Boolean getShouldRunSyncDeferred(RollupAsyncProcessor roll) {

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -12,6 +12,7 @@ public without sharing abstract class RollupCalculator {
   protected final Rollup__mdt metadata;
   protected final String lookupKeyQuery;
   protected final String lookupRecordKey;
+  protected final Boolean isChangedFieldCalc;
 
   protected Rollup.Evaluator eval;
   protected Boolean shouldShortCircuit = false;
@@ -113,6 +114,7 @@ public without sharing abstract class RollupCalculator {
       UserInfo.isMultiCurrencyOrganization() &&
       (this.opFieldOnCalcItem?.getDescribe().getType() == DisplayType.CURRENCY ||
       this.opFieldOnLookupObject?.getDescribe().getType() == DisplayType.CURRENCY);
+    this.isChangedFieldCalc = String.isNotBlank(this.metadata.ChangedFieldsOnCalcItem__c);
   }
   public virtual Object getReturnValue() {
     return this.returnVal;
@@ -272,12 +274,15 @@ public without sharing abstract class RollupCalculator {
         this.transformForMultiCurrencyOrgs(item);
         items.add(this.getTransformedCalcItem(item));
       } else if (
-        this.op == Rollup.Op.UPDATE_COUNT &&
+        (this.op == Rollup.Op.UPDATE_COUNT ||
+        this.op == Rollup.Op.UPDATE_CONCAT_DISTINCT ||
+        this.op == Rollup.Op.UPDATE_CONCAT ||
+        this.op == Rollup.Op.UPDATE_SUM) &&
+        this.isChangedFieldCalc == false &&
         currentItemMatches == false &&
         oldCalcItems.containsKey(item.Id) &&
         this.eval?.matches(oldCalcItems.get(item.Id)) == true
       ) {
-        // TODO - handle old item matching, new item not matching situation for (other non-full recalc) operations
         this.transformForMultiCurrencyOrgs(item);
         items.add(this.getTransformedCalcItem(item));
       }
@@ -394,7 +399,7 @@ public without sharing abstract class RollupCalculator {
         this.distinctValues.add(potentiallyNullValue);
       } else if (this.op == Rollup.Op.DELETE_COUNT_DISTINCT) {
         this.distinctValues.clear();
-        this.calculateNewAggregateVAlue(this.op, new Set<Id>{ calcItem.Id }, calcItem.getSObjectType());
+        this.calculateNewAggregateValue(this.op, new Set<Id>{ calcItem.Id }, calcItem.getSObjectType());
       }
       this.shouldShortCircuit = true;
     }
@@ -469,17 +474,22 @@ public without sharing abstract class RollupCalculator {
     }
 
     protected virtual Decimal getNumericChangedValue(SObject calcItem, Map<Id, SObject> oldCalcItems) {
-      SObject oldCalcItem = oldCalcItems.containsKey(calcItem.Id) ? oldCalcItems.get(calcItem.Id) : calcItem;
+      SObject oldCalcItem = oldCalcItems.get(calcItem.Id);
 
       Decimal newVal = this.getNumericValue(calcItem);
+      Decimal oldVal = oldCalcItem != null ? this.getNumericValue(oldCalcItem) : newVal;
+
+      Boolean matchesCurrent = this.eval?.matches(calcItem) == true;
+      Boolean matchesOld = oldCalcItem != null && this.eval?.matches(oldCalcItem) == true;
 
       if (this.isReparented(calcItem, oldCalcItem)) {
         return newVal;
-      } else if (this.eval?.matches(calcItem) == true && this.eval?.matches(oldCalcItem) == false) {
+      } else if (matchesCurrent && matchesOld == false && this.isChangedFieldCalc == false) {
         return newVal;
+      } else if (matchesCurrent == false && matchesOld && this.isChangedFieldCalc == false) {
+        return oldVal * -1;
       }
 
-      Decimal oldVal = this.getNumericValue(oldCalcItem);
       // could be negative, could be positive ... could be 0!
       return newVal - oldVal;
     }
@@ -725,6 +735,9 @@ public without sharing abstract class RollupCalculator {
         return 1;
       }
 
+      Boolean matchesCurrent = this.eval?.matches(calcItem) == true;
+      Boolean matchesPrior = this.eval?.matches(oldCalcItem) == true;
+
       // for updates, we have to decrement the count if the value has been cleared out
       Decimal retVal = 0;
       Object current = calcItem.get(this.opFieldOnCalcItem);
@@ -734,9 +747,9 @@ public without sharing abstract class RollupCalculator {
         retVal = -1;
       } else if (current != defaultVal && prior == defaultVal) {
         retVal = 1;
-      } else if (this.eval?.matches(oldCalcItem) == false && this.eval?.matches(calcItem) == true) {
+      } else if (matchesPrior == false && matchesCurrent) {
         retVal = 1;
-      } else if (this.eval?.matches(oldCalcItem) == true && this.eval?.matches(calcItem) == false) {
+      } else if (matchesPrior && matchesCurrent == false) {
         retVal = -1;
       }
       return retVal;
@@ -811,8 +824,11 @@ public without sharing abstract class RollupCalculator {
 
     public override void handleUpdateConcat(SObject calcItem, Map<Id, SObject> oldCalcItems) {
       String newVal = String.valueOf(calcItem.get(this.opFieldOnCalcItem));
-      String priorString = String.valueOf((oldCalcItems.containsKey(calcItem.Id) ? oldCalcItems.get(calcItem.Id).get(this.opFieldOnCalcItem) : newVal));
-      if (this.shouldConcat(newVal)) {
+      SObject priorItem = oldCalcItems.get(calcItem.Id);
+      if (this.eval?.matches(calcItem) == false && priorItem != null && this.eval?.matches(priorItem) == true) {
+        this.handleDeleteConcat(calcItem);
+      } else if (this.shouldConcat(newVal)) {
+        String priorString = String.valueOf(priorItem != null ? priorItem.get(this.opFieldOnCalcItem) : newVal);
         this.stringVal = this.replaceWithDelimiter(this.stringVal, priorString, newVal);
       }
     }

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -688,7 +688,13 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       SObjectField fieldToken = sObjectType.getDescribe().fields.getMap().get(relationshipName);
       if (fieldToken == null) {
         // it could be a rollup started from the parent using a parent-level where clause
-        return item.get(fieldPath.substringAfter('.'));
+        try {
+          return item.get(fieldPath.substringAfter('.'));
+        } catch (System.SObjectException ex) {
+          // if the field value is invalid, it's almost certainly a parent-level where clause targeting
+          // a different parent - pass the records through for now
+          return this.originalValues.isEmpty() == false ? this.originalValues[0] : null;
+        }
       }
       SObjectType parentSObjectType;
       if (fieldToken.getDescribe().isNamePointing() && item.get(relationshipName) != null) {

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -1,5 +1,5 @@
 public inherited sharing virtual class RollupFullBatchRecalculator extends RollupAsyncProcessor.FullRecalcProcessor implements Database.Stateful {
-  private final Map<String, Rollup.CalcItemBag> statefulLookupToCalcItems;
+  private final Map<String, CalcItemBag> statefulLookupToCalcItems;
 
   public RollupFullBatchRecalculator(
     String queryString,
@@ -9,7 +9,7 @@ public inherited sharing virtual class RollupFullBatchRecalculator extends Rollu
     Set<Id> recordIds
   ) {
     super(queryString, invokePoint, rollupInfo, calcItemType, recordIds);
-    this.statefulLookupToCalcItems = new Map<String, Rollup.CalcItemBag>();
+    this.statefulLookupToCalcItems = new Map<String, CalcItemBag>();
   }
 
   public override Database.QueryLocator start(Database.BatchableContext bc) {
@@ -45,23 +45,24 @@ public inherited sharing virtual class RollupFullBatchRecalculator extends Rollu
     return this.startBatchProcessor();
   }
 
-  protected override void retrieveAdditionalCalcItems(Map<String, Rollup.CalcItemBag> lookupToCalcItems, RollupAsyncProcessor rollup) {
-    RollupLogger.Instance.log(this.getTypeName() + ' checking on cached calc items ...', LoggingLevel.FINE);
-    Map<String, Rollup.CalcItemBag> local = new Map<String, Rollup.CalcItemBag>();
+  protected override void retrieveAdditionalCalcItems(Map<String, CalcItemBag> lookupToCalcItems, RollupAsyncProcessor rollup) {
+    RollupLogger.Instance.log('checking on cached calc items ...', LoggingLevel.FINE);
+    Map<String, CalcItemBag> local = new Map<String, CalcItemBag>();
     for (String lookupKey : lookupToCalcItems.keySet()) {
-      Rollup.CalcItemBag bag = lookupToCalcItems.get(lookupKey);
-      if (bag.hasQueriedForAdditionalItems == false && this.statefulLookupToCalcItems.containsKey(lookupKey)) {
-        lookupToCalcItems.remove(lookupKey);
+      CalcItemBag bag = lookupToCalcItems.get(lookupKey);
+      if (this.statefulLookupToCalcItems.containsKey(lookupKey)) {
+        lookupToCalcItems.put(lookupKey, this.statefulLookupToCalcItems.get(lookupKey));
       } else {
         local.put(lookupKey, bag);
       }
-      lookupToCalcItems.put(lookupKey, bag);
     }
 
     super.retrieveAdditionalCalcItems(local, rollup);
 
     for (String lookupKey : local.keySet()) {
-      this.statefulLookupToCalcItems.put(lookupKey, local.get(lookupKey));
+      CalcItemBag bag = local.get(lookupKey);
+      this.statefulLookupToCalcItems.put(lookupKey, bag);
+      lookupToCalcItems.put(lookupKey, bag);
     }
   }
 }

--- a/scripts/build-and-promote-package.ps1
+++ b/scripts/build-and-promote-package.ps1
@@ -128,7 +128,7 @@ if($currentBranch -eq "main") {
   if ($packageJson.version -ne $currentPackageVersion) {
     Write-Output "Bumping package.json version to: $currentPackageVersion"
 
-    $packageJson.version = Update-Last-Substring $currentPackageVersion ".0" ""
+    $packageJson.version = $currentPackageVersion
     $packagePath = "./package.json"
     ConvertTo-Json -InputObject $packageJson | Set-Content -Path $packagePath -NoNewline
 

--- a/scripts/build-and-promote-package.ps1
+++ b/scripts/build-and-promote-package.ps1
@@ -60,7 +60,7 @@ if(Test-Path ".\PACKAGING_SFDX_URL.txt") {
 }
 
 $sfdxProjectJson = Get-SFDX-Project-JSON
-$currentPackageVersion = $sfdxProjectJson.packageDirectories[0].versionNumber
+$currentPackageVersion = $sfdxProjectJson.packageDirectories[0].versionNumber.Remove($sfdxProjectJson.packageDirectories[0].versionNumber.Length - 2, 2)
 
 Write-Output "Current package version number: $currentPackageVersion"
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -85,6 +85,6 @@
         "apex-rollup@1.3.8-0": "04t6g000008Si24AAC",
         "apex-rollup@1.3.9-0": "04t6g000008Si5XAAS",
         "apex-rollup@1.3.10-0": "04t6g000008SiG7AAK",
-        "apex-rollup@1.3.11-0": "04t6g000008SiHAAA0"
+        "apex-rollup@1.3.11-0": "04t6g000008SiHeAAK"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -84,6 +84,7 @@
         "apex-rollup@1.3.7-0": "04t6g000008Si03AAC",
         "apex-rollup@1.3.8-0": "04t6g000008Si24AAC",
         "apex-rollup@1.3.9-0": "04t6g000008Si5XAAS",
-        "apex-rollup@1.3.10-0": "04t6g000008SiG7AAK"
+        "apex-rollup@1.3.10-0": "04t6g000008SiG7AAK",
+        "apex-rollup@1.3.11-0": "04t6g000008SiHAAA0"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -85,6 +85,6 @@
         "apex-rollup@1.3.8-0": "04t6g000008Si24AAC",
         "apex-rollup@1.3.9-0": "04t6g000008Si5XAAS",
         "apex-rollup@1.3.10-0": "04t6g000008SiG7AAK",
-        "apex-rollup@1.3.11-0": "04t6g000008SiHeAAK"
+        "apex-rollup@1.3.11-0": "04t6g000008SiHjAAK"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionNumber": "1.3.10.0",
+            "versionNumber": "1.3.11.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
* Fixes #207 by ensuring promotion script gets correct package Id to promote
* Adding missing fix for #203 - full recalc processors now respect lower Rollup Control batch size limits, too
* Patching a few issues further issues with CONCAT_DISTINCT, added in proper handling for old calc item matching and new one not matching for several operations
* Fixes #209 by deep cloning trigger records to prevent System.FinalException: Record is read-only
* Fix for #210 - properly reference cached calc items when performing full recalc across batches
* Fixes #204 by passing parent records through when parent-level filtering exists and the parent-level field referenced isn't on the current parent