### PR TITLE
V1.3.12 - First/Last/Average Optimizations & BigDecimal bugfix

### DIFF
--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -1334,4 +1334,57 @@ private class RollupFullRecalcTests {
     acc = [SELECT AnnualRevenue FROM Account];
     System.assertEquals(2, acc.AnnualRevenue);
   }
+
+  @IsTest
+  static void shouldNotRequeryForAverageItemsInFullRecalc() {
+    RollupAsyncProcessor.shouldRunAsBatch = true;
+    Rollup.defaultControl = new RollupControl__mdt(
+      ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.Synchronous,
+      BatchChunkSize__c = 4,
+      MaxLookupRowsBeforeBatching__c = 2,
+      IsRollupLoggingEnabled__c = true
+    );
+    Account acc = [SELECT Id FROM Account];
+    Account second = new Account(Name = 'Second');
+    insert second;
+
+    insert new List<Opportunity>{
+      new Opportunity(StageName = 'firstName', CloseDate = System.today(), AccountId = acc.Id, Name = 'one', Amount = 1),
+      new Opportunity(StageName = 'secondName', CloseDate = System.today(), AccountId = acc.Id, Name = 'two', Amount = 3),
+      new Opportunity(StageName = 'thirdName', CloseDate = System.today(), AccountId = second.Id, Name = 'three', Amount = 5),
+      new Opportunity(StageName = 'thirdName', CloseDate = System.today(), AccountId = second.Id, Name = 'four', Amount = 3)
+    };
+
+    List<Rollup__mdt> metas = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'Opportunity',
+        RollupFieldOnCalcItem__c = 'Amount',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupObject__c = 'Account',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'AVERAGE'
+      ),
+      new Rollup__mdt(
+        CalcItem__c = 'Opportunity',
+        RollupFieldOnCalcItem__c = 'Id',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupObject__c = 'Account',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'NumberOfEmployees',
+        RollupOperation__c = 'COUNT'
+      )
+    };
+
+    Test.startTest();
+    Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_LWC.name());
+    Test.stopTest();
+
+    // only one of the records will have been updated since the query limit will have led to an
+    // unprocessable deferral (since tests can't re-queue/batch)
+    second = [SELECT AnnualRevenue, NumberOfEmployees FROM Account WHERE Id = :second.Id];
+    System.assertEquals(4.00, second.AnnualRevenue);
+    System.assertEquals(2.00, second.NumberOfEmployees);
+    System.assertEquals(3, Limits.getQueries()); // 2 in rollup (one to get the parents, one to get additional children, plus the query above)
+  }
 }

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -1385,6 +1385,57 @@ private class RollupFullRecalcTests {
     second = [SELECT AnnualRevenue, NumberOfEmployees FROM Account WHERE Id = :second.Id];
     System.assertEquals(4.00, second.AnnualRevenue);
     System.assertEquals(2.00, second.NumberOfEmployees);
-    System.assertEquals(3, Limits.getQueries()); // 2 in rollup (one to get the parents, one to get additional children, plus the query above)
+  }
+
+  @IsTest
+  static void shouldNotRequeryInFullRecalcForFirstLast() {
+    RollupAsyncProcessor.shouldRunAsBatch = true;
+    Rollup.defaultControl = new RollupControl__mdt(
+      ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.Synchronous,
+      BatchChunkSize__c = 4,
+      MaxLookupRowsBeforeBatching__c = 2,
+      IsRollupLoggingEnabled__c = true
+    );
+    Account acc = [SELECT Id FROM Account];
+    Account second = new Account(Name = 'Second');
+    insert second;
+
+    insert new List<Opportunity>{
+      new Opportunity(StageName = 'firstName', CloseDate = System.today(), AccountId = acc.Id, Name = 'one', Amount = 1),
+      new Opportunity(StageName = 'secondName', CloseDate = System.today(), AccountId = acc.Id, Name = 'two', Amount = 3),
+      new Opportunity(StageName = 'thirdName', CloseDate = System.today(), AccountId = second.Id, Name = 'three', Amount = 5),
+      new Opportunity(StageName = 'thirdName', CloseDate = System.today(), AccountId = second.Id, Name = 'four', Amount = 3)
+    };
+
+    List<Rollup__mdt> metas = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'Opportunity',
+        RollupFieldOnCalcItem__c = 'Amount',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupObject__c = 'Account',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'FIRST'
+      ),
+      new Rollup__mdt(
+        CalcItem__c = 'Opportunity',
+        RollupFieldOnCalcItem__c = 'Id',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupObject__c = 'Account',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'NumberOfEmployees',
+        RollupOperation__c = 'COUNT'
+      )
+    };
+
+    Test.startTest();
+    Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_LWC.name());
+    Test.stopTest();
+
+    // only one of the records will have been updated since the query limit will have led to an
+    // unprocessable deferral (since tests can't re-queue/batch)
+    second = [SELECT AnnualRevenue, NumberOfEmployees FROM Account WHERE Id = :second.Id];
+    System.assertEquals(3.00, second.AnnualRevenue);
+    System.assertEquals(2.00, second.NumberOfEmployees);
   }
 }

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -2196,6 +2196,31 @@ private class RollupTests {
   }
 
   @IsTest
+  static void shouldSplitConcatCalcItemsFromFlow() {
+    Account acc = [SELECT Id FROM Account];
+    acc.Name = 'CDC';
+    update acc;
+
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
+      new ContactPointAddress(Name = 'CDC, GDG', ParentId = acc.Id),
+      new ContactPointAddress(Name = 'CDC, GDG', ParentId = acc.Id)
+    };
+    RollupTestUtils.DMLMock mock = RollupTestUtils.loadMock(cpas);
+    List<Rollup.FlowInput> flowInputs = RollupTestUtils.prepareFlowTest(cpas, 'INSERT', 'CONCAT_DISTINCT');
+    flowInputs[0].rollupFieldOnOpObject = 'Name';
+    flowInputs[0].rollupFieldOnCalcItem = 'Name';
+    flowInputs[0].splitConcatDelimiterOnCalcItem = true;
+
+    Test.startTest();
+    Rollup.performRollup(flowInputs);
+    Test.stopTest();
+
+    System.assertEquals(1, mock.Records.size(), 'CONCAT_DISTINCT AFTER_INSERT from flow did not update account');
+    Account updatedAcc = (Account) mock.Records[0];
+    System.assertEquals(cpas[0].Name, updatedAcc.Name, 'CONCAT_DISTINCT should have split on calc item values!');
+  }
+
+  @IsTest
   static void shouldBeInvokedRegardlessOfCasingFromFlow() {
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{ new ContactPointAddress(PreferenceRank = 1000) };
     RollupTestUtils.DMLMock mock = RollupTestUtils.loadAccountIdMock(cpas);

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1540,7 +1540,8 @@ global without sharing virtual class Rollup {
       CalcItem__c = flowInput.isRollupStartedFromParent || String.isNotBlank(flowInput.calcItemTypeWhenRollupStartedFromParent)
         ? flowInput.calcItemTypeWhenRollupStartedFromParent
         : String.valueOf(sObjectType),
-      IsRollupStartedFromParent__c = flowInput.isRollupStartedFromParent
+      IsRollupStartedFromParent__c = flowInput.isRollupStartedFromParent,
+      SplitConcatDelimiterOnCalcItem__c = flowInput.splitConcatDelimiterOnCalcItem
     );
   }
 

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -1091,26 +1091,28 @@ public without sharing abstract class RollupCalculator {
 
     @SuppressWarnings('PMD.UnusedLocalVariable')
     public override void performRollup(List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
-      SObjectType sObjectType = this.getCalcItemType();
-      // objIds is used as a bind variable in the resulting queryString
-      Set<Id> objIds = new Map<Id, SObject>(calcItems).keySet();
-      Set<String> queryFields = new Set<String>{
-        String.valueOf(this.opFieldOnCalcItem),
-        this.metadata.OrderByFirstLast__c,
-        this.metadata.LookupFieldOnCalcItem__c
-      };
-      if (String.isNotBlank(this.metadata.CalcItemWhereClause__c)) {
-        queryFields.addAll(RollupEvaluator.getWhereEval(this.metadata.CalcItemWhereClause__c, sObjectType).getQueryFields());
-      }
-      // a full-recalc is always necessary because we don't retain the information about the order by field
-      String queryString = RollupQueryBuilder.Current.getQuery(sObjectType, new List<String>(queryFields), 'Id', '!=', this.lookupKeyQuery);
+      if (this.isFullRecalc == false) {
+        SObjectType sObjectType = this.getCalcItemType();
+        // objIds is used as a bind variable in the resulting queryString
+        Set<Id> objIds = new Map<Id, SObject>(calcItems).keySet();
+        Set<String> queryFields = new Set<String>{
+          String.valueOf(this.opFieldOnCalcItem),
+          this.metadata.OrderByFirstLast__c,
+          this.metadata.LookupFieldOnCalcItem__c
+        };
+        if (String.isNotBlank(this.metadata.CalcItemWhereClause__c)) {
+          queryFields.addAll(RollupEvaluator.getWhereEval(this.metadata.CalcItemWhereClause__c, sObjectType).getQueryFields());
+        }
+        // a full-recalc is always necessary because we don't retain the information about the order by field
+        String queryString = RollupQueryBuilder.Current.getQuery(sObjectType, new List<String>(queryFields), 'Id', '!=', this.lookupKeyQuery);
 
-      // we have to exclude the current items on delete, otherwise they'll be incorrectly considered
-      List<SObject> additionalItems = Database.query(queryString);
-      if (this.op.name().contains('DELETE')) {
-        calcItems = additionalItems;
-      } else {
-        calcItems.addAll(additionalItems);
+        // we have to exclude the current items on delete, otherwise they'll be incorrectly considered
+        List<SObject> additionalItems = Database.query(queryString);
+        if (this.op.name().contains('DELETE')) {
+          calcItems = additionalItems;
+        } else {
+          calcItems.addAll(additionalItems);
+        }
       }
 
       calcItems = this.winnowItems(calcItems, oldCalcItems);

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -1021,29 +1021,32 @@ public without sharing abstract class RollupCalculator {
       super(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata.FullRecalculationDefaultNumberValue__c, metadata, lookupRecordKey, lookupKeyField);
     }
     public override void performRollup(List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
-      SObjectType sObjectType = this.getCalcItemType();
-      Set<Id> objIds = new Map<Id, SObject>(calcItems).keySet();
-      Boolean isArchivable = sObjectType == Task.SObjectType || sObjectType == Event.SObjectType;
-      String query = RollupQueryBuilder.Current.getQuery(sObjectType, new List<String>{ isArchivable ? 'Id' : 'Count()' }, 'Id', '!=', this.lookupKeyQuery);
-      Integer countOfPreExistingItems = isArchivable ? Database.query(query).size() : Database.countQuery(query);
+      List<SObject> applicableCalcItems = this.op == Rollup.Op.DELETE_AVERAGE ? new List<SObject>() : calcItems;
+      applicableCalcItems = this.winnowItems(applicableCalcItems, oldCalcItems);
+      Decimal oldSum;
+      Decimal denominator = Decimal.valueOf(applicableCalcItems.size());
+      if (this.isFullRecalc == false) {
+        SObjectType sObjectType = this.getCalcItemType();
+        Set<Id> objIds = new Map<Id, SObject>(calcItems).keySet();
+        String query = RollupQueryBuilder.Current.getQuery(sObjectType, new List<String>{ 'Id' }, 'Id', '!=', this.lookupKeyQuery);
+        // normally we could use countQuery here (except for Task/Event, which can be archived)
+        // something about this combination of steps led to exceptions on some code paths:
+        // System.UnexpectedException: class java.math.BigDecimal cannot be cast to class java.lang.Integer
+        // further downstream (when RollupSObjectUpdater.doUpdate was called). Incrementing by the size of the
+        // returned list works without issue.
+        denominator += Database.query(query).size();
+        oldSum = (Decimal) this.calculateNewAggregateValue(Rollup.Op.SUM, objIds, sObjectType);
+      }
 
-      Decimal oldSum = (Decimal) this.calculateNewAggregateValue(Rollup.Op.SUM, objIds, sObjectType);
       if (oldSum == null) {
         oldSum = 0;
       }
-
-      List<SObject> applicableCalcItems = this.op == Rollup.Op.DELETE_AVERAGE ? new List<SObject>() : calcItems;
-      applicableCalcItems = this.winnowItems(applicableCalcItems, oldCalcItems);
-
       Decimal newSum = 0;
-      Decimal currentDenominator = 0;
       for (SObject calcItem : applicableCalcItems) {
         Object potentialDecimal = calcItem.get(this.opFieldOnCalcItem);
         newSum += potentialDecimal == null ? 0 : (Decimal) potentialDecimal;
-        currentDenominator++;
       }
 
-      Decimal denominator = countOfPreExistingItems + currentDenominator;
       Decimal average = null;
       // We can't do the division if the denominator is 0
       if (denominator != 0) {

--- a/rollup/core/classes/RollupSObjectUpdater.cls
+++ b/rollup/core/classes/RollupSObjectUpdater.cls
@@ -29,26 +29,21 @@ public without sharing virtual class RollupSObjectUpdater {
   }
 
   public void updateField(SObject record, Object value) {
-    try {
-      record.put(this.fieldToken, value);
-    } catch (SObjectException sObjException) {
-      this.handleUpdateException(sObjException, record, value);
-    }
+    this.updateValue(record, value);
   }
 
-  private void handleUpdateException(SObjectException ex, SObject record, Object value) {
-    switch on ex.getMessage().substringAfter('Illegal assignment from ') {
-      when 'Datetime to Date' {
-        record.put(this.fieldToken, ((Datetime) value).dateGmt());
+  private void updateValue(SObject record, Object value) {
+    Schema.DisplayType fieldType = this.fieldToken.getDescribe().getType();
+
+    if (value instanceof Decimal) {
+      Decimal decimalValue = (Decimal) value;
+      if (fieldType == DisplayType.INTEGER) {
+        value = decimalValue.intValue();
       }
-      when 'Decimal to Integer' {
-        record.put(this.fieldToken, ((Decimal) value).intValue());
-      }
-      when else {
-        // this switch statement can be expanded as necessary to deal with other problems
-        throw ex;
-      }
+    } else if (fieldType == DisplayType.DATE && value instanceof Datetime) {
+      value = ((Datetime) value).dateGmt();
     }
+    record.put(this.fieldToken, value);
   }
 
   private void dispatch(List<SObject> updatedRecords) {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -85,6 +85,7 @@
         "apex-rollup@1.3.8-0": "04t6g000008Si24AAC",
         "apex-rollup@1.3.9-0": "04t6g000008Si5XAAS",
         "apex-rollup@1.3.10-0": "04t6g000008SiG7AAK",
-        "apex-rollup@1.3.11-0": "04t6g000008SiHjAAK"
+        "apex-rollup@1.3.11-0": "04t6g000008SiHjAAK",
+        "apex-rollup@1.3.12-0": "04t6g000008SiKsAAK"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionNumber": "1.3.11.0",
+            "versionNumber": "1.3.12.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
* Fixing issue reported by Katherine West with splitting by concat delimiter on calc items for Flow
* Adding additional optimization for First/Last-based rollups
* Fixes #212 where non-integer types can lead to a BigDecimal exception on DML update if arithmetic derived from `Database.countQuery` is used