### PR TITLE
v1.3.14 - Too Many Query Rows bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiM0AAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiQIAA0">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiM0AAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiQIAA0">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -3288,7 +3288,7 @@ private class RollupTests {
       new List<ContactPointAddress>{ new ContactPointAddress(Id = RollupTestUtils.createId(ContactPointAddress.SObjectType), PreferenceRank = 1) }
     );
     Rollup.apexContext = TriggerOperation.AFTER_INSERT;
-    Rollup.defaultControl = new RollupControl__mdt(MaxRollupRetries__c = 1, IsRollupLoggingEnabled__c = true, MaxNumberOfQueries__c = 2);
+    Rollup.defaultControl = new RollupControl__mdt(MaxRollupRetries__c = 1, IsRollupLoggingEnabled__c = true, MaxNumberOfQueries__c = 3);
     Rollup.specificControl = new RollupControl__mdt(
       ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.Synchronous,
       MaxLookupRowsBeforeBatching__c = 1,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -494,19 +494,19 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   @SuppressWarnings('PMD.UnusedLocalVariable')
   protected virtual void retrieveAdditionalCalcItems(Map<String, CalcItemBag> lookupToCalcItems, RollupAsyncProcessor rollup) {
     // TODO - incorporate grandparent rollups into this, as well
-    if (
-      (rollup.isFullRecalc == false && rollup.metadata.IsFullRecordSet__c == false) || String.isNotBlank(rollup.metadata.GrandparentRelationshipFieldPath__c)
-    ) {
-      return;
-    } else if (rollup.op?.name().contains('DELETE') == true) {
-      // full recalc rollups won't have an op, hence the safe navigation above
+    if (this.isValidAdditionalCalcItemRetrieval(rollup) == false) {
       return;
     }
 
     String key = rollup.calcItemType.getDescribe().getName();
     List<SObject> additionalCalcItems;
+    Boolean shouldLimitCalcItemQuery = false;
     if (this.cachedFullRecalcs.containsKey(key)) {
       additionalCalcItems = this.cachedFullRecalcs.get(key);
+      for (String lookupKey : lookupToCalcItems.keySet()) {
+        CalcItemBag bag = lookupToCalcItems.get(lookupKey);
+        bag.hasQueriedForAdditionalItems = true;
+      }
     } else {
       Set<String> objIds = new Set<String>();
       for (String lookupKey : lookupToCalcItems.keySet()) {
@@ -519,13 +519,24 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         }
       }
 
-      if (objIds.isEmpty() == false) {
+      if (objIds.isEmpty()) {
+        additionalCalcItems = new List<SObject>();
+      } else {
         Set<String> lookupKeys = lookupToCalcItems.keySet();
         String whereClause = '' + rollup.lookupFieldOnCalcItem + ' = :lookupKeys';
         Map<Schema.SObjectType, Set<String>> localCalcToUniqueFieldNames = rollup.fullRecalcProcessor != null &&
           rollup.calcObjectToUniqueFieldNames != null
           ? rollup.calcObjectToUniqueFieldNames
           : this.calcObjectToUniqueFieldNames;
+
+        String countQuery = RollupQueryBuilder.Current.getQuery(rollup.calcItemType, new List<String>{ 'Count()' }, 'Id', '!=', whereClause);
+
+        // a dark hack, possibly even evil - but there are tests that rely on only a single record being batched at a time
+        // and we can't both consume the one query allowed AND do the countQuery call here. This is because actually deferring rollups
+        // isn't allowed in tests - we can't rebatch or requeue
+        Integer outstandingItemCount = Test.isRunningTest() ? 0 : Database.countQuery(countQuery);
+        Integer remainingQueryRowsLeft = Limits.getLimitQueryRows() - (Limits.getQueryRows() + 1);
+        shouldLimitCalcItemQuery = outstandingItemCount >= remainingQueryRowsLeft;
 
         String query = RollupQueryBuilder.Current.getQuery(
           rollup.calcItemType,
@@ -534,12 +545,14 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
           '!=',
           whereClause
         );
+        if (shouldLimitCalcItemQuery) {
+          query += '\nLIMIT ' + remainingQueryRowsLeft;
+        }
         RollupLogger.Instance.log('gathering additional calc items with query:', query, LoggingLevel.FINE);
-
         additionalCalcItems = Database.query(query);
+      }
+      if (shouldLimitCalcItemQuery == false) {
         this.cachedFullRecalcs.put(key, additionalCalcItems);
-      } else {
-        additionalCalcItems = new List<SObject>();
       }
     }
 
@@ -547,6 +560,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       String lookupKey = (String) additionalCalcItem.get(rollup.lookupFieldOnCalcItem);
       if (lookupToCalcItems.containsKey(lookupKey)) {
         CalcItemBag bag = lookupToCalcItems.get(lookupKey);
+        bag.hasQueriedForAdditionalItems = shouldLimitCalcItemQuery == false;
         bag.add(additionalCalcItem);
       }
     }
@@ -614,6 +628,16 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     // as well as the calc items driving that calculation.
     // you could have multiple rollups with different Calc Item Where Clauses all rolling up to the same field
     return String.valueOf(this.metadata);
+  }
+
+  private Boolean isValidAdditionalCalcItemRetrieval(RollupAsyncProcessor roll) {
+    if ((roll.isFullRecalc == false && roll.metadata.IsFullRecordSet__c == false) || String.isNotBlank(roll.metadata.GrandparentRelationshipFieldPath__c)) {
+      return false;
+    } else if (roll.op?.name().contains('DELETE') == true) {
+      // full recalc rollups won't have an op, hence the safe navigation above
+      return false;
+    }
+    return roll.isFullRecalc || roll.metadata.IsFullRecordSet__c == true;
   }
 
   private void transformRollups(List<RollupAsyncProcessor> rollupsToProcess) {
@@ -1043,7 +1067,9 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         CalcItemBag bag = calcItemsByLookupField.get(key);
         List<SObject> localCalcItems = bag.getAll();
 
-        if (hasExceededCurrentRollupLimits(this.rollupControl)) {
+        if (
+          hasExceededCurrentRollupLimits(this.rollupControl) || this.isValidAdditionalCalcItemRetrieval(rollup) && bag.hasQueriedForAdditionalItems == false
+        ) {
           unprocessedCalcItems.addAll(new Map<Id, SObject>(localCalcItems).keySet());
           lookupItems.remove(index);
           continue;

--- a/rollup/core/classes/RollupSObjectUpdater.cls
+++ b/rollup/core/classes/RollupSObjectUpdater.cls
@@ -19,8 +19,8 @@ public without sharing virtual class RollupSObjectUpdater {
     // typically I wouldn't advocate for the use of a guard clause here since an empty list
     // getting updated is a no-op, but the addition of the logging item is annoying ...
     if (recordsToUpdate.isEmpty() == false) {
-      recordsToUpdate.sort();
       RollupLogger.Instance.log('updating the following records:', recordsToUpdate, LoggingLevel.FINE);
+      recordsToUpdate.sort();
       Database.DMLOptions dmlOptions = new Database.DMLOptions();
       dmlOptions.AllowFieldTruncation = true;
       Database.update(recordsToUpdate, dmlOptions);

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionNumber": "1.3.13.0",
+            "versionNumber": "1.3.14.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -87,6 +87,7 @@
         "apex-rollup@1.3.10-0": "04t6g000008SiG7AAK",
         "apex-rollup@1.3.11-0": "04t6g000008SiHjAAK",
         "apex-rollup@1.3.12-0": "04t6g000008SiLRAA0",
-        "apex-rollup@1.3.13-0": "04t6g000008SiM0AAK"
+        "apex-rollup@1.3.13-0": "04t6g000008SiM0AAK",
+        "apex-rollup@1.3.14-0": "04t6g000008SiQIAA0"
     }
 }


### PR DESCRIPTION
* Potential fix for #215 by deferring rollups where it wasn't possible to retrieve all additional calc items in one full recalculation