### PR TITLE
V1.3.17 - Code Coverage Plugin & Test Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ PACKAGING_SFDX_URL.txt
 tests/apex
 **/main/default/
 coverage/
+plugins/ExtraCodeCoverage

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiSdAAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiTgAAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiSdAAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiTgAAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -911,7 +911,9 @@ You can use the included `Rollup Plugin Parameter` CMDT record `Logging Debug Le
 
 #### Other Rollup Plugins
 
-To perform additional post-processing on the newly updated parent records, a ["callback" plugin](plugins/RollupCallback) is also now available as a 2GP unmanaged package. For more information, check out [the Readme](plugins/RollupCallback), as there are a variety of options available when it comes to post-processing.
+ - To perform additional post-processing on the newly updated parent records, a ["callback" plugin](plugins/RollupCallback) is also now available as a 2GP unmanaged package. For more information, check out [the Readme](plugins/RollupCallback), as there are a variety of options available when it comes to post-processing.
+
+ - If you need to generate additional test code coverage for `apex-rollup` (which might be necessary in a highly declarative org), you can install the [Extra Code Coverage plugin](plugins/ExtraCodeCoverage), which automatically gets updated any time I make changes to tests here.
 
 ### Multi-Currency Orgs
 

--- a/extra-tests/classes/RollupDateLiteralTests.cls
+++ b/extra-tests/classes/RollupDateLiteralTests.cls
@@ -414,7 +414,8 @@ private class RollupDateLiteralTests {
     RollupDateLiteral nextNMonths = RollupDateLiteral.get('NEXT_N_MONTHS:2');
 
     System.assertEquals(true, nextNMonths.matches(nextNMonthsDate, '='), 'Date value should have matched: ' + nextNMonthsDate + ' | ' + nextNMonths);
-    System.assertEquals(true, nextNMonths.matches(nextNMonthsDate.addDays(30), '='), 'Date was within: ' + nextNMonths);
+    // take February into account
+    System.assertEquals(true, nextNMonths.matches(nextNMonthsDate.addDays(27), '='), 'Date was within: ' + nextNMonths + ' | ' + nextNMonthsDate);
     System.assertEquals(true, nextNMonths.matches(nextNMonthsDatetime, '='), 'Datetime value should have matched: ' + nextNMonthsDatetime);
 
     System.assertEquals(true, nextNMonths.matches(nextNMonthsDate, '>='));
@@ -818,7 +819,14 @@ private class RollupDateLiteralTests {
 
     System.assertEquals(true, lastFiscalNQuarter.matches(startDate, '='), startDate + ' | ' + lastFiscalNQuarter);
     System.assertEquals(true, lastFiscalNQuarter.matches(endDate, '='), endDate + ' | ' + lastFiscalNQuarter);
-    System.assertEquals(true, lastFiscalNQuarter.matches(lastNFiscalQuarterDate, '='), 'Date value should have matched: ' + lastNFiscalQuarterDate + ' | ' + lastFiscalNQuarter);
+    System.assertEquals(
+      true,
+      lastFiscalNQuarter.matches(lastNFiscalQuarterDate, '='),
+      'Date value should have matched: ' +
+      lastNFiscalQuarterDate +
+      ' | ' +
+      lastFiscalNQuarter
+    );
     System.assertEquals(true, lastFiscalNQuarter.matches(lastNFiscalQuarterDate.addDays(28), '='), 'Date was within: ' + lastFiscalNQuarter);
     System.assertEquals(true, lastFiscalNQuarter.matches(lastNFiscalQuarterDatetime, '='), 'Datetime value should have matched: ' + lastNFiscalQuarterDatetime);
 
@@ -859,13 +867,27 @@ private class RollupDateLiteralTests {
 
     System.assertEquals(true, nextNFiscalQuarter.matches(startDate, '='), startDate + ' | ' + nextNFiscalQuarter);
     System.assertEquals(true, nextNFiscalQuarter.matches(endDate, '='), endDate + ' | ' + nextNFiscalQuarter);
-    System.assertEquals(true, nextNFiscalQuarter.matches(nextNFiscalQuarterDate, '='), 'Date value should have matched: ' + nextNFiscalQuarterDate + ' | ' + nextNFiscalQuarter);
+    System.assertEquals(
+      true,
+      nextNFiscalQuarter.matches(nextNFiscalQuarterDate, '='),
+      'Date value should have matched: ' +
+      nextNFiscalQuarterDate +
+      ' | ' +
+      nextNFiscalQuarter
+    );
     System.assertEquals(true, nextNFiscalQuarter.matches(nextNFiscalQuarterDate.addDays(28), '='), 'Date was within: ' + nextNFiscalQuarter);
     System.assertEquals(true, nextNFiscalQuarter.matches(nextNFiscalQuarterDatetime, '='), 'Datetime value should have matched: ' + nextNFiscalQuarterDatetime);
 
     System.assertEquals(true, nextNFiscalQuarter.matches(nextNFiscalQuarterDate, '>='));
     System.assertEquals(true, nextNFiscalQuarter.matches(nextNFiscalQuarterDatetime, '>='));
-    System.assertEquals(true, nextNFiscalQuarter.matches(endDate.addDays(1), '>'), 'End date + 1: ' + endDate.addDays(1) + ' should exceed: ' + nextNFiscalQuarter);
+    System.assertEquals(
+      true,
+      nextNFiscalQuarter.matches(endDate.addDays(1), '>'),
+      'End date + 1: ' +
+      endDate.addDays(1) +
+      ' should exceed: ' +
+      nextNFiscalQuarter
+    );
     System.assertNotEquals(true, nextNFiscalQuarter.matches(System.now().addMonths(-1), '>'));
     System.assertNotEquals(true, nextNFiscalQuarter.matches(nextNFiscalQuarterDate, '>'));
 
@@ -886,8 +908,19 @@ private class RollupDateLiteralTests {
     Datetime startOfLastFiscalYearDatetime = Datetime.newInstanceGmt(startOfLastFiscalYearDate, Time.newInstance(0, 0, 0, 0));
     RollupDateLiteral lastFiscalYear = RollupDateLiteral.get('LAST_FISCAL_YEAR');
 
-    System.assertEquals(true, lastFiscalYear.matches(startOfLastFiscalYearDate, '='), 'Date value should have matched: ' + startOfLastFiscalYearDate + ' ' + lastFiscalYear);
-    System.assertEquals(true, lastFiscalYear.matches(startOfLastFiscalYearDatetime, '='), 'Datetime value should have matched: ' + startOfLastFiscalYearDatetime);
+    System.assertEquals(
+      true,
+      lastFiscalYear.matches(startOfLastFiscalYearDate, '='),
+      'Date value should have matched: ' +
+      startOfLastFiscalYearDate +
+      ' ' +
+      lastFiscalYear
+    );
+    System.assertEquals(
+      true,
+      lastFiscalYear.matches(startOfLastFiscalYearDatetime, '='),
+      'Datetime value should have matched: ' + startOfLastFiscalYearDatetime
+    );
     System.assertEquals(true, lastFiscalYear.matches(startOfLastFiscalYearDate.addMonths(6), '='), 'Date within bounds: ' + lastFiscalYear);
 
     System.assertEquals(true, lastFiscalYear.matches(startOfLastFiscalYearDate, '>='));
@@ -923,7 +956,6 @@ private class RollupDateLiteralTests {
     System.assertEquals(true, thisYear.matches(startOfThisYearDatetime, '<='));
     System.assertNotEquals(true, thisYear.matches(System.today().addYears(2), '<='));
   }
-
 
   @IsTest
   static void shouldWorkForNextFiscalYear() {

--- a/extra-tests/classes/RollupEvaluatorTests.cls
+++ b/extra-tests/classes/RollupEvaluatorTests.cls
@@ -510,7 +510,6 @@ private class RollupEvaluatorTests {
     Opportunity oppThree = new Opportunity(ForecastCategoryName = 'Best Case');
     Opportunity oppFour = new Opportunity(ForecastCategoryName = 'Commit');
     Opportunity oppFive = new Opportunity(Amount = 5, ForecastCategoryName = 'Closed');
-    Formula.recalculateFormulas(new List<Opportunity>{ oppOne, oppTwo, oppThree, oppFour, oppFive });
 
     String whereClause = 'ForecastCategoryName = \'Omitted\' OR ForecastCategoryName = \'Best Case\' OR ForecastCategoryName = \'Pipeline\' OR Amount = 5';
 
@@ -1034,10 +1033,6 @@ private class RollupEvaluatorTests {
     String whereClause = 'Account.AnnualRevenue = 5';
     RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, Account.SObjectType);
     System.assertEquals(true, eval.matches(new Account(AnnualRevenue = 5)));
-
-    whereClause = 'RollupParent__r.NumberField__c = 1';
-    eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, RollupParent__c.SObjectType);
-    System.assertEquals(true, eval.matches(new RollupParent__c(NumberField__c = 1)));
   }
 
   @IsTest

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -973,6 +973,28 @@ private class RollupIntegrationTests {
   }
 
   @IsTest
+  static void shouldEvaluateCorrectlyForCustomParentFields() {
+    String whereClause = 'RollupParent__r.NumberField__c = 1';
+    Rollup.Evaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, RollupParent__c.SObjectType);
+    System.assertEquals(true, eval.matches(new RollupParent__c(NumberField__c = 1)));
+  }
+
+  @IsTest
+  static void shouldFilterOnFormulaText() {
+    String whereClause = 'NameFormula__c = \'GermanyFormula\'';
+
+    RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, Account.SObjectType);
+
+    Account acc = new Account(Name = 'Germany');
+
+    System.assertNotEquals(true, eval.matches(acc));
+
+    Formula.recalculateFormulas(new List<Account>{ acc });
+
+    System.assertEquals(true, eval.matches(acc));
+  }
+
+  @IsTest
   static void shouldCorrectlyRollupFromTriggerOnMerge() {
     Account parent = [SELECT Id, Name FROM Account];
 

--- a/extra-tests/objects/Account/fields/NameFormula__c.field-meta.xml
+++ b/extra-tests/objects/Account/fields/NameFormula__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>NameFormula__c</fullName>
+    <description>Appends &apos;Formula&apos; to the Account Name</description>
+    <externalId>false</externalId>
+    <formula>Name + &quot;Formula&quot;</formula>
+    <inlineHelpText>Appends &apos;Formula&apos; to the Account Name</inlineHelpText>
+    <label>Name Formula</label>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/extra-tests/profiles/Admin.profile-meta.xml
+++ b/extra-tests/profiles/Admin.profile-meta.xml
@@ -87,6 +87,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Account.NameFormula__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Account.SumAmountRollupSummary__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,5 +1,21 @@
+const extraCodeCoveragePaths = [
+  'extra-tests/classes/RollupTestUtils.cls',
+  'extra-tests/classes/RollupTests.cls',
+  'extra-tests/classes/RollupEvaluatorTests.cls',
+  'extra-tests/classes/RollupRelationshipFieldFinderTests.cls',
+  'extra-tests/classes/RollupLoggerTests.cls',
+  'extra-tests/classes/RollupQueryBuilderTests.cls',
+  'extra-tests/classes/RollupRecursionItemTests.cls'
+];
+
 module.exports = {
   '**/lwc/*.js': filenames => `eslint ${filenames.join(' ')} --fix`,
-  '*.{cls,cmp,component,css,html,js,json,md,page,trigger,yaml,yml}': filenames => filenames.map(filename => `prettier --write '${filename}'`),
+  '*.{cls,cmp,component,css,html,js,json,md,page,trigger,yaml,yml}': filenames => {
+    const commands = filenames.map(filename => `prettier --write '${filename}'`);
+    if (filenames.filter(fileName => extraCodeCoveragePaths.includes(fileName)).length > 0) {
+      commands.push('npm run create:package:code-coverage')
+    }
+    return commands;
+  },
   '*.{cls,trigger}': () => 'npm run scan'
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "create:package:nebula:adapter": "sfdx force:package:version:create --package \"Apex Rollup - Nebula Logger\" -w 20 -x -c",
     "create:package:logger": "sfdx force:package:version:create --package \"Apex Rollup - Custom Logger\" -w 20 -x -c",
     "create:package:callback": "sfdx force:package:version:create --package \"Apex Rollup - Rollup Callback\" -w 20 -x -c",
+    "create:package:code-coverage": ". ./scripts/generateExtraCodeCoveragePlugin.ps1",
     "husky:pre-commit": "lint-staged",
     "lint:verify": "eslint **/lwc/**",
     "prepare": "husky install",

--- a/plugins/ExtraCodeCoverage/README.md
+++ b/plugins/ExtraCodeCoverage/README.md
@@ -1,0 +1,13 @@
+# Extra Code Coverage
+
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiTHAA0">
+  <img alt="Deploy to Salesforce"
+       src="../../media/deploy-package-to-prod.png">
+</a>
+
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiTHAA0">
+  <img alt="Deploy to Salesforce Sandbox"
+       src="../../media/deploy-package-to-sandbox.png">
+</a>
+
+This plugin includes a subset of test files from the [extra tests](../../extra-tests/classes/) directory; while I encourage users to write their own tests surrounding rollup behavior, I also recognize that won't always be possible. This plugin aims to bridge the possible gap in code coverage for the classes installed as part of the base package!

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -141,7 +141,7 @@ public without sharing abstract class RollupCalculator {
   public virtual void performRollup(List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
     // if we're already in a full recalc, we've got all the items we need already
     this.shouldTriggerFullRecalc = this.isFullRecalc == false;
-    Set<Id> exclusionIds = new Set<Id>();
+    List<Id> exclusionIds = new List<Id>();
     for (SObject calcItem : calcItems) {
       if (calcItem.Id != null) {
         exclusionIds.add(calcItem.Id);
@@ -168,7 +168,7 @@ public without sharing abstract class RollupCalculator {
         continue;
       } else if (this.isCDCUpdate) {
         // here we don't exclude items because the calc items have already been updated
-        this.returnVal = this.calculateNewAggregateValue(this.op, new Set<Id>(), calcItem.getSObjectType());
+        this.returnVal = this.calculateNewAggregateValue(this.op, new List<Id>(), calcItem.getSObjectType());
         // not just a break, a return. We don't want to pass go - we don't want to call "setReturnValue" below
         return;
       } else {
@@ -295,7 +295,7 @@ public without sharing abstract class RollupCalculator {
     return ((SObject) Type.forName(this.metadata.CalcItem__c).newInstance()).getSObjectType();
   }
 
-  protected virtual Object calculateNewAggregateValue(Rollup.Op op, Set<Id> objIds, SObjectType sObjectType) {
+  protected virtual Object calculateNewAggregateValue(Rollup.Op op, List<Object> objIds, SObjectType sObjectType) {
     String operationName = Rollup.getBaseOperationName(op.name());
     String alias = operationName.toLowerCase() + 'Field';
     List<SObject> aggregate = this.tryQuery(sObjectType, new Set<String>{ operationName + '(' + this.opFieldOnCalcItem + ')' + alias }, objIds);
@@ -310,7 +310,7 @@ public without sharing abstract class RollupCalculator {
     return RollupCurrencyInfo.getCalcItem(calcItem);
   }
 
-  protected Object performBaseCalculation(Rollup.Op op, Set<Id> objIds, SObjectType sObjectType) {
+  protected Object performBaseCalculation(Rollup.Op op, List<Object> objIds, SObjectType sObjectType) {
     this.returnVal = RollupFieldInitializer.Current.getDefaultValue(this.opFieldOnLookupObject);
 
     if (this.isRecursiveRecalc == false) {
@@ -343,7 +343,7 @@ public without sharing abstract class RollupCalculator {
     return this.returnVal;
   }
 
-  private List<SObject> tryQuery(SObjectType sObjectType, Set<String> queryFields, Set<Id> objIds) {
+  private List<SObject> tryQuery(SObjectType sObjectType, Set<String> queryFields, List<Object> objIds) {
     String query = RollupQueryBuilder.Current.getQuery(sObjectType, new List<String>(queryFields), 'Id', '!=', this.lookupKeyQuery);
     List<SObject> results;
     try {
@@ -399,7 +399,7 @@ public without sharing abstract class RollupCalculator {
         this.distinctValues.add(potentiallyNullValue);
       } else if (this.op == Rollup.Op.DELETE_COUNT_DISTINCT) {
         this.distinctValues.clear();
-        this.calculateNewAggregateValue(this.op, new Set<Id>{ calcItem.Id }, calcItem.getSObjectType());
+        this.calculateNewAggregateValue(this.op, new List<Id>{ calcItem.Id }, calcItem.getSObjectType());
       }
       this.shouldShortCircuit = true;
     }
@@ -410,7 +410,7 @@ public without sharing abstract class RollupCalculator {
     }
 
     @SuppressWarnings('PMD.ApexSOQLInjection')
-    protected override Object calculateNewAggregateValue(Rollup.Op op, Set<Id> objIds, SObjectType sObjectType) {
+    protected override Object calculateNewAggregateValue(Rollup.Op op, List<Object> objIds, SObjectType sObjectType) {
       if (this.shouldTriggerFullRecalc == true) {
         this.distinctValues.clear();
       }
@@ -425,12 +425,9 @@ public without sharing abstract class RollupCalculator {
       String query =
         RollupQueryBuilder.Current.getQuery(sObjectType, queryFields, 'Id', '!=', this.lookupKeyQuery + ('\nAND ' + this.opFieldOnCalcItem + '!= null')) +
         (isGroupable && this.isIdCount == false ? ('\nGROUP BY ' + this.opFieldOnCalcItem) : '');
-      if (this.isIdCount) {
-        query = query.replaceAll('(?<=(\\s|,))Id,', '');
-      }
 
       if (this.isIdCount) {
-        Integer result = Database.countQuery(query);
+        Integer result = Database.countQuery(query.replaceAll('(?<=(\\s|,))Id,', ''));
         for (Integer index = 0; index < result; index++) {
           this.distinctValues.add(index);
         }
@@ -558,7 +555,7 @@ public without sharing abstract class RollupCalculator {
         newVal >= thisPriorVal)
       ) {
         this.shouldShortCircuit = true;
-        Object potentialReturnValue = this.calculateNewAggregateValue(this.op, oldCalcItems.keySet(), calcItem.getSObjectType());
+        Object potentialReturnValue = this.calculateNewAggregateValue(this.op, oldCalcItems.values(), calcItem.getSObjectType());
         this.returnDecimal = this.getDecimalOrDefault(potentialReturnValue);
         if (this.returnDecimal == 0 && this.op.name().contains('DELETE') == false) {
           this.returnDecimal = newVal;
@@ -574,7 +571,7 @@ public without sharing abstract class RollupCalculator {
       this.returnVal = this.returnDecimal;
     }
 
-    protected virtual override Object calculateNewAggregateValue(Rollup.Op op, Set<Id> objIds, SObjectType sObjectType) {
+    protected virtual override Object calculateNewAggregateValue(Rollup.Op op, List<Object> objIds, SObjectType sObjectType) {
       Object aggregate;
       try {
         aggregate = super.calculateNewAggregateValue(op, objIds, sObjectType);
@@ -622,7 +619,7 @@ public without sharing abstract class RollupCalculator {
       return RollupFieldInitializer.Current.getApexCompliantDatetime(datetimeWithMs).getTime();
     }
 
-    protected override Object calculateNewAggregateValue(Rollup.Op op, Set<Id> excludedItems, SObjectType sObjectType) {
+    protected override Object calculateNewAggregateValue(Rollup.Op op, List<Object> excludedItems, SObjectType sObjectType) {
       Object aggregate = super.calculateNewAggregateValue(op, excludedItems, sObjectType);
       if (aggregate instanceof Datetime) {
         aggregate = ((Datetime) aggregate).getTime();
@@ -867,14 +864,14 @@ public without sharing abstract class RollupCalculator {
         newVal >= this.stringVal)
       ) {
         this.shouldShortCircuit = true;
-        Object potentialReturnValue = this.calculateNewAggregateValue(this.op, oldCalcItems.keySet(), calcItem.getSObjectType());
+        Object potentialReturnValue = this.calculateNewAggregateValue(this.op, oldCalcItems.values(), calcItem.getSObjectType());
         this.stringVal = potentialReturnValue == null ? '' : String.valueOf(potentialReturnValue);
       } else if (this.isTrueFor(newVal, this.stringVal)) {
         this.stringVal = newVal;
       }
     }
 
-    protected override Object calculateNewAggregateValue(Rollup.Op op, Set<Id> objIds, SObjectType sObjectType) {
+    protected override Object calculateNewAggregateValue(Rollup.Op op, List<Object> objIds, SObjectType sObjectType) {
       this.stringVal = (String) super.performBaseCalculation(op, objIds, sObjectType);
       return this.stringVal;
     }
@@ -1021,6 +1018,7 @@ public without sharing abstract class RollupCalculator {
     ) {
       super(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata.FullRecalculationDefaultNumberValue__c, metadata, lookupRecordKey, lookupKeyField);
     }
+    @SuppressWarnings('PMD.UnusedLocalVariable')
     public override void performRollup(List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
       List<SObject> applicableCalcItems = this.op == Rollup.Op.DELETE_AVERAGE ? new List<SObject>() : calcItems;
       applicableCalcItems = this.winnowItems(applicableCalcItems, oldCalcItems);
@@ -1028,10 +1026,10 @@ public without sharing abstract class RollupCalculator {
       Decimal denominator = Decimal.valueOf(applicableCalcItems.size());
       if (this.isFullRecalc == false) {
         SObjectType sObjectType = this.getCalcItemType();
-        Set<Id> objIds = new Map<Id, SObject>(calcItems).keySet();
+        List<SObject> objIds = calcItems;
         String query = RollupQueryBuilder.Current.getQuery(sObjectType, new List<String>{ 'Count()' }, 'Id', '!=', this.lookupKeyQuery);
         denominator += Database.countQuery(query);
-        oldSum = (Decimal) this.calculateNewAggregateValue(Rollup.Op.SUM, objIds, sObjectType);
+        oldSum = (Decimal) this.calculateNewAggregateValue(Rollup.Op.SUM, calcItems, sObjectType);
       }
 
       if (oldSum == null) {

--- a/rollup/core/classes/RollupQueryBuilder.cls
+++ b/rollup/core/classes/RollupQueryBuilder.cls
@@ -15,10 +15,7 @@ public without sharing class RollupQueryBuilder {
     String equality,
     String optionalWhereClause
   ) {
-    DescribeSObjectResult sObjectToken = sObjectType.getDescribe();
-    Map<String, SObjectField> baseFields = sObjectToken.fields.getMap();
     Set<String> lowerCaseFieldNames = new Set<String>();
-
     for (Integer index = uniqueQueryFieldNames.size() - 1; index >= 0; index--) {
       String uniqueFieldName = uniqueQueryFieldNames[index];
       if (String.isBlank(uniqueFieldName)) {
@@ -34,25 +31,9 @@ public without sharing class RollupQueryBuilder {
       } else {
         lowerCaseFieldNames.add(lowerCaseField);
       }
-      // ensure that the base relationship name field is transformed appropriately
-      if (baseFields.containsKey(uniqueFieldName + 'Id') || baseFields.containsKey(uniqueFieldName + '__c')) {
-        SObjectField baseField = baseFields.get(uniqueFieldName + 'Id') == null
-          ? baseFields.get(uniqueFieldName + '__c')
-          : baseFields.get(uniqueFieldName + 'Id');
-        DescribeFieldResult fieldToken = baseField.getDescribe();
-        if (fieldToken.getType() == DisplayType.REFERENCE && uniqueQueryFieldNames.contains(fieldToken.getName()) == false) {
-          uniqueQueryFieldNames[index] = fieldToken.getName();
-        }
-      } else if (
-        baseFields.containsKey(uniqueFieldName) &&
-        sObjectToken.getName() == uniqueFieldName.substringBefore('.') &&
-        uniqueQueryFieldNames.contains(uniqueFieldName) == false
-      ) {
-        uniqueQueryFieldNames[index] = uniqueFieldName;
-      }
     }
 
-    this.addCurrencyIsoCodeForMultiCurrencyOrgs(uniqueQueryFieldNames, sObjectToken);
+    this.addCurrencyIsoCodeForMultiCurrencyOrgs(uniqueQueryFieldNames, sObjectType.getDescribe());
 
     optionalWhereClause = this.adjustWhereClauseForPolymorphicFields(sObjectType, uniqueQueryFieldNames, optionalWhereClause);
 
@@ -134,7 +115,7 @@ public without sharing class RollupQueryBuilder {
     return optionalWhereClause;
   }
 
-  private Boolean hasPolymorphicOwnerClause(String whereClause, Map<String, SObjectField> fieldNameToField ) {
+  private Boolean hasPolymorphicOwnerClause(String whereClause, Map<String, SObjectField> fieldNameToField) {
     Boolean hasPolymorphicField = false;
     if (whereClause?.contains('.Owner') == true) {
       List<String> fields = whereClause.split('\\.');

--- a/scripts/build-and-promote-package.ps1
+++ b/scripts/build-and-promote-package.ps1
@@ -4,6 +4,7 @@
 # this script generates a new package version Id per unique Action run, and promotes that package on merges to main
 # it also updates the Ids referenced in the README, and bumps the package version number in the package.json file
 $ErrorActionPreference = 'Stop'
+. .\scripts\helper-functions.ps1
 
 function Get-Current-Git-Branch() {
   Invoke-Expression 'git rev-parse --abbrev-ref HEAD'
@@ -18,10 +19,6 @@ function Get-Apex-Rollup-Package-Alias {
     $packageVersion = $packageVersion.Substring(0, $packageVersion.Length - $matchString.Length);
   }
   return "apex-rollup@$packageVersion-0"
-}
-
-function Get-SFDX-Project-JSON {
-  Get-Content -Path ./sfdx-project.json | ConvertFrom-Json
 }
 
 function Get-Package-JSON {
@@ -115,13 +112,7 @@ if($currentBranch -eq "main") {
   Write-Output "New package version: $currentPackageVersionId"
 
   if($currentPackageVersionId -ne $priorPackageVersionId) {
-    $readmePath = "./README.md"
-    $loginReplacement = "https://login.salesforce.com/packaging/installPackage.apexp?p0=" + $currentPackageVersionId
-    $testReplacement = "https://test.salesforce.com/packaging/installPackage.apexp?p0=" + $currentPackageVersionId
-    ((Get-Content -path $readmePath -Raw) -replace "https:\/\/login.salesforce.com\/packaging\/installPackage.apexp\?p0=.{0,18}", $loginReplacement) | Set-Content -Path $readmePath -NoNewline
-    ((Get-Content -path $readmePath -Raw) -replace "https:\/\/test.salesforce.com\/packaging\/installPackage.apexp\?p0=.{0,18}", $testReplacement) | Set-Content -Path $readmePath -NoNewline
-
-    git add $readmePath
+    Update-Package-Install-Links "./README.md" $currentPackageVersionId
   }
 
   $packageJson = Get-Package-JSON

--- a/scripts/generateExtraCodeCoveragePlugin.ps1
+++ b/scripts/generateExtraCodeCoveragePlugin.ps1
@@ -1,0 +1,56 @@
+$ErrorActionPreference = 'Stop'
+
+$packageJsonPath = "./sfdx-project.json"
+function Get-SFDX-Project-JSON {
+  Get-Content -Path $packageJsonPath | ConvertFrom-Json
+}
+
+if (Test-Path "./plugins/ExtraCodeCoverage" ) {
+  Write-Output "Dir exists"
+} else {
+  Write-Output "Making ExtraCodeCoverage dir"
+  mkdir ./plugins/ExtraCodeCoverage
+}
+
+Write-Output "Copying rollup tests to gitignored plugins/ExtraCodeCoverage directory"
+
+$fileNames = "RollupTestUtils","RollupTests","RollupEvaluatorTests","RollupRelationshipFieldFinderTests","RollupLoggerTests","RollupQueryBuilderTests","RollupRecursionItemTests"
+foreach ($fileName in $fileNames) {
+  Copy-Item "extra-tests/classes/$fileName.cls" "plugins/ExtraCodeCoverage"
+  Copy-Item "extra-tests/classes/$fileName.cls-meta.xml" "plugins/ExtraCodeCoverage"
+}
+
+$packageJson = Get-SFDX-Project-JSON
+$currentCodeCoveragePlugin = ($packageJson.packageDirectories | Select-Object | ?{ $_.package -eq "Apex Rollup - Extra Code Coverage" })
+$currentPluginVersion = $currentCodeCoveragePlugin.versionNumber
+$currentPluginVersion = $currentPluginVersion.Remove($currentPluginVersion.LastIndexOf(".0"))
+# increment package version prior to calling SFDX
+$currentVersionNumber = ([int]$currentPluginVersion.Substring(4)) + 1
+$currentPluginVersion = "0.0." + $currentVersionNumber.ToString() + ".0"
+$currentCodeCoveragePlugin.versionNumber = $currentPluginVersion
+
+Write-Output "Re-incrementing sfdx-project.json ExtraCodeCoverage version number ..."
+
+ConvertTo-Json -InputObject $packageJson -Depth 4 | Set-Content -Path $packageJsonPath -NoNewline
+yarn prettier --write $packageJsonPath --tab-width 4 --ignore-path .forceignore
+
+Write-Output "Creating package version: $currentPluginVersion"
+
+$createPackageResult = sfdx force:package:version:create -p "Apex Rollup - Extra Code Coverage" -w 30 -c -x -n $currentPluginVersion --json | ConvertFrom-Json
+Write-Output $createPackageResult
+$currentPackageVersionId = $createPackageResult.result.SubscriberPackageVersionId
+
+Write-Output "Successfully created package Id: $currentPackageVersionId, promoting ..."
+sdfx force:package:version:promote -p $currentPackageVersionId -n
+
+$readmePath = "./plugins/ExtraCodeCoverage/README.md"
+$loginReplacement = "https://login.salesforce.com/packaging/installPackage.apexp?p0=" + $currentPackageVersionId
+$testReplacement = "https://test.salesforce.com/packaging/installPackage.apexp?p0=" + $currentPackageVersionId
+((Get-Content -path $readmePath -Raw) -replace "https:\/\/login.salesforce.com\/packaging\/installPackage.apexp\?p0=.{0,18}", $loginReplacement) | Set-Content -Path $readmePath -NoNewline
+((Get-Content -path $readmePath -Raw) -replace "https:\/\/test.salesforce.com\/packaging\/installPackage.apexp\?p0=.{0,18}", $testReplacement) | Set-Content -Path $readmePath -NoNewline
+
+# have to force add, as the rest of the dir is gitignored
+git add $readmePath -f
+git add $packageJsonPath
+
+Write-Output "Done"

--- a/scripts/helper-functions.ps1
+++ b/scripts/helper-functions.ps1
@@ -1,0 +1,16 @@
+function Get-SFDX-Project-JSON {
+  Get-Content -Path ./sfdx-project.json | ConvertFrom-Json
+}
+
+function Update-Package-Install-Links {
+  param (
+    $filePath,
+    $newPackageVersionId
+  )
+
+  $loginReplacement = "https://login.salesforce.com/packaging/installPackage.apexp?p0=" + $newPackageVersionId
+  $testReplacement = "https://test.salesforce.com/packaging/installPackage.apexp?p0=" + $newPackageVersionId
+  ((Get-Content -path $filePath -Raw) -replace "https:\/\/login.salesforce.com\/packaging\/installPackage.apexp\?p0=.{0,18}", $loginReplacement) | Set-Content -Path $filePath -NoNewline
+  ((Get-Content -path $filePath -Raw) -replace "https:\/\/test.salesforce.com\/packaging\/installPackage.apexp\?p0=.{0,18}", $testReplacement) | Set-Content -Path $filePath -NoNewline
+  git add $filePath -f
+}

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -105,6 +105,7 @@
         "apex-rollup@1.3.14-0": "04t6g000008SiQIAA0",
         "apex-rollup@1.3.15-0": "04t6g000008SiRGAA0",
         "apex-rollup@1.3.16-0": "04t6g000008SiSdAAK",
-        "Apex Rollup - Extra Code Coverage@0.0.1-0": "04t6g000008SiTHAA0"
+        "Apex Rollup - Extra Code Coverage@0.0.1-0": "04t6g000008SiTHAA0",
+        "apex-rollup@1.3.17-0": "04t6g000008SiTgAAK"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Fixing CONCAT_DISTINCT + SplitConcatDelimiter__c bug",
-            "versionNumber": "1.3.16.0",
+            "versionName": "Adding more formula tests, created Code Coverage plugin",
+            "versionNumber": "1.3.17.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -14,7 +14,7 @@
         },
         {
             "package": "Apex Rollup - Custom Logger",
-            "path": "plugins/CustomObjectRollupLogger",
+            "path": "plugins\\CustomObjectRollupLogger",
             "dependencies": [
                 {
                     "package": "apex-rollup@1.3.8-0"
@@ -29,7 +29,7 @@
         },
         {
             "package": "Apex Rollup - Nebula Logger",
-            "path": "plugins/NebulaLogger",
+            "path": "plugins\\NebulaLogger",
             "dependencies": [
                 {
                     "package": "apex-rollup@1.3.8-0"
@@ -47,7 +47,7 @@
         },
         {
             "package": "Apex Rollup - Rollup Callback",
-            "path": "plugins/RollupCallback",
+            "path": "plugins\\RollupCallback",
             "dependencies": [
                 {
                     "package": "apex-rollup@1.3.0-0"
@@ -63,6 +63,18 @@
         {
             "path": "extra-tests",
             "default": false
+        },
+        {
+            "path": "plugins\\ExtraCodeCoverage",
+            "package": "Apex Rollup - Extra Code Coverage",
+            "versionName": "Updating code coverage",
+            "versionNumber": "0.0.1.0",
+            "default": false,
+            "dependencies": [
+                {
+                    "package": "apex-rollup@1.3.15-0"
+                }
+            ]
         }
     ],
     "namespace": "",
@@ -80,6 +92,7 @@
         "Apex Rollup - Rollup Callback": "0Ho6g000000GnA1CAK",
         "Apex Rollup - Rollup Callback@0.0.1-0": "04t6g000008ShTJAA0",
         "Apex Rollup - Rollup Callback@0.0.2-0": "04t6g000008ShztAAC",
+        "Apex Rollup - Extra Code Coverage": "0Ho6g000000GnCWCA0",
         "apex-rollup@1.3.5-0": "04t6g000008ShhXAAS",
         "apex-rollup@1.3.6-0": "04t6g000008Shn7AAC",
         "apex-rollup@1.3.7-0": "04t6g000008Si03AAC",
@@ -91,6 +104,7 @@
         "apex-rollup@1.3.13-0": "04t6g000008SiM0AAK",
         "apex-rollup@1.3.14-0": "04t6g000008SiQIAA0",
         "apex-rollup@1.3.15-0": "04t6g000008SiRGAA0",
-        "apex-rollup@1.3.16-0": "04t6g000008SiSdAAK"
+        "apex-rollup@1.3.16-0": "04t6g000008SiSdAAK",
+        "Apex Rollup - Extra Code Coverage@0.0.1-0": "04t6g000008SiTHAA0"
     }
 }


### PR DESCRIPTION
* Added [Code Coverage Plugin](https://github.com/jamessimone/apex-rollup/tree/v1.3.17/plugins/ExtraCodeCoverage) for orgs that need additional code coverage for rollup. This plugin is auto-updated whenever changes are made to qualifying tests found in the `extra-tests` directory (where "qualifying" means: "no reliance on custom fields, CMDT, flows, triggers, etc ...) - thanks to Karl Berlin for pointing out the need for this one 🚀
* Efficiency improvements within `RollupCalculator` by getting rid of intermediate lists/sets when possible prior to querying 🧮
* Fixed a broken test in `RollupDateLiteralTests` (didn't work for `NEXT_N_MONTHS` literal when the month in question was February and the test was always adding 30 days 🤦‍♂️)
