### PR TITLE
v1.3.19 - Combating Record Lock Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiUyAAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiVIAA0">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiUyAAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiVIAA0">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -411,6 +411,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       return System.enqueueJob(this);
     }
 
+    @SuppressWarnings('PMD.ApexSOQLInjection')
     protected override List<SObject> getExistingLookupItems(Set<String> objIds, RollupAsyncProcessor rollup, Set<String> uniqueQueryFieldNames) {
       if (objIds.isEmpty()) {
         return new List<SObject>();

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -433,7 +433,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
               new List<String>(uniqueQueryFieldNames),
               String.valueOf(rollup.lookupFieldOnLookupObject),
               '='
-            ) + '\nFOR UPDATE';
+            ) + (this.isSingleRecordSyncUpdate(rollup) ? '\nFOR UPDATE' : '');
           // non-obvious coupling between "objIds" and the computed "queryString", which uses dynamic variable binding
           localLookupItems = Database.query(queryString);
         }
@@ -925,8 +925,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         rollup.rollupControl.ShouldRunAs__c == RollupMetaPicklists.ShouldRunAs.Synchronous ||
         ((hasExceededCurrentRollupLimits(rollup.rollupControl) == false) && isRunningAsync) ||
         System.isBatch() && Limits.getQueueableJobs() >= Limits.getLimitQueueableJobs() ||
-        this.calcItems?.size() == 1 &&
-        (this.rollupControl.ShouldRunSingleRecordsSynchronously__c || rollup.rollupControl.ShouldRunSingleRecordsSynchronously__c);
+        this.isSingleRecordSyncUpdate(rollup);
 
       if (rollup.rollupControl.ShouldAbortRun__c || this.rollupControl.ShouldAbortRun__c) {
         this.rollups.remove(index);
@@ -941,6 +940,11 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
       this.overrideParentRollupControlValues(rollup.rollupControl);
     }
+  }
+
+  private Boolean isSingleRecordSyncUpdate(RollupAsyncProcessor roll) {
+    return this.calcItems?.size() == 1 &&
+      (this.rollupControl.ShouldRunSingleRecordsSynchronously__c || roll.rollupControl.ShouldRunSingleRecordsSynchronously__c);
   }
 
   private void overrideParentRollupControlValues(RollupControl__mdt specificControl) {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Adding more formula tests, created Code Coverage plugin",
-            "versionNumber": "1.3.18.0",
+            "versionName": "Removing record locking from all but single record sync updates to combat issues from 1.3.18",
+            "versionNumber": "1.3.19.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -107,6 +107,7 @@
         "apex-rollup@1.3.16-0": "04t6g000008SiSdAAK",
         "Apex Rollup - Extra Code Coverage@0.0.1-0": "04t6g000008SiTHAA0",
         "apex-rollup@1.3.17-0": "04t6g000008SiTgAAK",
-        "apex-rollup@1.3.18-0": "04t6g000008SiUyAAK"
+        "apex-rollup@1.3.18-0": "04t6g000008SiUyAAK",
+        "apex-rollup@1.3.19-0": "04t6g000008SiVIAA0"
     }
 }


### PR DESCRIPTION
* Combating record lock issues generated by overnight scheduled rollup runs - `FOR UPDATE` was too aggressively locking the parent records in these cases