### PR TITLE
V1.3.20 - Date Literal Function Support and RollupParentResetProcessor bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiVIAA0">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiaJAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiVIAA0">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiaJAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupDateLiteralTests.cls
+++ b/extra-tests/classes/RollupDateLiteralTests.cls
@@ -49,6 +49,29 @@ private class RollupDateLiteralTests {
     }
   }
 
+  @IsTest
+  static void shouldProperlyDetectDateFunctionStrings() {
+    List<String> dateFunctions = new List<String>{
+      'CALENDAR_MONTH(CreatedDate)',
+      'CALENDAR_QUARTER(CreatedDate)',
+      'CALENDAR_YEAR(CreatedDate)',
+      'CALENDAR_YEAR(CreatedDate)',
+      'DAY_IN_MONTH(CreatedDate)',
+      'DAY_IN_WEEK(CreatedDate)',
+      'DAY_IN_YEAR(CreatedDate)',
+      'DAY_ONLY(CreatedDate)',
+      'FISCAL_MONTH(CreatedDate)',
+      'FISCAL_QUARTER(CreatedDate)',
+      'FISCAL_YEAR(CreatedDate)',
+      'HOUR_IN_DAY(CreatedDate)',
+      'WEEK_IN_MONTH(CreatedDate)',
+      'WEEK_IN_YEAR(CreatedDate)'
+    };
+    for (String dateFunction : dateFunctions) {
+      System.assertEquals(true, RollupDateLiteral.isSoqlDateFunction(dateFunction), 'Date function not detected properly: ' + dateFunction);
+    }
+  }
+
   // these tests are more or less in the order that the SOQL date literals appear within the corresponding Salesforce Developer doc page for them
   // though I have standardized last/current/next ordering since ... that just makes sense
 
@@ -458,11 +481,11 @@ private class RollupDateLiteralTests {
   @IsTest
   static void shouldWorkForThisQuarter() {
     Period thisQuarterPeriod = [SELECT StartDate, EndDate FROM Period WHERE Type = 'Quarter' AND StartDate = THIS_QUARTER];
-    Date thisQuarterDate = thisQuarterPeriod.StartDate.addMonths(1);
+    Date thisQuarterDate = thisQuarterPeriod.StartDate;
     Datetime thisQuarterDatetime = Datetime.newInstanceGmt(thisQuarterDate, Time.newInstance(0, 0, 0, 0));
     RollupDateLiteral thisQuarter = RollupDateLiteral.get('THIS_QUARTER');
 
-    System.assertEquals(true, thisQuarter.matches(thisQuarterPeriod.StartDate, '='));
+    System.assertEquals(true, thisQuarter.matches(thisQuarterPeriod.StartDate, '='), thisQuarterPeriod.StartDate + ' | ' + thisQuarter);
     System.assertEquals(true, thisQuarter.matches(thisQuarterPeriod.EndDate, '='), thisQuarterPeriod.EndDate + ' | ' + thisQuarter);
     System.assertEquals(true, thisQuarter.matches(thisQuarterDate, '='), 'Date value should have matched: ' + thisQuarterDate + ' | ' + thisQuarter);
     System.assertEquals(true, thisQuarter.matches(thisQuarterDate.addDays(28), '='), 'Date was within: ' + thisQuarter);
@@ -1034,5 +1057,306 @@ private class RollupDateLiteralTests {
     System.assertEquals(true, nextNYears.matches(nextNYearsDatetime, '<='));
     System.assertNotEquals(true, nextNYears.matches(System.now().addYears(2), '<'));
     System.assertNotEquals(null, nextNYears.toString());
+  }
+
+  @IsTest
+  static void shouldWorkForCalendarMonth() {
+    Integer november = 11;
+    RollupDateLiteral calendarMonth = RollupDateLiteral.getFunction('CALENDAR_MONTH(CloseDate)', String.valueOf(november));
+    Date monthDate = Date.newInstance(2021, november, 1);
+    Date oneMonthAhead = monthDate.addMonths(1);
+    Date oneMonthBehind = monthDate.addMonths(-1);
+
+    System.assertEquals(true, calendarMonth.matches(monthDate, '='));
+    System.assertEquals(false, calendarMonth.matches(oneMonthAhead, '='));
+    System.assertEquals(false, calendarMonth.matches(oneMonthBehind, '='));
+    System.assertEquals(false, calendarMonth.matches(monthDate, '!='));
+
+    System.assertEquals(true, calendarMonth.matches(oneMonthAhead, '>'));
+    System.assertEquals(true, calendarMonth.matches(oneMonthBehind, '<'));
+  }
+
+  @IsTest
+  static void shouldWorkForCalendarYearFunction() {
+    Integer year = 2021;
+    RollupDateLiteral calendarYear = RollupDateLiteral.getFunction('CALENDAR_YEAR(CloseDate)', String.valueOf(year));
+    Date twentyTwentyOne = Date.newInstance(year, 12, 1);
+    Date oneYearAhead = twentyTwentyOne.addYears(1);
+    Date oneYearBehind = twentyTwentyOne.addYears(-1);
+
+    System.assertEquals(true, calendarYear.matches(twentyTwentyOne, '='));
+    System.assertEquals(false, calendarYear.matches(oneYearAhead, '='));
+    System.assertEquals(false, calendarYear.matches(oneYearBehind, '='));
+    System.assertEquals(false, calendarYear.matches(twentyTwentyOne, '!='));
+
+    System.assertEquals(true, calendarYear.matches(oneYearAhead, '>'));
+    System.assertEquals(true, calendarYear.matches(oneYearBehind, '<'));
+  }
+
+  @IsTest
+  static void shouldWorkForCalendarQuarterFunction() {
+    Integer secondQuarterMonth = 4;
+    RollupDateLiteral quarter = RollupDateLiteral.getFunction('CALENDAR_QUARTER(CloseDate)', '2');
+    Date secondQuarterDate = Date.newInstance(2021, secondQuarterMonth, 1);
+    Date oneQuarterAhead = secondQuarterDate.addMonths(3);
+    Date oneQuarterBehind = secondQuarterDate.addMonths(-1);
+
+    System.assertEquals(true, quarter.matches(secondQuarterDate, '='));
+    System.assertEquals(false, quarter.matches(oneQuarterAhead, '='));
+    System.assertEquals(false, quarter.matches(oneQuarterBehind, '='));
+    System.assertEquals(false, quarter.matches(secondQuarterDate, '!='));
+
+    System.assertEquals(true, quarter.matches(oneQuarterAhead, '>'));
+    System.assertEquals(true, quarter.matches(oneQuarterBehind, '<'));
+  }
+
+  @IsTest
+  static void shouldWorkForDayInWeekFunction() {
+    Date startOfWeek = System.today().toStartOfWeek();
+    Date secondDayInWeek = startOfWeek.addDays(1);
+    Date thirdDayInWeek = startOfWeek.addDays(2);
+    RollupDateLiteral dayInWeek = RollupDateLiteral.getFunction('DAY_IN_WEEK(CloseDate)', '2');
+
+    System.assertEquals(true, dayInWeek.matches(secondDayInWeek, '='));
+    System.assertEquals(false, dayInWeek.matches(startOfWeek, '='));
+    System.assertEquals(false, dayInWeek.matches(thirdDayInWeek, '='));
+    System.assertEquals(false, dayInWeek.matches(secondDayInWeek, '!='));
+
+    System.assertEquals(true, dayInWeek.matches(thirdDayInWeek, '>'));
+    System.assertEquals(true, dayInWeek.matches(startOfWeek, '<'));
+  }
+
+  @IsTest
+  static void shouldWorkForDayInYearFunction() {
+    Datetime startOfYear = Datetime.newInstanceGmt(System.today().year(), 1, 1);
+    Datetime secondDayInYear = startOfYear.addDays(1);
+    Datetime thirdDayInYear = startOfYear.addDays(2);
+    RollupDateLiteral dayInYear = RollupDateLiteral.getFunction('DAY_IN_YEAR(CloseDate)', '2');
+
+    System.assertEquals(true, dayInYear.matches(secondDayInYear, '='));
+    System.assertEquals(false, dayInYear.matches(startOfYear, '='));
+    System.assertEquals(false, dayInYear.matches(thirdDayInYear, '='));
+    System.assertEquals(false, dayInYear.matches(secondDayInYear, '!='));
+
+    System.assertEquals(true, dayInYear.matches(thirdDayInYear, '>'));
+    System.assertEquals(true, dayInYear.matches(startOfYear, '<'));
+  }
+
+  @IsTest
+  static void shouldWorkForDayOnlyFunction() {
+    Datetime comparisonDate = Datetime.newInstanceGmt(2020, 3, 7);
+    Datetime oneDayBefore = comparisonDate.addDays(-1);
+    Datetime oneDayAfter = comparisonDate.addDays(1);
+    RollupDateLiteral dayOnly = RollupDateLiteral.getFunction('DAY_ONLY(CreatedDate)', '2020-03-07');
+
+    System.assertEquals(true, dayOnly.matches(comparisonDate, '='), dayOnly);
+    System.assertEquals(false, dayOnly.matches(oneDayBefore, '='));
+    System.assertEquals(false, dayOnly.matches(oneDayAfter, '='));
+    System.assertEquals(false, dayOnly.matches(comparisonDate, '!='));
+
+    System.assertEquals(true, dayOnly.matches(oneDayAfter, '>'));
+    System.assertEquals(true, dayOnly.matches(oneDayBefore, '<'));
+  }
+
+  @IsTest
+  static void shouldWorkForFiscalMonthFunction() {
+    Datetime comparisonDate = Datetime.newInstanceGmt(2020, 4, 1);
+    Datetime oneQuarterBefore = comparisonDate.addMonths(-1);
+    Datetime oneQuarterAfter = comparisonDate.addMonths(4);
+    RollupDateLiteral fiscalMonth = RollupDateLiteral.getFunction('FISCAL_MONTH(CreatedDate)', '4');
+
+    System.assertEquals(true, fiscalMonth.matches(comparisonDate, '='), fiscalMonth);
+    System.assertEquals(false, fiscalMonth.matches(oneQuarterBefore, '='));
+    System.assertEquals(false, fiscalMonth.matches(oneQuarterAfter, '='));
+    System.assertEquals(false, fiscalMonth.matches(comparisonDate, '!='));
+
+    System.assertEquals(true, fiscalMonth.matches(oneQuarterAfter, '>'));
+    System.assertEquals(true, fiscalMonth.matches(oneQuarterBefore, '<'));
+  }
+
+  @IsTest
+  static void shouldWorkForFiscalQuarterFunction() {
+    // sort of a nightmare test - I apologize in advance
+    RollupDateLiteral quarter = RollupDateLiteral.getFunction('FISCAL_QUARTER(CloseDate)', '2');
+    Date quarterDate = Date.newInstance(2021, 4, 1);
+    Date oneQuarterAhead = quarterDate.addMonths(3);
+    Date oneQuarterBehind = quarterDate.addMonths(-1);
+
+    System.assertEquals(true, quarter.matches(quarterDate, '='));
+    System.assertEquals(false, quarter.matches(oneQuarterAhead, '='));
+    System.assertEquals(false, quarter.matches(oneQuarterBehind, '='));
+    System.assertEquals(false, quarter.matches(quarterDate, '!='));
+
+    System.assertEquals(true, quarter.matches(oneQuarterAhead, '>'));
+    System.assertEquals(true, quarter.matches(oneQuarterBehind, '<'));
+
+    quarter = RollupDateLiteral.getFunction('FISCAL_QUARTER(CloseDate)', '1');
+    quarterDate = Date.newInstance(2021, 1, 1);
+    oneQuarterAhead = quarterDate.addMonths(3);
+    oneQuarterBehind = quarterDate.addMonths(-1);
+
+    System.assertEquals(true, quarter.matches(quarterDate, '='));
+    System.assertEquals(false, quarter.matches(oneQuarterAhead, '='));
+    System.assertEquals(false, quarter.matches(oneQuarterBehind, '='));
+    System.assertEquals(false, quarter.matches(quarterDate, '!='));
+
+    System.assertEquals(true, quarter.matches(oneQuarterAhead, '>'));
+    // deviation - last quarter is 4
+    System.assertEquals(true, quarter.matches(oneQuarterBehind, '>'), quarter);
+    System.assertEquals(true, quarter.matches(oneQuarterBehind.addYears(-2), '>'), quarter);
+
+    quarter = RollupDateLiteral.getFunction('FISCAL_QUARTER(CloseDate)', '3');
+    quarterDate = Date.newInstance(2021, 7, 1);
+    oneQuarterAhead = quarterDate.addMonths(3);
+    oneQuarterBehind = quarterDate.addMonths(-1);
+
+    System.assertEquals(true, quarter.matches(quarterDate, '='));
+    System.assertEquals(false, quarter.matches(oneQuarterAhead, '='));
+    System.assertEquals(false, quarter.matches(oneQuarterBehind, '='));
+    System.assertEquals(false, quarter.matches(quarterDate, '!='));
+
+    System.assertEquals(true, quarter.matches(oneQuarterAhead, '>'));
+    System.assertEquals(true, quarter.matches(oneQuarterBehind, '<'));
+
+    quarter = RollupDateLiteral.getFunction('FISCAL_QUARTER(CloseDate)', '4');
+    quarterDate = Date.newInstance(2021, 10, 1);
+    oneQuarterAhead = quarterDate.addMonths(3);
+    oneQuarterBehind = quarterDate.addMonths(-1);
+
+    System.assertEquals(true, quarter.matches(quarterDate, '='));
+    System.assertEquals(false, quarter.matches(oneQuarterAhead, '='));
+    System.assertEquals(false, quarter.matches(oneQuarterBehind, '='));
+    System.assertEquals(false, quarter.matches(quarterDate, '!='));
+
+    // deviation - next quarter is 1 again
+    System.assertEquals(true, quarter.matches(oneQuarterAhead, '<'));
+    System.assertEquals(true, quarter.matches(oneQuarterBehind, '<'));
+  }
+
+  @IsTest
+  static void shouldWorkForFiscalYearFunction() {
+    RollupDateLiteral fiscalYear = RollupDateLiteral.getFunction('FISCAL_YEAR(CloseDate)', '2021');
+    Date twentyTwentyOne = Date.newInstance(2021, 12, 1);
+    Date oneYearAhead = twentyTwentyOne.addYears(1);
+    Date oneYearBehind = twentyTwentyOne.addYears(-1);
+
+    System.assertEquals(true, fiscalYear.matches(twentyTwentyOne, '='));
+    System.assertEquals(false, fiscalYear.matches(oneYearAhead, '='));
+    System.assertEquals(false, fiscalYear.matches(oneYearBehind, '='));
+    System.assertEquals(false, fiscalYear.matches(twentyTwentyOne, '!='));
+
+    System.assertEquals(true, fiscalYear.matches(oneYearAhead, '>'));
+    System.assertEquals(true, fiscalYear.matches(oneYearBehind, '<'));
+  }
+
+  @IsTest
+  static void shouldWorkForHourInDayFunction() {
+    Datetime comparisonDate = Datetime.newInstanceGmt(2020, 1, 1, 4, 0, 0);
+    Datetime oneHourBefore = comparisonDate.addHours(-1);
+    Datetime oneHourAfter = comparisonDate.addHours(1);
+    RollupDateLiteral hourInDay = RollupDateLiteral.getFunction('HOUR_IN_DAY(CreatedDate)', '4');
+
+    System.assertEquals(true, hourInDay.matches(comparisonDate, '='), hourInDay);
+    System.assertEquals(false, hourInDay.matches(oneHourBefore, '='));
+    System.assertEquals(false, hourInDay.matches(oneHourAfter, '='));
+    System.assertEquals(false, hourInDay.matches(comparisonDate, '!='));
+
+    System.assertEquals(true, hourInDay.matches(oneHourAfter, '>'));
+    System.assertEquals(true, hourInDay.matches(oneHourBefore, '<'));
+  }
+
+  @IsTest
+  static void shouldWorkForWeekInMonthFunction() {
+    Datetime comparisonDate = Datetime.newInstanceGmt(2020, 1, 1);
+    Datetime oneWeekBefore = comparisonDate.addDays(-7);
+    Datetime oneWeekAfter = comparisonDate.addDays(7);
+    RollupDateLiteral weekInMonth = RollupDateLiteral.getFunction('WEEK_IN_MONTH(CreatedDate)', '1');
+
+    System.assertEquals(true, weekInMonth.matches(comparisonDate, '='), weekInMonth);
+    System.assertEquals(false, weekInMonth.matches(oneWeekBefore, '='));
+    System.assertEquals(false, weekInMonth.matches(oneWeekAfter, '='));
+    System.assertEquals(false, weekInMonth.matches(comparisonDate, '!='));
+
+    System.assertEquals(true, weekInMonth.matches(oneWeekAfter, '>'));
+    // deviation - last week of the last month exceeds the first week of this month
+    System.assertEquals(true, weekInMonth.matches(oneWeekBefore, '>'));
+
+    comparisonDate = Datetime.newInstanceGmt(2020, 1, 8);
+    oneWeekBefore = comparisonDate.addDays(-7);
+    oneWeekAfter = comparisonDate.addDays(7);
+    weekInMonth = RollupDateLiteral.getFunction('WEEK_IN_MONTH(CreatedDate)', '2');
+
+    System.assertEquals(true, weekInMonth.matches(comparisonDate, '='), weekInMonth);
+    System.assertEquals(false, weekInMonth.matches(oneWeekBefore, '='));
+    System.assertEquals(false, weekInMonth.matches(oneWeekAfter, '='));
+    System.assertEquals(false, weekInMonth.matches(comparisonDate, '!='));
+
+    System.assertEquals(true, weekInMonth.matches(oneWeekAfter, '>'));
+    System.assertEquals(true, weekInMonth.matches(oneWeekBefore, '<'));
+
+    comparisonDate = Datetime.newInstanceGmt(2020, 1, 15);
+    oneWeekBefore = comparisonDate.addDays(-7);
+    oneWeekAfter = comparisonDate.addDays(7);
+    weekInMonth = RollupDateLiteral.getFunction('WEEK_IN_MONTH(CreatedDate)', '3');
+
+    System.assertEquals(true, weekInMonth.matches(comparisonDate, '='), weekInMonth);
+    System.assertEquals(false, weekInMonth.matches(oneWeekBefore, '='));
+    System.assertEquals(false, weekInMonth.matches(oneWeekAfter, '='));
+    System.assertEquals(false, weekInMonth.matches(comparisonDate, '!='));
+
+    System.assertEquals(true, weekInMonth.matches(oneWeekAfter, '>'));
+    System.assertEquals(true, weekInMonth.matches(oneWeekBefore, '<'));
+
+    // ensure february is handled correctly
+    comparisonDate = Datetime.newInstanceGmt(2020, 2, 28);
+    oneWeekBefore = comparisonDate.addDays(-7);
+    oneWeekAfter = comparisonDate.addDays(7);
+    weekInMonth = RollupDateLiteral.getFunction('WEEK_IN_MONTH(CreatedDate)', '4');
+
+    System.assertEquals(true, weekInMonth.matches(comparisonDate, '='), weekInMonth);
+    System.assertEquals(false, weekInMonth.matches(oneWeekBefore, '='));
+    System.assertEquals(false, weekInMonth.matches(oneWeekAfter, '='));
+    System.assertEquals(false, weekInMonth.matches(comparisonDate, '!='));
+
+    // deviation - week after is now week one of the next month
+    System.assertEquals(true, weekInMonth.matches(oneWeekAfter, '<'));
+    System.assertEquals(true, weekInMonth.matches(oneWeekBefore, '<'));
+
+    comparisonDate = Datetime.newInstanceGmt(2020, 12, 29);
+    oneWeekBefore = comparisonDate.addDays(-7);
+    oneWeekAfter = comparisonDate.addDays(7);
+    weekInMonth = RollupDateLiteral.getFunction('WEEK_IN_MONTH(CreatedDate)', '5');
+
+    System.assertEquals(true, weekInMonth.matches(comparisonDate, '='), weekInMonth);
+    System.assertEquals(false, weekInMonth.matches(oneWeekBefore, '='));
+    System.assertEquals(false, weekInMonth.matches(oneWeekAfter, '='));
+    System.assertEquals(false, weekInMonth.matches(comparisonDate, '!='));
+
+    // deviation - week after is now week one of the next month
+    System.assertEquals(true, weekInMonth.matches(oneWeekAfter, '<'));
+    System.assertEquals(true, weekInMonth.matches(oneWeekBefore, '<'));
+  }
+
+  @IsTest
+  static void shouldWorkForWeekInYearFunction() {
+    Datetime comparisonDate = Datetime.newInstanceGmt(2020, 4, 1);
+    Datetime oneWeekBefore = comparisonDate.addDays(-7);
+    Datetime oneWeekAfter = comparisonDate.addDays(7);
+    RollupDateLiteral weekInYear = RollupDateLiteral.getFunction('WEEK_IN_YEAR(CreatedDate)', '14');
+
+    System.assertEquals(true, weekInYear.matches(comparisonDate, '='), weekInYear);
+    System.assertEquals(false, weekInYear.matches(oneWeekBefore, '='));
+    System.assertEquals(false, weekInYear.matches(oneWeekAfter, '='));
+    System.assertEquals(false, weekInYear.matches(comparisonDate, '!='));
+
+    comparisonDate = Datetime.newInstanceGmt(2020, 12, 22);
+    oneWeekBefore = comparisonDate.addDays(-7);
+    oneWeekAfter = comparisonDate.addDays(7);
+    weekInYear = RollupDateLiteral.getFunction('WEEK_IN_YEAR(CreatedDate)', '52');
+
+    System.assertEquals(true, weekInYear.matches(comparisonDate, '='), weekInYear);
+    System.assertEquals(false, weekInYear.matches(oneWeekBefore, '='));
+    System.assertEquals(false, weekInYear.matches(oneWeekAfter, '='));
+    System.assertEquals(false, weekInYear.matches(comparisonDate, '!='));
   }
 }

--- a/extra-tests/classes/RollupEvaluatorTests.cls
+++ b/extra-tests/classes/RollupEvaluatorTests.cls
@@ -689,6 +689,13 @@ private class RollupEvaluatorTests {
     System.assertEquals(new List<String>{ 'Owner.Name' }, eval.getQueryFields());
   }
 
+  @IsTest
+  static void shouldReturnDateFunctionFields() {
+    String queryString = 'HOUR_IN_DAY(CreatedDate) = 15';
+    RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(queryString, Account.SObjectType);
+    System.assertEquals(new List<String>{ 'CreatedDate' }, eval.getQueryFields());
+  }
+
   @SuppressWarnings('PMD.ApexUnitTestClassShouldHaveAsserts')
   @IsTest
   static void shouldThrowExceptionForImproperlyEnteredWhereClause() {
@@ -1016,16 +1023,25 @@ private class RollupEvaluatorTests {
   static void shouldProperlyEvaluateDateLiteral() {
     String whereClause = 'CloseDate = THIS_YEAR';
     RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, Opportunity.SObjectType);
-    System.assertEquals(true, eval.matches(new Opportunity(CloseDate = System.today().addDays(-1))));
+    System.assertEquals(true, eval.matches(new Opportunity(CloseDate = System.today())));
     System.assertEquals(false, eval.matches(new Opportunity(CloseDate = System.today().addYears(-1))));
   }
 
   @IsTest
-  static void shouldStripOutDateFunctionsFromSelectStatements() {
-    String whereClause = 'CALENDAR_YEAR(CreatedDate) = ' + System.today().year();
-    RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, ContactPointAddress.SObjectType);
-    List<String> queryFields = eval.getQueryFields();
-    System.assertEquals(true, queryFields.isEmpty(), 'Query fields should have been empty but contained: ' + queryFields);
+  static void shouldProperlyEvaluateDateFunction() {
+    String whereClause = 'HOUR_IN_DAY(ReminderDateTime) = 5';
+    RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, Task.SObjectType);
+    Time fifthHour = Time.newInstance(5, 0, 0, 0);
+    Datetime fifthHourDt = Datetime.newInstanceGmt(System.today(), fifthHour);
+    System.assertEquals(true, eval.matches(new Task(ReminderDateTime = fifthHourDt)));
+  }
+
+  @IsTest
+  static void shouldProperlyEvaluateLiteralDateFunctions() {
+    Date comparisonDate = Date.newInstance(2020, 3, 7);
+    String whereClause = 'DAY_ONLY(ReminderDateTime) = 2020-03-07';
+    RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, Task.SObjectType);
+    System.assertEquals(true, eval.matches(new Task(ReminderDateTime = Datetime.newInstanceGmt(comparisonDate, Time.newInstance(0, 0, 0, 0)))));
   }
 
   @IsTest

--- a/extra-tests/classes/RollupFieldInitializerTests.cls
+++ b/extra-tests/classes/RollupFieldInitializerTests.cls
@@ -108,6 +108,8 @@ private class RollupFieldInitializerTests {
      * (java.math.BigDecimal and java.lang.Integer are in module java.base of loader 'bootstrap')
      */
     RollupFieldInitializer init = RollupFieldInitializer.Current;
+    // never ever fill out the Name field here; there's a reason it's blank
+    // and it would cause this test to pass without exercising the actual underlying fix
     Account one = new Account();
     Account two = new Account();
 

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -9,7 +9,7 @@ private class RollupFullRecalcTests {
   }
 
   @IsTest
-  static void shouldSortFullRecalcsToEnd() {
+  static void shouldSortParentResetProcessorsToBeginning() {
     RollupAsyncProcessor actualProcessor = RollupAsyncProcessor.getProcessor(
       new Rollup.FilterResults(),
       Contact.Id,
@@ -23,14 +23,26 @@ private class RollupFullRecalcTests {
       null,
       null
     );
+    RollupParentResetProcessor resetProcessor = new RollupParentResetProcessor(
+      new List<Rollup__mdt>(),
+      null,
+      '',
+      new Set<Id>(),
+      Rollup.InvocationPoint.FROM_APEX
+    );
     List<RollupAsyncProcessor> processors = new List<RollupAsyncProcessor>{
+      resetProcessor,
       actualProcessor,
       actualProcessor,
-      new RollupParentResetProcessor(new List<Rollup__mdt>(), null, '', new Set<Id>(), Rollup.InvocationPoint.FROM_APEX)
+      resetProcessor,
+      actualProcessor,
+      resetProcessor
     };
     processors.sort();
 
     System.assertEquals(true, processors[0] instanceof RollupParentResetProcessor, processors[0]);
+    System.assertEquals(true, processors[1] instanceof RollupParentResetProcessor, processors[0]);
+    System.assertEquals(true, processors[2] instanceof RollupParentResetProcessor, processors[0]);
   }
 
   @IsTest

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -25,12 +25,12 @@ private class RollupFullRecalcTests {
     );
     List<RollupAsyncProcessor> processors = new List<RollupAsyncProcessor>{
       actualProcessor,
-      new RollupDeferredFullRecalcProcessor(new List<Rollup__mdt>(), null, null, null, null),
-      actualProcessor
+      actualProcessor,
+      new RollupParentResetProcessor(new List<Rollup__mdt>(), null, '', new Set<Id>(), Rollup.InvocationPoint.FROM_APEX)
     };
     processors.sort();
 
-    System.assertEquals(true, processors[2] instanceof RollupDeferredFullRecalcProcessor, processors);
+    System.assertEquals(true, processors[0] instanceof RollupParentResetProcessor, processors[0]);
   }
 
   @IsTest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1827,6 +1827,14 @@ global without sharing virtual class Rollup {
     return queryFields;
   }
 
+  private static String getFullRecalcQueryString(List<Rollup__mdt> metas) {
+    List<String> orderByFields = new List<String>();
+    for (Rollup__mdt meta : metas) {
+      orderByFields.add(meta.LookupFieldOnCalcItem__c);
+    }
+    return '\nORDER BY ' + String.join(orderByFields, ',');
+  }
+
   private static List<Rollup> getFullRecalcRollups(List<FullRecalculationMetadata> fullRecalcMetas, InvocationPoint invokePoint) {
     Map<SObjectType, RollupMetadata> typeToWrappedMeta = new Map<SObjectType, RollupMetadata>();
     for (Integer index = 0; index < fullRecalcMetas.size(); index++) {
@@ -1919,7 +1927,8 @@ global without sharing virtual class Rollup {
     } else if (shouldQueue) {
       return new RollupDeferredFullRecalcProcessor(matchingMeta, calcItemType, queryString, recordIds, invokePoint);
     } else {
-      return new RollupFullBatchRecalculator(queryString, invokePoint, matchingMeta, calcItemType, recordIds);
+      String queryWithOrderBy = (queryString + getFullRecalcQueryString(matchingMeta)).replace('ALL ROWS', '');
+      return new RollupFullBatchRecalculator(queryWithOrderBy, invokePoint, matchingMeta, calcItemType, recordIds);
     }
   }
 

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1927,7 +1927,7 @@ global without sharing virtual class Rollup {
     } else if (shouldQueue) {
       return new RollupDeferredFullRecalcProcessor(matchingMeta, calcItemType, queryString, recordIds, invokePoint);
     } else {
-      String queryWithOrderBy = (queryString + getFullRecalcQueryString(matchingMeta)).replace('ALL ROWS', '');
+      String queryWithOrderBy = (queryString + getFullRecalcQueryString(matchingMeta));
       return new RollupFullBatchRecalculator(queryWithOrderBy, invokePoint, matchingMeta, calcItemType, recordIds);
     }
   }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1827,14 +1827,6 @@ global without sharing virtual class Rollup {
     return queryFields;
   }
 
-  private static String getFullRecalcQueryString(List<Rollup__mdt> metas) {
-    List<String> orderByFields = new List<String>();
-    for (Rollup__mdt meta : metas) {
-      orderByFields.add(meta.LookupFieldOnCalcItem__c);
-    }
-    return '\nORDER BY ' + String.join(orderByFields, ',');
-  }
-
   private static List<Rollup> getFullRecalcRollups(List<FullRecalculationMetadata> fullRecalcMetas, InvocationPoint invokePoint) {
     Map<SObjectType, RollupMetadata> typeToWrappedMeta = new Map<SObjectType, RollupMetadata>();
     for (Integer index = 0; index < fullRecalcMetas.size(); index++) {
@@ -1927,8 +1919,7 @@ global without sharing virtual class Rollup {
     } else if (shouldQueue) {
       return new RollupDeferredFullRecalcProcessor(matchingMeta, calcItemType, queryString, recordIds, invokePoint);
     } else {
-      String queryWithOrderBy = (queryString + getFullRecalcQueryString(matchingMeta)).replace('ALL ROWS', '');
-      return new RollupFullBatchRecalculator(queryWithOrderBy, invokePoint, matchingMeta, calcItemType, recordIds);
+      return new RollupFullBatchRecalculator(queryString, invokePoint, matchingMeta, calcItemType, recordIds);
     }
   }
 

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -11,6 +11,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   protected Boolean isProcessed = false;
   protected Boolean overridesRunCalc = false;
   protected FullRecalcProcessor fullRecalcProcessor;
+  protected Boolean shouldSortToFront = false;
 
   private RollupRelationshipFieldFinder.Traversal traversal;
   private Map<SObjectType, Set<String>> lookupObjectToUniqueFieldNames;
@@ -209,9 +210,9 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     Integer numberToReturn = 0;
     if (otherRollup instanceof RollupAsyncProcessor) {
       RollupAsyncProcessor that = (RollupAsyncProcessor) otherRollup;
-      if (this.op == null && that.op != null) {
+      if (this.shouldSortToFront == false && that.shouldSortToFront) {
         numberToReturn = 1;
-      } else if (that.op == null && this.op != null) {
+      } else if (that.shouldSortToFront == false && this.shouldSortToFront) {
         numberToReturn = -1;
       } else if (this.op != null && that.op != null) {
         Boolean thisDelete = this.op.name().contains('DELETE');

--- a/rollup/core/classes/RollupDateLiteral.cls
+++ b/rollup/core/classes/RollupDateLiteral.cls
@@ -4,8 +4,8 @@ public without sharing abstract class RollupDateLiteral {
     '(LAST|NEXT)_N_(DAYS|WEEKS|MONTHS|YEARS|QUARTERS|FISCAL_QUARTERS|FISCAL_YEARS):\\s?\\d*'
   );
   private static final Pattern DATE_FUNCTION_PATTERN = Pattern.compile(
-    '(CALENDAR_MONTH|CALENDAR_QUARTER|CALENDAR_YEAR|CALENDAR_YEAR|DAY_IN_MONTH|DAY_IN_WEEK|DAY_IN_YEAR|DAY_ONLY|FISCAL_MONTH' +
-    '|FISCAL_QUARTER|FISCAL_YEAR|HOUR_IN_DAY|WEEK_IN_MONTH|WEEK_IN_YEAR)\\(.+?\\)'
+    '(CALENDAR_MONTH|CALENDAR_QUARTER|CALENDAR_YEAR|DAY_IN_MONTH|DAY_IN_WEEK|DAY_IN_YEAR|DAY_ONLY|FISCAL_MONTH|' +
+    'FISCAL_QUARTER|FISCAL_YEAR|HOUR_IN_DAY|WEEK_IN_MONTH|WEEK_IN_YEAR)\\(.+?\\)'
   );
 
   private static final Time START_TIME {
@@ -90,7 +90,21 @@ public without sharing abstract class RollupDateLiteral {
           'THIS_FISCAL_YEAR' => ThisFiscalYearLiteral.class,
           'NEXT_FISCAL_YEAR' => NextFiscalYearLiteral.class,
           'LAST_N_FISCAL_YEARS' => LastNFiscalYearsLiteral.class,
-          'NEXT_N_FISCAL_YEARS' => NextNFiscalYearsLiteral.class
+          'NEXT_N_FISCAL_YEARS' => NextNFiscalYearsLiteral.class,
+          // Functions
+          'CALENDAR_MONTH(' => CalendarMonthFunctionLiteral.class,
+          'CALENDAR_YEAR(' => CalendarYearFunctionLiteral.class,
+          'CALENDAR_QUARTER(' => CalendarQuarterFunctionLiteral.class,
+          'DAY_IN_MONTH(' => DayInMonthFunctionLiteral.class,
+          'DAY_IN_WEEK(' => DayInWeekFunctionLiteral.class,
+          'DAY_IN_YEAR(' => DayInYearFunctionLiteral.class,
+          'DAY_ONLY(' => DayOnlyFunctionLiteral.class,
+          'FISCAL_MONTH(' => FiscalMonthFunctionLiteral.class,
+          'FISCAL_QUARTER(' => FiscalQuarterFunctionLiteral.class,
+          'FISCAL_YEAR(' => FiscalYearFunctionLiteral.class,
+          'HOUR_IN_DAY(' => HourInDayFunctionLiteral.class,
+          'WEEK_IN_MONTH(' => WeekInMonthFunctionLiteral.class,
+          'WEEK_IN_YEAR(' => WeekInYearFunctionLiteral.class
         };
       }
       return KEY_TO_DATE_LITERAL;
@@ -112,6 +126,10 @@ public without sharing abstract class RollupDateLiteral {
     return literal;
   }
 
+  public static RollupDateLiteral getFunction(String key, String val) {
+    return getLazyLoadedLiteral(key.substringBefore('(') + '(', val);
+  }
+
   private static RollupDateLiteral getLazyLoadedLiteral(String dictionaryKey, String possibleDynamicValue) {
     /**
      * neatly solves a thorny issue - we want to cache the RollupDateLiteral instances,
@@ -124,9 +142,9 @@ public without sharing abstract class RollupDateLiteral {
     if (literal instanceof Type) {
       Type literalType = (Type) literal;
       literal = (RollupDateLiteral) literalType.newInstance();
-      ((RollupDateLiteral) literal).setDynamicValue(possibleDynamicValue);
       KEY_TO_DATE_LITERAL.put(dictionaryKey, literal);
     }
+    ((RollupDateLiteral) literal).setDynamicValue(possibleDynamicValue);
     return (RollupDateLiteral) literal;
   }
 
@@ -147,33 +165,57 @@ public without sharing abstract class RollupDateLiteral {
     return fiscalInfo;
   }
 
-  private static Integer getCurrentQuarter() {
-    Integer currentQuarterStartingMonth;
-    switch on System.today().month() {
+  private static Integer getQuarter(Integer month) {
+    Integer calendarQuarter;
+    switch on month {
       when 1, 2, 3 {
-        currentQuarterStartingMonth = 1;
+        calendarQuarter = 1;
       }
       when 4, 5, 6 {
-        currentQuarterStartingMonth = 4;
+        calendarQuarter = 2;
       }
       when 7, 8, 9 {
-        currentQuarterStartingMonth = 7;
+        calendarQuarter = 3;
       }
       when else {
-        currentQuarterStartingMonth = 10;
+        calendarQuarter = 4;
       }
     }
-    return currentQuarterStartingMonth;
+    return calendarQuarter;
+  }
+
+  private static Integer getCurrentQuarter() {
+    return getQuarter(System.today().month());
+  }
+
+  private static Integer getCurrentQuarterStartMonth() {
+    Integer currentQuarter = getCurrentQuarter();
+    Integer quarterStartMonth;
+    switch on currentQuarter {
+      when 1 {
+        quarterStartMonth = 1;
+      }
+      when 2 {
+        quarterStartMonth = 4;
+      }
+      when 3 {
+        quarterStartMonth = 7;
+      }
+      when else {
+        quarterStartMonth = 10;
+      }
+    }
+    return quarterStartMonth;
   }
 
   private static Date getPriorQuarterStart() {
-    Integer currentQuarterStartMonth = getCurrentQuarter();
+    Integer currentQuarterStartMonth = getCurrentQuarterStartMonth();
     Boolean isFirstQuarter = currentQuarterStartMonth == 1;
     return Date.newInstance(System.today().year() - (isFirstQuarter ? 1 : 0), isFirstQuarter ? 10 : (currentQuarterStartMonth - 3), 1);
   }
 
   private static Date getNextQuarterStart() {
-    Integer currentQuarterStartMonth = getCurrentQuarter();
+    Integer currentQuarterStartMonth = getCurrentQuarterStartMonth();
     Integer nextQuarterStartMonth = currentQuarterStartMonth == 10 ? 1 : currentQuarterStartMonth + 3;
     Integer yearForNextQuarterOffset = nextQuarterStartMonth == 1 ? 1 : 0;
     return Date.newInstance(System.today().year() + yearForNextQuarterOffset, nextQuarterStartMonth, 1);
@@ -206,7 +248,7 @@ public without sharing abstract class RollupDateLiteral {
   }
 
   public virtual override String toString() {
-    return this.ref.format();
+    return this.ref?.format();
   }
 
   protected virtual Boolean isEqualTo(Datetime val) {
@@ -361,7 +403,7 @@ public without sharing abstract class RollupDateLiteral {
     protected override void setDynamicValue(String num) {
       Integer dateRange = Integer.valueOf(num);
       this.bound = Datetime.newInstanceGmt(System.today(), END_TIME); // includes all of today
-      this.ref = START_OF_TODAY.addDays(-dateRange);
+      this.ref = Datetime.newInstanceGmt(START_OF_TODAY.addDays(-(dateRange + 1)).dateGmt(), END_TIME);
     }
   }
 
@@ -449,7 +491,7 @@ public without sharing abstract class RollupDateLiteral {
     }
 
     protected virtual Date getThisQuarterStart() {
-      return Date.newInstance(System.today().year(), getCurrentQuarter(), 1);
+      return Date.newInstance(System.today().year(), getCurrentQuarterStartMonth(), 1);
     }
   }
 
@@ -650,6 +692,174 @@ public without sharing abstract class RollupDateLiteral {
   private class NextNFiscalYearsLiteral extends NextNYearsLiteral {
     protected override Date getStartOfNextYear() {
       return FISCAL_INFO.FiscalYearStartDate.addYears(1);
+    }
+  }
+
+  /**
+   * Function Section.
+   */
+
+  private abstract class FunctionLiteral extends RollupDateLiteral {
+    protected Integer bound;
+
+    public override String toString() {
+      return String.valueOf(this.bound);
+    }
+
+    protected override void setDynamicValue(String num) {
+      this.bound = Integer.valueOf(num);
+    }
+
+    protected abstract Integer getComparisonNumber(Datetime val);
+
+    protected override Boolean isEqualTo(Datetime val) {
+      return this.bound == this.getComparisonNumber(val);
+    }
+    protected override Boolean isGreaterThan(Datetime val) {
+      return this.bound < this.getComparisonNumber(val);
+    }
+    protected override Boolean isLessThan(Datetime val) {
+      return this.bound > this.getComparisonNumber(val);
+    }
+  }
+
+  private class CalendarMonthFunctionLiteral extends FunctionLiteral {
+    protected override Integer getComparisonNumber(Datetime val) {
+      return val.monthGmt();
+    }
+  }
+
+  private class CalendarYearFunctionLiteral extends FunctionLiteral {
+    protected override Integer getComparisonNumber(Datetime val) {
+      return val.yearGmt();
+    }
+  }
+
+  private class CalendarQuarterFunctionLiteral extends FunctionLiteral {
+    protected override Integer getComparisonNumber(Datetime val) {
+      return getQuarter(val.monthGmt());
+    }
+  }
+
+  private class DayInMonthFunctionLiteral extends FunctionLiteral {
+    protected override Integer getComparisonNumber(Datetime val) {
+      return val.dayGmt();
+    }
+  }
+
+  private class DayInWeekFunctionLiteral extends FunctionLiteral {
+    protected override Integer getComparisonNumber(Datetime val) {
+      Date startOfWeek = val.dateGmt().toStartOfWeek();
+      Integer daysBetween = startOfWeek.daysBetween(val.dateGmt());
+      return daysBetween + 1;
+    }
+  }
+
+  private class DayInYearFunctionLiteral extends FunctionLiteral {
+    protected override Integer getComparisonNumber(Datetime val) {
+      return val.dayOfYearGmt();
+    }
+  }
+
+  // there's always an exception to the rule!
+  /** Returns a Date representing the day portion of a DateTime field. */
+  private class DayOnlyFunctionLiteral extends RangedLiteral {
+    protected override void setDynamicValue(String dateString) {
+      this.ref = Datetime.newInstanceGmt(Date.valueOf(dateString), START_TIME);
+      this.bound = this.ref;
+    }
+  }
+
+  private class FiscalMonthFunctionLiteral extends FunctionLiteral {
+    protected override Integer getComparisonNumber(Datetime val) {
+      Integer yearDiff = FISCAL_INFO.FiscalYearStartDate.year() - val.yearGmt();
+      if (yearDiff > 0) {
+        val = val.addYears(yearDiff);
+      }
+      Integer monthsBetween = FISCAL_INFO.FiscalYearStartDate.monthsBetween(val.dateGmt()) + 1;
+      return getFiscalMonthsOffset(monthsBetween);
+    }
+  }
+
+  private static Integer getFiscalMonthsOffset(Integer monthsSinceFiscalStart) {
+    if (Math.abs(monthsSinceFiscalStart) > 12) {
+      monthsSinceFiscalStart = Math.mod(monthsSinceFiscalStart, 12);
+    }
+    return monthsSinceFiscalStart;
+  }
+
+  private class FiscalQuarterFunctionLiteral extends FunctionLiteral {
+    protected override Integer getComparisonNumber(Datetime val) {
+      Integer fiscalQuarter;
+      Integer monthsSinceFiscalStart = getFiscalMonthsOffset(FISCAL_INFO.FiscalYearStartDate.monthsBetween(val.dateGmt()) + 1);
+      if (monthsSinceFiscalStart == 0) {
+        monthsSinceFiscalStart = 12;
+      }
+      switch on monthsSinceFiscalStart {
+        when 1, 2, 3, -10, -11, -12 {
+          fiscalQuarter = 1;
+        }
+        when 4, 5, 6, -7, -8, -9 {
+          fiscalQuarter = 2;
+        }
+        when 7, 8, 9, -4, -5, -6 {
+          fiscalQuarter = 3;
+        }
+        when 10, 11, 12, -1, -2, -3 {
+          fiscalQuarter = 4;
+        }
+        when else {
+          RollupLogger.Instance.log('unable to find fiscal quarter:', monthsSinceFiscalStart, LoggingLevel.ERROR);
+        }
+      }
+      return fiscalQuarter;
+    }
+  }
+
+  private class FiscalYearFunctionLiteral extends FunctionLiteral {
+    protected override Integer getComparisonNumber(Datetime val) {
+      return val.monthGmt() >= FISCAL_INFO.FiscalYearStartDate.month() &&
+        val.yearGmt() > FISCAL_INFO.FiscalYearStartDate.year()
+        ? val.yearGmt() + 1
+        : val.yearGmt();
+    }
+  }
+
+  private class HourInDayFunctionLiteral extends FunctionLiteral {
+    protected override Integer getComparisonNumber(Datetime val) {
+      return val.hourGmt();
+    }
+  }
+
+  private class WeekInMonthFunctionLiteral extends FunctionLiteral {
+    protected override Integer getComparisonNumber(Datetime val) {
+      return getWeekNumber(val.dayGmt());
+    }
+  }
+
+  private static Integer getWeekNumber(Integer dayNumber) {
+    Integer currentWeek;
+    if (dayNumber <= 7) {
+      currentWeek = 1;
+    } else if (dayNumber > 7 && dayNumber <= 14) {
+      currentWeek = 2;
+    } else if (dayNumber > 14 && dayNumber <= 21) {
+      currentWeek = 3;
+    } else if (dayNumber > 21 && dayNumber <= 28) {
+      currentWeek = 4;
+    } else {
+      currentWeek = 5;
+    }
+    return currentWeek;
+  }
+
+  /**
+   * Week 1 is the first week that has at least 4 days in the current year - yikes!
+   * There can also be a week 53. The sadness.
+   */
+  private class WeekInYearFunctionLiteral extends FunctionLiteral {
+    protected override Integer getComparisonNumber(Datetime val) {
+      return Integer.valueOf(val.format('ww'));
     }
   }
 }

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -229,6 +229,8 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
             this.isValidRelationshipField(condition.fieldName)
           ) {
             fieldNames.add(condition.fieldName);
+          } else if (RollupDateLiteral.isSoqlDateFunction(condition.fieldName)) {
+            fieldNames.add(getDateFunctionField(condition.fieldName));
           } else if (hasRelationshipField == false) {
             fieldNames.add(condition.fieldName);
           }
@@ -401,10 +403,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       List<WhereFieldCondition> conditions = new List<WhereFieldCondition>();
       localClause = localClause.trim();
       String fieldName = localClause.substring(0, localClause.indexOf(' '));
-      if (RollupDateLiteral.isSoqlDateFunction(fieldName)) {
-        // TODO remove this after full support for SOQL date functions is introduced
-        return conditions;
-      }
+
       localClause = localClause.removeStart(fieldName).trim();
       String criteria = localClause.substring(0, localClause.indexOf(' ')).trim();
       String value = this.getValue(localClause.substringAfter(criteria));
@@ -592,11 +591,16 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
     public Boolean equals(Object o) {
       SObject item = (SObject) o;
       Boolean isEqual = true;
+      Boolean hasOnlyOneValue = this.originalValues.size() == 1;
+      Boolean isDateFunction = RollupDateLiteral.isSoqlDateFunction(this.fieldName);
 
-      Object originalValue = this.getFieldValue(item, this.fieldName, this.sObjectType);
+      String fieldNameToUse = isDateFunction ? getDateFunctionField(this.fieldName) : this.fieldName;
+      Object originalValue = this.getFieldValue(item, fieldNameToUse, this.sObjectType);
       String storedValue = originalValue == null ? (String) originalValue : String.valueOf(originalValue);
 
-      if (this.originalValues.isEmpty() == false && RollupDateLiteral.isDateLiteral(this.originalValues[0])) {
+      if (hasOnlyOneValue && isDateFunction) {
+        return RollupDateLiteral.getFunction(this.fieldName, this.originalValues[0]).matches(originalValue, this.criteria);
+      } else if (hasOnlyOneValue && RollupDateLiteral.isDateLiteral(this.originalValues[0])) {
         return RollupDateLiteral.get(this.originalValues[0]).matches(originalValue, this.criteria);
       } else if (originalValue instanceof Decimal) {
         for (Integer index = 0; index < this.values.size(); index++) {
@@ -666,7 +670,6 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       if (item == null) {
         return '';
       }
-
       // handle compound fields separately
       Boolean hasField = sObjectType.getDescribe().fields.getMap().containsKey(fieldPath);
       if (fieldPath.contains('.') && hasField == false) {
@@ -847,5 +850,9 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
 
   private static String getCurrentTransactionId() {
     return stubRequestId != null ? stubRequestId : Request.getCurrent().getRequestId();
+  }
+
+  private static String getDateFunctionField(String field) {
+    return field.substringBetween('(', ')');
   }
 }

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -8,7 +8,7 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupA
     SObjectType calcItemType,
     Set<Id> recordIds
   ) {
-    super(queryString, invokePoint, rollupInfo, calcItemType, recordIds);
+    super(getFullBatchQueryString(queryString, rollupInfo), invokePoint, rollupInfo, calcItemType, recordIds);
     this.statefulLookupToCalcItems = new Map<String, CalcItemBag>();
   }
 
@@ -64,5 +64,13 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupA
       this.statefulLookupToCalcItems.put(lookupKey, bag);
       lookupToCalcItems.put(lookupKey, bag);
     }
+  }
+
+  private static String getFullBatchQueryString(String query, List<Rollup__mdt> metas) {
+    List<String> orderByFields = new List<String>();
+    for (Rollup__mdt meta : metas) {
+      orderByFields.add(meta.LookupFieldOnCalcItem__c);
+    }
+    return (query.replace('ALL ROWS', '') + '\nORDER BY ' + String.join(orderByFields, ',')) + ' ALL ROWS';
   }
 }

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -14,9 +14,13 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupA
 
   public override Database.QueryLocator start(Database.BatchableContext bc) {
     this.isProcessed = true;
-    // note - if the optional where clause was appended to the passed in query string, this.recordIds is also
-    // used as a bind variable
-    return Database.getQueryLocator(this.queryString);
+    // note - if the optional where clause was appended to the passed in query string,
+    // this.recordIds is also used as a bind variable
+    String finalQueryString = this.queryString;
+    if (this.queryString.contains('ORDER BY') && this.queryString.contains('ALL ROWS')) {
+      finalQueryString = this.queryString.replace('ALL ROWS', '') + ' ALL ROWS';
+    }
+    return Database.getQueryLocator(finalQueryString);
   }
 
   public virtual override void execute(Database.BatchableContext bc, List<SObject> calcItems) {

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -8,7 +8,7 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupA
     SObjectType calcItemType,
     Set<Id> recordIds
   ) {
-    super(getFullBatchQueryString(queryString, rollupInfo), invokePoint, rollupInfo, calcItemType, recordIds);
+    super(queryString, invokePoint, rollupInfo, calcItemType, recordIds);
     this.statefulLookupToCalcItems = new Map<String, CalcItemBag>();
   }
 
@@ -64,13 +64,5 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupA
       this.statefulLookupToCalcItems.put(lookupKey, bag);
       lookupToCalcItems.put(lookupKey, bag);
     }
-  }
-
-  private static String getFullBatchQueryString(String query, List<Rollup__mdt> metas) {
-    List<String> orderByFields = new List<String>();
-    for (Rollup__mdt meta : metas) {
-      orderByFields.add(meta.LookupFieldOnCalcItem__c);
-    }
-    return (query.replace('ALL ROWS', '') + '\nORDER BY ' + String.join(orderByFields, ',')) + ' ALL ROWS';
   }
 }

--- a/rollup/core/classes/RollupParentResetProcessor.cls
+++ b/rollup/core/classes/RollupParentResetProcessor.cls
@@ -25,6 +25,7 @@ public inherited sharing class RollupParentResetProcessor extends RollupFullBatc
     super(getRefinedQueryString(queryString, matchingMeta), invokePoint, matchingMeta, calcItemType, recordIds);
     this.overridesRunCalc = true;
     this.isNoOp = false;
+    this.shouldSortToFront = true;
   }
 
   public override String runCalc() {
@@ -50,6 +51,7 @@ public inherited sharing class RollupParentResetProcessor extends RollupFullBatc
     for (SObject parentItem : calcItems) {
       for (Rollup__mdt rollupMeta : this.rollupInfo) {
         parentItem.put(rollupMeta.RollupFieldOnLookupObject__c, null);
+        RollupLogger.Instance.log('resetting parent field:', parentItem, LoggingLevel.FINE);
       }
     }
     this.getDML().doUpdate(calcItems);

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -108,6 +108,7 @@
         "Apex Rollup - Extra Code Coverage@0.0.1-0": "04t6g000008SiTHAA0",
         "apex-rollup@1.3.17-0": "04t6g000008SiTgAAK",
         "apex-rollup@1.3.18-0": "04t6g000008SiUyAAK",
-        "apex-rollup@1.3.19-0": "04t6g000008SiVIAA0"
+        "apex-rollup@1.3.19-0": "04t6g000008SiVIAA0",
+        "apex-rollup@1.3.20-0": "04t6g000008SiaJAAS"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Prevent RollupParentResetProcessor from accidentally wiping out correctly calculated values",
+            "versionName": "Prevent RollupParentResetProcessor from accidentally wiping out correctly calculated values, added date literal function support",
             "versionNumber": "1.3.20.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Removing record locking from all but single record sync updates to combat issues from 1.3.18",
-            "versionNumber": "1.3.19.0",
+            "versionName": "Prevent RollupParentResetProcessor from accidentally wiping out correctly calculated values",
+            "versionNumber": "1.3.20.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
* Fixes #179 by ensuring `RollupParentResetProcessor` recalcs always run first when multiple operations are enqueued. Also added logging for when those parent-level fields are reset
* Added support for [date literal functions](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_date_functions.htm), started exploring any possible issues associated with #224