### PR TITLE
V1.3.24 - Flow bugfixes & Parent-Level Filter updates

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,1 @@
-dmc_config.json
 sfdx-project.json

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SitmAAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Siu6AAC">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SitmAAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Siu6AAC">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Siu6AAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiuBAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Siu6AAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SiuBAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SitNAAS">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SitmAAC">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SitNAAS">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SitmAAC">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupCalcItemReplacerTests.cls
+++ b/extra-tests/classes/RollupCalcItemReplacerTests.cls
@@ -8,7 +8,7 @@ private class RollupCalcItemReplacerTests {
   @IsTest
   static void shouldNotTryToQueryRelationshipFieldsWhenTheyAlreadyExistOnPassedInRecords() {
     Rollup.defaultControl = new RollupControl__mdt(ShouldAbortRun__c = true);
-    Account acc = [SELECT Id FROM Account];
+    Account acc = [SELECT Id, Name FROM Account];
 
     Contact con = new Contact(LastName = 'Lookup to Account', AccountId = acc.Id);
     insert con;
@@ -30,7 +30,7 @@ private class RollupCalcItemReplacerTests {
   @IsTest
   static void shouldSafelyRequeryRelationshipFields() {
     Rollup.defaultControl = new RollupControl__mdt(ShouldAbortRun__c = true);
-    Account acc = [SELECT Id FROM Account];
+    Account acc = [SELECT Id, Name FROM Account];
 
     Contact con = new Contact(LastName = 'Lookup to Account', AccountId = acc.Id);
     insert con;

--- a/extra-tests/classes/RollupCalcItemReplacerTests.cls
+++ b/extra-tests/classes/RollupCalcItemReplacerTests.cls
@@ -1,10 +1,14 @@
 @IsTest
 private class RollupCalcItemReplacerTests {
+  @TestSetup
+  static void setup() {
+    insert new Account(Name = RollupCalcItemReplacerTests.class.getName());
+  }
+
   @IsTest
   static void shouldNotTryToQueryRelationshipFieldsWhenTheyAlreadyExistOnPassedInRecords() {
     Rollup.defaultControl = new RollupControl__mdt(ShouldAbortRun__c = true);
-    Account acc = new Account(Name = RollupCalcItemReplacerTests.class.getName());
-    insert acc;
+    Account acc = [SELECT Id FROM Account];
 
     Contact con = new Contact(LastName = 'Lookup to Account', AccountId = acc.Id);
     insert con;
@@ -26,8 +30,7 @@ private class RollupCalcItemReplacerTests {
   @IsTest
   static void shouldSafelyRequeryRelationshipFields() {
     Rollup.defaultControl = new RollupControl__mdt(ShouldAbortRun__c = true);
-    Account acc = new Account(Name = RollupCalcItemReplacerTests.class.getName());
-    insert acc;
+    Account acc = [SELECT Id FROM Account];
 
     Contact con = new Contact(LastName = 'Lookup to Account', AccountId = acc.Id);
     insert con;
@@ -45,5 +48,26 @@ private class RollupCalcItemReplacerTests {
     con = (Contact) replacedContacts[0];
     System.assertEquals(RollupCalcItemReplacerTests.class.getName(), con.Account.Name);
     System.assertNotEquals(null, con.Account.Owner.Id);
+  }
+
+  @IsTest
+  static void shouldWorkWithNonReparentableItems() {
+    Opportunity opp = new Opportunity(CloseDate = System.today(), StageName = 'test non reparent', Name = 'opp', Amount = 5);
+    Contact con = new Contact(LastName = 'Con');
+    insert new List<SObject>{ opp, con };
+
+    OpportunityContactRole oppConRole = new OpportunityContactRole(OpportunityId = opp.Id, ContactId = con.Id);
+    insert oppConRole;
+
+    RollupCalcItemReplacer replacer = new RollupCalcItemReplacer(
+      new RollupControl__mdt(IsRollupLoggingEnabled__c = true, ReplaceCalcItemsAsyncWhenOverCount__c = 1)
+    );
+    List<SObject> replacedOppContactRoles = replacer.replace(
+      new List<OpportunityContactRole>{ oppConRole },
+      new List<Rollup__mdt>{ new Rollup__mdt(CalcItemWhereClause__c = 'Opportunity.Amount = 1') }
+    );
+    oppConRole = (OpportunityContactRole) replacedOppContactRoles[0];
+
+    System.assertEquals(opp.Amount, oppConRole.Opportunity.Amount, 'Should not fail due to Relationship not editable error');
   }
 }

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -93,7 +93,7 @@ private class RollupFullRecalcTests {
   }
 
   @IsTest
-  static void shouldDecrementProperlyOnUpdateWithParentFilterFields() {
+  static void shouldDecrementProperlyOnRefreshUpdateWithParentFilterFields() {
     Account acc = [SELECT Id, Name FROM Account];
     Account second = new Account(Name = 'Second', AnnualRevenue = 1000);
     insert second;

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -93,6 +93,43 @@ private class RollupFullRecalcTests {
   }
 
   @IsTest
+  static void shouldDecrementProperlyOnUpdateWithParentFilterFields() {
+    Account acc = [SELECT Id, Name FROM Account];
+    Account second = new Account(Name = 'Second', AnnualRevenue = 1000);
+    insert second;
+    // ensure another matching item exists outside of the passed in list
+    insert new ContactPointAddress(PreferenceRank = 500, ParentId = acc.Id, Name = 'One');
+
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
+      new ContactPointAddress(
+        PreferenceRank = second.AnnualRevenue.intValue(),
+        ParentId = second.Id,
+        Name = 'Two'
+      )
+    };
+    insert cpas;
+
+    List<Rollup.FlowInput> flowInputs = RollupTestUtils.prepareFlowTest(cpas, 'REFRESH', 'SUM');
+    flowInputs[0].calcItemWhereClause = 'Parent.Name = \'' + acc.Name + '\'';
+    flowInputs[0].oldRecordsToRollup = new List<SObject>{
+      new ContactPointAddress(PreferenceRank = cpas[0].PreferenceRank, ParentId = acc.Id, Name = 'Two', Id = cpas[0].Id)
+    };
+
+    Test.startTest();
+    List<Rollup.FlowOutput> flowOutputs = Rollup.performRollup(flowInputs);
+    Test.stopTest();
+
+    System.assertEquals(1, flowOutputs.size(), 'Flow outputs were not provided');
+    System.assertEquals('SUCCESS', flowOutputs[0].message);
+    System.assertEquals(true, flowOutputs[0].isSuccess);
+
+    Account updatedAcc = [SELECT Id, AnnualRevenue FROM Account WHERE Id = :acc.Id];
+    System.assertEquals(500, updatedAcc.AnnualRevenue, 'Calc item where clause with parent filtering should work for REFRESH');
+    Account secondUpdatedAcc = [SELECT Id, AnnualRevenue FROM Account WHERE Id = :second.Id];
+    System.assertEquals(0, secondUpdatedAcc.AnnualRevenue, 'Amount should have decremented on update!');
+  }
+
+  @IsTest
   static void shouldPerformFullRecalcWithHierarchy() {
     Account acc = [SELECT Id FROM Account];
     Account childAccount = new Account(Name = 'Hierarchy child', ParentId = acc.Id);

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -69,6 +69,30 @@ private class RollupFullRecalcTests {
   }
 
   @IsTest
+  static void shouldCorrectlyFilterParentFieldsFromFlowChildren() {
+    Account acc = [SELECT Id, Name FROM Account];
+    // ensure another matching item exists outside of the passed in list
+    insert new ContactPointAddress(PreferenceRank = 500, ParentId = acc.Id, Name = 'One');
+
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{ new ContactPointAddress(PreferenceRank = 1000, ParentId = acc.Id, Name = 'Two') };
+    insert cpas;
+
+    List<Rollup.FlowInput> flowInputs = RollupTestUtils.prepareFlowTest(cpas, 'REFRESH', 'SUM');
+    flowInputs[0].calcItemWhereClause = 'Parent.Name = \'' + acc.Name + '\'';
+
+    Test.startTest();
+    List<Rollup.FlowOutput> flowOutputs = Rollup.performRollup(flowInputs);
+    Test.stopTest();
+
+    System.assertEquals(1, flowOutputs.size(), 'Flow outputs were not provided');
+    System.assertEquals('SUCCESS', flowOutputs[0].message);
+    System.assertEquals(true, flowOutputs[0].isSuccess);
+
+    Account updatedAcc = [SELECT Id, AnnualRevenue FROM Account];
+    System.assertEquals(1500, updatedAcc.AnnualRevenue, 'Calc item where clause with parent filtering should work for REFRESH');
+  }
+
+  @IsTest
   static void shouldPerformFullRecalcWithHierarchy() {
     Account acc = [SELECT Id FROM Account];
     Account childAccount = new Account(Name = 'Hierarchy child', ParentId = acc.Id);

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -1759,6 +1759,46 @@ private class RollupIntegrationTests {
     System.assert(true, 'Should make it here');
   }
 
+  @IsTest
+  static void shouldDecrementProperlyOnUpdateWithParentFilterFields() {
+    Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
+    acc.AnnualRevenue = 500;
+    acc.NumberOfEmployees = acc.AnnualRevenue.intValue() + 250;
+    update acc;
+
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
+      new ContactPointAddress(PreferenceRank = acc.AnnualRevenue.intValue(), ParentId = acc.Id, Name = 'Non-match')
+    };
+    insert cpas;
+
+    List<SObject> oldFlowRecords = new List<SObject>{
+      new ContactPointAddress(PreferenceRank = cpas[0].PreferenceRank, ParentId = acc.Id, Name = 'Two', Id = cpas[0].Id)
+    };
+
+    List<Rollup.FlowInput> flowInputs = RollupTestUtils.prepareFlowTest(cpas, 'UPDATE', 'SUM');
+    flowInputs[0].rollupFieldOnOpObject = 'NumberOfEmployees';
+    flowInputs[0].oldRecordsToRollup = oldFlowRecords;
+    flowInputs[0].calcItemWhereClause = 'Name = \'Two\'';
+    flowInputs.addAll(RollupTestUtils.prepareFlowTest(cpas, 'UPDATE', 'SUM'));
+    flowInputs[1].calcItemWhereClause = 'Name = \'Two\' AND Parent.Name = \'' + acc.Name + '\'';
+    flowInputs[1].oldRecordsToRollup = oldFlowRecords;
+    Test.startTest();
+    List<Rollup.FlowOutput> flowOutputs = Rollup.performRollup(flowInputs);
+    Test.stopTest();
+
+    System.assertEquals(2, flowOutputs.size(), 'Flow outputs were not provided');
+    System.assertEquals('SUCCESS', flowOutputs[0].message);
+    System.assertEquals(true, flowOutputs[0].isSuccess);
+
+    Account updatedAcc = [SELECT Id, AnnualRevenue, NumberOfEmployees FROM Account WHERE Id = :acc.Id];
+    System.assertEquals(
+      null,
+      updatedAcc.AnnualRevenue,
+      'Calc item where clause with parent filtering should decrement on update when old item matches and new item does not'
+    );
+    System.assertEquals(250, updatedAcc.NumberOfEmployees, 'Number of employees should also have been decremented');
+  }
+
   /** Schedulable tests */
   @IsTest
   static void shouldThrowExceptionForBadQuery() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.3.23",
+  "version": "1.3.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.3.23",
+  "version": "1.3.24",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1739,7 +1739,6 @@ global without sharing virtual class Rollup {
   }
 
   private static QueryWrapper getFullRecalcQueryWrapper(Rollup__mdt meta, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
-    // TODO - can we use the filter method here?
     QueryWrapper wrapper;
     meta.RollupOperation__c = meta.RollupOperation__c.replace('REFRESH_', '');
     if (String.isNotBlank(meta.CalcItemWhereClause__c)) {

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1759,7 +1759,7 @@ global without sharing virtual class Rollup {
     if (meta.IsRollupStartedFromParent__c == false) {
       wrapper = new QueryWrapper('', meta.LookupFieldOnCalcItem__c);
       for (SObject calcItem : calcItems) {
-        wrapper.addRecordId((String) calcItem.get(meta.LookupFieldOnCalcItem__c));
+        fillWrapper(wrapper, meta.LookupFieldOnCalcItem__c, calcItem, oldCalcItems);
       }
     } else {
       wrapper = getParentWhereClause(
@@ -2113,16 +2113,7 @@ global without sharing virtual class Rollup {
 
     QueryWrapper wrapper = new QueryWrapper(lookupObjectName, fieldName);
     for (SObject calcItem : calcItems) {
-      String lookupId = (String) calcItem.get(lookupFieldOnLookupObject);
-      if (String.isNotBlank(lookupId)) {
-        wrapper.addRecordId(lookupId);
-      }
-      if (oldCalcItems.containsKey(calcItem.Id)) {
-        String oldLookupId = (String) oldCalcItems.get(calcItem.Id).get(lookupFieldOnLookupObject);
-        if (String.isNotBlank(oldLookupId)) {
-          wrapper.addRecordId(oldLookupId);
-        }
-      }
+      fillWrapper(wrapper, lookupFieldOnLookupObject, calcItem, oldCalcItems);
     }
     if (String.isNotBlank(potentialWhereClause)) {
       String whereClause = '(' + potentialWhereClause + ') AND ';
@@ -2147,6 +2138,19 @@ global without sharing virtual class Rollup {
       // not all queries are valid, particularly those with polymorphic fields referencing parent fields
       // return a sentinel value instead, to be checked for downstream
       return RollupQueryBuilder.SENTINEL_COUNT_VALUE;
+    }
+  }
+
+  private static void fillWrapper(QueryWrapper wrapper, String fieldName, SObject calcItem, Map<Id, SObject> oldCalcItems) {
+    String lookupId = (String) calcItem.get(fieldName);
+    if (String.isNotBlank(lookupId)) {
+      wrapper.addRecordId(lookupId);
+    }
+    if (oldCalcItems.containsKey(calcItem.Id)) {
+      String oldLookupId = (String) oldCalcItems.get(calcItem.Id).get(fieldName);
+      if (String.isNotBlank(oldLookupId)) {
+        wrapper.addRecordId(oldLookupId);
+      }
     }
   }
 

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -554,10 +554,10 @@ global without sharing virtual class Rollup {
 
   private class FlowInputWrapper {
     private final FlowInput flowInput;
-    private final Map<Id, SObject> oldFlowRecords;
     private final String rollupContext;
     private final SObjectType sObjectType;
     private final Set<Rollup__mdt> rollupMetadata;
+    private Map<Id, SObject> oldFlowRecords;
 
     private FlowInputWrapper(FlowInput flowInput, String rollupContext, SObjectType sObjectType, Rollup__mdt meta) {
       this.oldFlowRecords = new Map<Id, SObject>(flowInput.oldRecordsToRollup);
@@ -620,6 +620,10 @@ global without sharing virtual class Rollup {
     for (String key : keyToInputWrapper.keySet()) {
       FlowInputWrapper wrapper = keyToInputWrapper.get(key);
       List<Rollup__mdt> metas = new List<Rollup__mdt>(wrapper.rollupMetadata);
+      wrapper.flowInput.recordsToRollup = CALC_ITEM_REPLACER.replace(wrapper.flowInput.recordsToRollup, metas);
+      if (wrapper.oldFlowRecords?.isEmpty() == false) {
+        wrapper.oldFlowRecords = new Map<Id, SObject>(CALC_ITEM_REPLACER.replace(wrapper.oldFlowRecords.values(), metas));
+      }
       processCustomMetadata(
         localRollups,
         metas,
@@ -1735,16 +1739,16 @@ global without sharing virtual class Rollup {
   }
 
   private static QueryWrapper getFullRecalcQueryWrapper(Rollup__mdt meta, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
+    // TODO - can we use the filter method here?
     QueryWrapper wrapper;
     meta.RollupOperation__c = meta.RollupOperation__c.replace('REFRESH_', '');
     if (String.isNotBlank(meta.CalcItemWhereClause__c)) {
-      RollupEvaluator.WhereFieldEvaluator eval = RollupEvaluator.getWhereEval(meta.CalcItemWhereClause__c, calcItems[0].getSObjectType());
+      SObjectType calcItemType = calcItems[0].getSObjectType();
+      RollupEvaluator.WhereFieldEvaluator eval = RollupEvaluator.getWhereEval(meta.CalcItemWhereClause__c, calcItemType);
       Boolean matches = false;
+      FilterResults filter = filter(calcItems, oldCalcItems, eval, meta, calcItemType, CALC_ITEM_REPLACER);
       for (SObject calcItem : calcItems) {
-        matches = matches || eval.matches(calcItem);
-        if (oldCalcItems.containsKey(calcItem.Id)) {
-          matches = matches || eval.matches(oldCalcItems.get(calcItem.Id));
-        }
+        matches = matches || filter.matchingItemIds.contains(calcItem.Id);
         if (matches) {
           break;
         }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -557,10 +557,8 @@ global without sharing virtual class Rollup {
     private final String rollupContext;
     private final SObjectType sObjectType;
     private final Set<Rollup__mdt> rollupMetadata;
-    private Map<Id, SObject> oldFlowRecords;
 
     private FlowInputWrapper(FlowInput flowInput, String rollupContext, SObjectType sObjectType, Rollup__mdt meta) {
-      this.oldFlowRecords = new Map<Id, SObject>(flowInput.oldRecordsToRollup);
       this.flowInput = flowInput;
       this.rollupContext = rollupContext;
       this.sObjectType = sObjectType;
@@ -580,7 +578,7 @@ global without sharing virtual class Rollup {
 
     // Flow bulkifies things, but poorly. It's possible to get multiple FlowInputs with the same metadata, but different calc items (for example)
     // let's head that off at the pass by bulkifying here
-    Map<String, FlowInputWrapper> keyToInputWrapper = new Map<String, FlowInputWrapper>();
+    Map<Rollup__mdt, FlowInputWrapper> metaToInputWrapper = new Map<Rollup__mdt, FlowInputWrapper>();
     for (FlowInput flowInput : flowInputs) {
       flowInput.rollupOperation = flowInput.rollupOperation.toUpperCase();
       RollupLogger.Instance.log('processing invocable data:', flowInput, LoggingLevel.DEBUG);
@@ -596,46 +594,37 @@ global without sharing virtual class Rollup {
         enforceFlowSpecificRules(flowInput, sObjectType);
         winnowOldFlowRecords(flowInput);
 
-        Map<Id, SObject> oldFlowRecords = new Map<Id, SObject>(flowInput.oldRecordsToRollup);
-        String rollupContext = getFlowRollupContext(flowInput, flowInput.recordsToRollup[0], sObjectType, oldFlowRecords);
+        String rollupContext = getFlowRollupContext(flowInput, flowInput.recordsToRollup[0], sObjectType, flowInput.oldRecordsToRollup);
 
         Rollup__mdt meta = transformFlowInputToRollupMetadata(flowInput, rollupContext, sObjectType);
-        String key = String.valueOf(meta);
-        if (keyToInputWrapper.containsKey(key)) {
-          FlowInputWrapper wrapper = keyToInputWrapper.get(key);
+        if (metaToInputWrapper.containsKey(meta)) {
+          FlowInputWrapper wrapper = metaToInputWrapper.get(meta);
           if (wrapper.rollupMetadata.contains(meta)) {
             wrapper.flowInput.recordsToRollup.addAll(flowInput.recordsToRollup);
-            wrapper.oldFlowRecords.putAll(flowInput.oldRecordsToRollup);
+            wrapper.flowInput.oldRecordsToRollup.addAll(flowInput.oldRecordsToRollup);
           } else {
             wrapper.rollupMetadata.add(meta);
           }
         } else {
-          keyToInputWrapper.put(key, new FlowInputWrapper(flowInput, rollupContext, sObjectType, meta));
+          metaToInputWrapper.put(meta, new FlowInputWrapper(flowInput, rollupContext, sObjectType, meta));
         }
       }
 
       flowOutputs.add(flowOutput);
     }
 
-    for (String key : keyToInputWrapper.keySet()) {
-      FlowInputWrapper wrapper = keyToInputWrapper.get(key);
+    Map<Integer, List<SObject>> hashCodeToCalcItems = new Map<Integer, List<SObject>>();
+    for (Rollup__mdt key : metaToInputWrapper.keySet()) {
+      FlowInputWrapper wrapper = metaToInputWrapper.get(key);
+      // here we clone the list because it can get winnowed in "processCustomMetadata"
       List<Rollup__mdt> metas = new List<Rollup__mdt>(wrapper.rollupMetadata);
-      wrapper.flowInput.recordsToRollup = CALC_ITEM_REPLACER.replace(wrapper.flowInput.recordsToRollup, metas);
-      if (wrapper.oldFlowRecords?.isEmpty() == false) {
-        wrapper.oldFlowRecords = new Map<Id, SObject>(CALC_ITEM_REPLACER.replace(wrapper.oldFlowRecords.values(), metas));
-      }
-      processCustomMetadata(
-        localRollups,
-        metas,
-        wrapper.flowInput.recordsToRollup,
-        wrapper.oldFlowRecords,
-        new Set<String>(),
-        wrapper.rollupContext,
-        fromInvocable
-      );
+      wrapper.flowInput.recordsToRollup = replaceFlowInputCalcItemsIfNecessary(hashCodeToCalcItems, wrapper.flowInput.recordsToRollup, metas);
+      wrapper.flowInput.oldRecordsToRollup = replaceFlowInputCalcItemsIfNecessary(hashCodeToCalcItems, wrapper.flowInput.oldRecordsToRollup, metas);
+      Map<Id, SObject> oldFlowRecords = new Map<Id, SObject>(wrapper.flowInput.oldRecordsToRollup);
+      processCustomMetadata(localRollups, metas, wrapper.flowInput.recordsToRollup, oldFlowRecords, new Set<String>(), wrapper.rollupContext, fromInvocable);
 
       if (metas.isEmpty() == false) {
-        Rollup rollupConductor = getRollup(metas, wrapper.sObjectType, wrapper.flowInput.recordsToRollup, wrapper.oldFlowRecords, null, fromInvocable);
+        Rollup rollupConductor = getRollup(metas, wrapper.sObjectType, wrapper.flowInput.recordsToRollup, oldFlowRecords, null, fromInvocable);
         String logMessage = 'adding invocable rollup to list:';
         if (wrapper.flowInput.deferProcessing) {
           logMessage = 'deferring processing for rollup:';
@@ -1939,6 +1928,20 @@ global without sharing virtual class Rollup {
     }
   }
 
+  private static List<SObject> replaceFlowInputCalcItemsIfNecessary(
+    Map<Integer, List<SObject>> hashCodeToCalcItems,
+    List<SObject> calcItems,
+    List<Rollup__mdt> metas
+  ) {
+    Integer priorHashCode = calcItems.hashCode();
+    if (hashCodeToCalcItems.containsKey(priorHashCode)) {
+      return hashCodeToCalcItems.get(priorHashCode);
+    }
+    calcItems = CALC_ITEM_REPLACER.replace(calcItems, metas);
+    hashCodeToCalcItems.put(priorHashCode, calcItems);
+    return calcItems;
+  }
+
   private static String batch(List<Rollup> rollups, InvocationPoint invokePoint) {
     Rollup conductor;
     if (rollups.isEmpty()) {
@@ -2154,9 +2157,9 @@ global without sharing virtual class Rollup {
     }
   }
 
-  private static String getFlowRollupContext(FlowInput firstInput, SObject firstRecord, SObjectType sObjectType, Map<Id, SObject> oldFlowRecords) {
+  private static String getFlowRollupContext(FlowInput firstInput, SObject firstRecord, SObjectType sObjectType, List<SObject> oldFlowRecords) {
     String flowContext = firstInput.rollupContext.toUpperCase();
-    if (String.isBlank(flowContext) || flowContext == 'UPSERT' && oldFlowRecords.containsKey(firstRecord.Id) == false) {
+    if (String.isBlank(flowContext) || flowContext == 'UPSERT' && oldFlowRecords.isEmpty()) {
       flowContext = 'INSERT';
     } else if (flowContext == 'UPSERT') {
       flowContext = 'UPDATE';

--- a/rollup/core/classes/RollupCalcItemReplacer.cls
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls
@@ -102,8 +102,10 @@ public without sharing class RollupCalcItemReplacer {
     Map<String, Object> populatedFields = firstItem.getPopulatedFieldsAsMap();
     List<String> optionalWhereClauses = new List<String>();
     Set<String> additionalQueryFields = new Set<String>();
-    RollupEvaluator.WhereFieldEvaluator eval = this.metaToEval.get(metadata);
-    this.processWhereClauseForDownstreamEvals(optionalWhereClauses, additionalQueryFields, sObjectType, typeField, owner, metadata, eval);
+    if (this.metaToEval.containsKey(metadata)) {
+      RollupEvaluator.WhereFieldEvaluator eval = this.metaToEval.get(metadata);
+      this.processWhereClauseForDownstreamEvals(optionalWhereClauses, additionalQueryFields, sObjectType, typeField, owner, metadata, eval);
+    }
 
     Boolean hasOwnerPrepolulated = populatedFields.containsKey('Owner');
     Boolean hasTypePrepopulated = populatedFields.containsKey('Type');

--- a/rollup/core/classes/RollupCalcItemReplacer.cls
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls
@@ -224,7 +224,8 @@ public without sharing class RollupCalcItemReplacer {
 
   private void appendUpdatedParentFields(List<SObject> calcItems, Map<Id, SObject> idToCalcItemsWithParentFields) {
     Map<String, SObjectField> fieldNameToFieldToken = calcItems[0].getSObjectType().getDescribe().fields.getMap();
-    for (SObject calcItem : calcItems) {
+    for (Integer index = 0; index < calcItems.size(); index++) {
+      SObject calcItem = calcItems[index];
       SObject calcItemWIthUpdatedParentField = idToCalcItemsWithParentFields.get(calcItem.Id);
       if (calcItemWIthUpdatedParentField == null) {
         continue;
@@ -234,7 +235,12 @@ public without sharing class RollupCalcItemReplacer {
           DescribeFieldResult fieldToken = fieldNameToFieldToken.get(fieldName).getDescribe();
           Boolean isAcceptableField = fieldToken.getReferenceTo().isEmpty() == false && fieldToken.getName() != 'Id';
           if (isAcceptableField && fieldToken.isNamePointing() == false) {
-            calcItem.putSObject(fieldToken.getRelationshipName(), calcItemWIthUpdatedParentField.getSObject(fieldToken.getRelationshipName()));
+            try {
+              calcItem.putSObject(fieldToken.getRelationshipName(), calcItemWIthUpdatedParentField.getSObject(fieldToken.getRelationshipName()));
+            } catch (SObjectException ex) {
+              // avoids "System.SObjectException: Relationship { relationship name } is not editable"
+              calcItems.set(index, this.serializeReplace(calcItem, calcItemWithUpdatedParentField, fieldToken.getRelationshipName()));
+            }
           } else if (isAcceptableField) {
             // polymorphic parent fields that are returned from SOQL can get retrieved via .getSObject,
             // but can't be appended via .putSObject without reinitializing the parent object to its actual type
@@ -250,5 +256,11 @@ public without sharing class RollupCalcItemReplacer {
         }
       }
     }
+  }
+
+  private SObject serializeReplace(SObject calcItem, SObject calcItemWithUpdatedParent, String relationshipName) {
+    Map<String, Object> deserialized = (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(calcItem));
+    deserialized.put(relationshipName, calcItemWithUpdatedParent.getSObject(relationshipName));
+    return (SObject) JSON.deserialize(JSON.serialize(deserialized), SObject.class);
   }
 }

--- a/rollup/core/classes/RollupCalcItemReplacer.cls
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls
@@ -230,8 +230,20 @@ public without sharing class RollupCalcItemReplacer {
       for (String fieldName : calcItemWIthUpdatedParentField.getPopulatedFieldsAsMap().keySet()) {
         if (fieldNameToFieldToken.containsKey(fieldName)) {
           DescribeFieldResult fieldToken = fieldNameToFieldToken.get(fieldName).getDescribe();
-          if (fieldToken.getReferenceTo().isEmpty() == false && fieldToken.isNamePointing() == false && fieldToken.getName() != 'Id') {
+          Boolean isAcceptableField = fieldToken.getReferenceTo().isEmpty() == false && fieldToken.getName() != 'Id';
+          if (isAcceptableField && fieldToken.isNamePointing() == false) {
             calcItem.putSObject(fieldToken.getRelationshipName(), calcItemWIthUpdatedParentField.getSObject(fieldToken.getRelationshipName()));
+          } else if (isAcceptableField) {
+            // polymorphic parent fields that are returned from SOQL can get retrieved via .getSObject,
+            // but can't be appended via .putSObject without reinitializing the parent object to its actual type
+            // this is because they are returned with type "Name", and avoids the dreaded:
+            // "System.SObjectException: Illegal assignment from Name to { the calcItem type }"
+            SObject parentFieldObject = calcItemWIthUpdatedParentField.getSObject(fieldToken.getRelationshipName());
+            SObject replacementObject = parentFieldObject.Id.getSObjectType().newSObject();
+            for (String populatedFieldName : parentFieldObject.getPopulatedFieldsAsMap().keySet()) {
+              replacementObject.put(populatedFieldName, parentFieldObject.get(populatedFieldName));
+            }
+            calcItem.putSObject(fieldToken.getRelationshipName(), replacementObject);
           }
         }
       }

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger extends Rollup implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.3.23';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.3.24';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -53,7 +53,7 @@ public without sharing virtual class RollupLogger extends Rollup implements ILog
   }
 
   protected String getBaseLoggingMessage() {
-    return 'Rollup: ' + CURRENT_VERSION_NUMBER + ' ';
+    return 'Rollup ' + CURRENT_VERSION_NUMBER + ': ';
   }
 
   @SuppressWarnings('PMD.AvoidDebugStatements')

--- a/scripts/generatePackage.ps1
+++ b/scripts/generatePackage.ps1
@@ -90,7 +90,7 @@ function Get-Next-Package-Version() {
     ConvertTo-Json -InputObject $sfdxProjectJson -Depth 4 | Set-Content -Path $sfdxProjectJsonPath -NoNewline
     # sfdx-project.json is ignored by default; use another file as the --ignore-path to force prettier
     # to run on it
-    npx run prettier --write $sfdxProjectJsonPath --tab-width 4 --ignore-path .forceignore
+    npx prettier --write $sfdxProjectJsonPath --tab-width 4 --ignore-path ..\.forceignore
   }
   if ("apex-rollup" -eq $packageName) {
     $versionNumberToWrite = $currentPackageVersion.Remove($currentPackageVersion.LastIndexOf(".0"))

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,7 +5,7 @@
             "package": "apex-rollup",
             "path": "rollup",
             "versionName": "Fixing BigDecimal issues, standardizing plugin infrastructure",
-            "versionNumber": "1.3.23.0",
+            "versionNumber": "1.3.24.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -106,6 +106,7 @@
         "apex-rollup@1.3.20-0": "04t6g000008SiaJAAS",
         "apex-rollup@1.3.21-0": "04t6g000008SigrAAC",
         "apex-rollup@1.3.22-0": "04t6g000008SijvAAC",
-        "apex-rollup@1.3.23-0": "04t6g000008SitNAAS"
+        "apex-rollup@1.3.23-0": "04t6g000008SitNAAS",
+        "apex-rollup@1.3.24-0": "04t6g000008SitmAAC"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Fixing BigDecimal issues, standardizing plugin infrastructure",
+            "versionName": "Flow bugfixes, logging readability improvements, some tooling work related to plugins",
             "versionNumber": "1.3.24.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -107,6 +107,6 @@
         "apex-rollup@1.3.21-0": "04t6g000008SigrAAC",
         "apex-rollup@1.3.22-0": "04t6g000008SijvAAC",
         "apex-rollup@1.3.23-0": "04t6g000008SitNAAS",
-        "apex-rollup@1.3.24-0": "04t6g000008SitmAAC"
+        "apex-rollup@1.3.24-0": "04t6g000008Siu6AAC"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -107,6 +107,6 @@
         "apex-rollup@1.3.21-0": "04t6g000008SigrAAC",
         "apex-rollup@1.3.22-0": "04t6g000008SijvAAC",
         "apex-rollup@1.3.23-0": "04t6g000008SitNAAS",
-        "apex-rollup@1.3.24-0": "04t6g000008Siu6AAC"
+        "apex-rollup@1.3.24-0": "04t6g000008SiuBAAS"
     }
 }


### PR DESCRIPTION
* Fixes several issues raised by @solo-1234 related to rollups invoked by flow - ensures REFRESH rollups are fired properly when parent-level filtering is used; fixes issue with parent-level filtering where multiple rollups are present _and_ the reason the rollup is firing is due to the old item matching and the new item not matching
* Fixes #232 by working around a thorny `SObjectException` related to non-reparentable child records. The fix for this is _not_ as performant as I would like, but it may be the only workaround for now
* Tooling work - updates to base logging string for increased readability; tweaked the way packages are created to increase readability of pwsh output log