### PR TITLE
Adding check for 'Avg' operation

### DIFF
--- a/scripts/convert-dlrs-rules.apex
+++ b/scripts/convert-dlrs-rules.apex
@@ -26,6 +26,9 @@ for (dlrs__LookupRollupSummary2__mdt dlrsRule : dlrs__LookupRollupSummary2__mdt.
 
   String operation;
   switch on dlrsRule.dlrs__AggregateOperation__c {
+    when 'Avg' {
+      operation = 'AVERAGE';
+    }
     when 'Concatenate' {
       operation = 'CONCAT';
     }


### PR DESCRIPTION
I had a couple errors when running the convert-dlrs-rules script, since DLRS uses the operator 'Avg' and Apex Rollups uses 'AVERAGE'.  I added a check where you're converting other operations to be compatible.  I don't think any tests exist for scripts so it's just this update.  
