### PR TITLE
V1.4.1 - Spring 22 & FIRST/LAST ordering fix for Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SjG5AAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SjGKAA0">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SjG5AAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SjGKAA0">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sj8oAAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SjFqAAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sj8oAAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SjFqAAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SjFqAAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SjG5AAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SjFqAAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SjG5AAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,12 +1,14 @@
 coverage:
-    status:
-        project:
-            default:
-                target: 75 # otherwise any regression in code coverage fails the build
-                threshold: 2%
-                if_ci_failed: success
-                flags:
-                    - Apex
-                    - LWC
-        patch: off
+  status:
+    project:
+      default:
+        target: 90
+        threshold: 2%
+        if_ci_failed: success
+        flags:
+          - Apex
+          - LWC
+    patch: off
 github_checks: false
+comment:
+  behavior: new

--- a/extra-tests/classes/CustomMetadataDrivenTests.cls-meta.xml
+++ b/extra-tests/classes/CustomMetadataDrivenTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/InvocableDrivenTests.cls-meta.xml
+++ b/extra-tests/classes/InvocableDrivenTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupCalcItemReplacerTests.cls-meta.xml
+++ b/extra-tests/classes/RollupCalcItemReplacerTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupCalculatorTests.cls-meta.xml
+++ b/extra-tests/classes/RollupCalculatorTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupCurrencyInfoTests.cls-meta.xml
+++ b/extra-tests/classes/RollupCurrencyInfoTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupDateLiteralTests.cls-meta.xml
+++ b/extra-tests/classes/RollupDateLiteralTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>53.0</apiVersion>
+	<apiVersion>54.0</apiVersion>
 	<status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupEvaluatorTests.cls-meta.xml
+++ b/extra-tests/classes/RollupEvaluatorTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>53.0</apiVersion>
+  <apiVersion>54.0</apiVersion>
   <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupFieldInitializerTests.cls-meta.xml
+++ b/extra-tests/classes/RollupFieldInitializerTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupFinalizerTests.cls-meta.xml
+++ b/extra-tests/classes/RollupFinalizerTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupFirstLastSorterTests.cls
+++ b/extra-tests/classes/RollupFirstLastSorterTests.cls
@@ -104,9 +104,7 @@ private class RollupFirstLastSorterTests {
   static void shouldProperlySortPicklists() {
     RollupFirstLastSorter sorter = new RollupFirstLastSorter(
       Rollup.Op.FIRST,
-      new List<RollupOrderBy__mdt>{
-        new RollupOrderBy__mdt(Ranking__c = 0, FieldName__c = 'Industry')
-      }
+      new List<RollupOrderBy__mdt>{ new RollupOrderBy__mdt(Ranking__c = 0, FieldName__c = 'Industry') }
     );
 
     List<Schema.PicklistEntry> picklistEntries = Account.Industry.getDescribe().getPicklistValues();
@@ -114,9 +112,7 @@ private class RollupFirstLastSorterTests {
 
     for (Integer reverseIndex = picklistEntries.size() - 1; reverseIndex >= 0; reverseIndex--) {
       Schema.PicklistEntry entry = picklistEntries[reverseIndex];
-      accs.add(
-        new Account(Name = entry.getValue(), Industry = entry.getValue())
-      );
+      accs.add(new Account(Name = entry.getValue(), Industry = entry.getValue()));
     }
 
     sorter.sort(accs);
@@ -147,5 +143,20 @@ private class RollupFirstLastSorterTests {
 
     System.assertEquals(opp, opps[0]);
     System.assertEquals(second, opps[1]);
+  }
+
+  @IsTest
+  static void shouldNotFailOnBlankFieldNames() {
+    RollupFirstLastSorter sorter = new RollupFirstLastSorter(
+      Rollup.Op.FIRST,
+      new List<RollupOrderBy__mdt>{ new RollupOrderBy__mdt(Ranking__c = 0, FieldName__c = 'Amount'), new RollupOrderBy__mdt(Ranking__c = 1, FieldName__c = '') }
+    );
+
+    Opportunity expectedFirstItem = new Opportunity(Amount = null);
+    Opportunity expectedSecondItem = new Opportunity(Amount = 1);
+    List<Opportunity> oppsToSort = new List<Opportunity>{ new Opportunity(Amount = 1), new Opportunity(Amount = 3), expectedSecondItem, expectedFirstItem };
+    sorter.sort(oppsToSort);
+
+    System.assert(true, 'Should make it here');
   }
 }

--- a/extra-tests/classes/RollupFirstLastSorterTests.cls
+++ b/extra-tests/classes/RollupFirstLastSorterTests.cls
@@ -1,7 +1,7 @@
 @IsTest
 private class RollupFirstLastSorterTests {
   @IsTest
-  static void shouldOrderByTwoFields() {
+  static void shouldOrderByTwoFieldsFirst() {
     RollupFirstLastSorter sorter = new RollupFirstLastSorter(
       Rollup.Op.FIRST,
       new List<RollupOrderBy__mdt>{
@@ -17,6 +17,31 @@ private class RollupFirstLastSorterTests {
       new Opportunity(Amount = 1, CloseDate = System.today()),
       // this record should essentially be thrown out of sorting since it "loses" on the first ordering,
       // which is on Amount
+      new Opportunity(Amount = 3, CloseDate = severalDaysAgo.addDays(-1)),
+      expectedSecondItem,
+      expectedFirstItem
+    };
+    sorter.sort(oppsToSort);
+
+    System.assertEquals(expectedFirstItem, oppsToSort[0]);
+    System.assertEquals(expectedSecondItem, oppsToSort[1]);
+  }
+
+  @IsTest
+  static void shouldOrderByTwoFieldsLast() {
+    RollupFirstLastSorter sorter = new RollupFirstLastSorter(
+      Rollup.Op.LAST,
+      new List<RollupOrderBy__mdt>{
+        new RollupOrderBy__mdt(Ranking__c = 0, FieldName__c = 'Amount'),
+        new RollupOrderBy__mdt(Ranking__c = 1, FieldName__c = 'CloseDate')
+      }
+    );
+
+    Date severalDaysAgo = System.today().addDays(-2);
+    Opportunity expectedFirstItem = new Opportunity(Amount = 6, CloseDate = severalDaysAgo);
+    Opportunity expectedSecondItem = new Opportunity(Amount = 4, CloseDate = severalDaysAgo);
+    List<Opportunity> oppsToSort = new List<Opportunity>{
+      new Opportunity(Amount = 1, CloseDate = System.today()),
       new Opportunity(Amount = 3, CloseDate = severalDaysAgo.addDays(-1)),
       expectedSecondItem,
       expectedFirstItem

--- a/extra-tests/classes/RollupFirstLastSorterTests.cls-meta.xml
+++ b/extra-tests/classes/RollupFirstLastSorterTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupFlowBulkProcessorTests.cls-meta.xml
+++ b/extra-tests/classes/RollupFlowBulkProcessorTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupFlowFullRecalcDispatcherTests.cls-meta.xml
+++ b/extra-tests/classes/RollupFlowFullRecalcDispatcherTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupFullRecalcTests.cls-meta.xml
+++ b/extra-tests/classes/RollupFullRecalcTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupIntegrationTests.cls-meta.xml
+++ b/extra-tests/classes/RollupIntegrationTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupLoggerTests.cls-meta.xml
+++ b/extra-tests/classes/RollupLoggerTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupParentResetProcessorTests.cls-meta.xml
+++ b/extra-tests/classes/RollupParentResetProcessorTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupQueryBuilderTests.cls-meta.xml
+++ b/extra-tests/classes/RollupQueryBuilderTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupRecursionItemTests.cls-meta.xml
+++ b/extra-tests/classes/RollupRecursionItemTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupRelationshipFieldFinderTests.cls-meta.xml
+++ b/extra-tests/classes/RollupRelationshipFieldFinderTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>53.0</apiVersion>
+  <apiVersion>54.0</apiVersion>
   <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupSObjectUpdaterTests.cls-meta.xml
+++ b/extra-tests/classes/RollupSObjectUpdaterTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupTestUtils.cls-meta.xml
+++ b/extra-tests/classes/RollupTestUtils.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupTests.cls-meta.xml
+++ b/extra-tests/classes/RollupTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/flows/Rollup_Integration_Multiple_Deferred_Case_Rollups.flow-meta.xml
+++ b/extra-tests/flows/Rollup_Integration_Multiple_Deferred_Case_Rollups.flow-meta.xml
@@ -501,7 +501,7 @@
         </inputParameters>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </actionCalls>
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <assignments>
         <name>Add_case_and_prior_case_to_collections</name>
         <label>Add case and prior case to collections</label>

--- a/extra-tests/flows/Rollup_Integration_Parent_Where_Clause_Filtering.flow-meta.xml
+++ b/extra-tests/flows/Rollup_Integration_Parent_Where_Clause_Filtering.flow-meta.xml
@@ -85,7 +85,7 @@
         </inputParameters>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </actionCalls>
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <assignments>
         <name>Add_to_collections</name>
         <label>Add to collections</label>

--- a/extra-tests/triggers/AccountTrigger.trigger-meta.xml
+++ b/extra-tests/triggers/AccountTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>53.0</apiVersion>
+  <apiVersion>54.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/extra-tests/triggers/ApplicationLogTrigger.trigger-meta.xml
+++ b/extra-tests/triggers/ApplicationLogTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>53.0</apiVersion>
+  <apiVersion>54.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/extra-tests/triggers/ApplicationTrigger.trigger-meta.xml
+++ b/extra-tests/triggers/ApplicationTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>53.0</apiVersion>
+  <apiVersion>54.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/extra-tests/triggers/ParentApplicationTrigger.trigger-meta.xml
+++ b/extra-tests/triggers/ParentApplicationTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>53.0</apiVersion>
+  <apiVersion>54.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/extra-tests/triggers/RollupChildTrigger.trigger-meta.xml
+++ b/extra-tests/triggers/RollupChildTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>53.0</apiVersion>
+  <apiVersion>54.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/plugins/CustomObjectRollupLogger/classes/RollupCustomObjectLogger.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/classes/RollupCustomObjectLogger.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/classes/RollupLogBatchPurger.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/classes/RollupLogBatchPurger.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/classes/RollupLogControl.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/classes/RollupLogControl.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/classes/RollupLogEventHandler.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/classes/RollupLogEventHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/classes/RollupPurgerSchedulable.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/classes/RollupPurgerSchedulable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/tests/RollupCustomObjectLoggerTests.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/tests/RollupCustomObjectLoggerTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/tests/RollupLogBatchPurgerTests.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/tests/RollupLogBatchPurgerTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/triggers/RollupLogEventTrigger.trigger-meta.xml
+++ b/plugins/CustomObjectRollupLogger/triggers/RollupLogEventTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>53.0</apiVersion>
+  <apiVersion>54.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/plugins/NebulaLogger/classes/RollupNebulaLoggerAdapter.cls-meta.xml
+++ b/plugins/NebulaLogger/classes/RollupNebulaLoggerAdapter.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/NebulaLogger/tests/RollupNebulaLoggerAdapterTest.cls-meta.xml
+++ b/plugins/NebulaLogger/tests/RollupNebulaLoggerAdapterTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/RollupCallback/README.md
+++ b/plugins/RollupCallback/README.md
@@ -43,7 +43,7 @@ export default class RollupChangeNotifier extends LightningElement {
 <!-- in rollupChangeNotifier.js-meta.xml -->
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Rollup Change Notifier</masterLabel>
     <targets>

--- a/plugins/RollupCallback/classes/RollupDispatch.cls-meta.xml
+++ b/plugins/RollupCallback/classes/RollupDispatch.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/RollupCallback/tests/RollupDispatchTests.cls-meta.xml
+++ b/plugins/RollupCallback/tests/RollupDispatchTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/app/lwc/recalculateParentRollupFlexipage/recalculateParentRollupFlexipage.js-meta.xml
+++ b/rollup/app/lwc/recalculateParentRollupFlexipage/recalculateParentRollupFlexipage.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Recalc Rollups Button</masterLabel>
     <targets>

--- a/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js-meta.xml
+++ b/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
       <target>lightning__AppPage</target>

--- a/rollup/app/lwc/rollupOrderBy/rollupOrderBy.js-meta.xml
+++ b/rollup/app/lwc/rollupOrderBy/rollupOrderBy.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/rollup/app/lwc/rollupUtils/rolupUtils.js-meta.xml
+++ b/rollup/app/lwc/rollupUtils/rolupUtils.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -2369,6 +2369,9 @@ global without sharing virtual class Rollup {
       if (rollupMetadata.IsFullRecordSet__c != true && isFullRecalcOp(getBaseOperationName(rollupMetadata.RollupOperation__c))) {
         rollupMetadata.IsFullRecordSet__c = true;
       }
+      if (rollupOp.name().contains(Op.FIRST.name()) || rollupOp.name().contains(Op.LAST.name())) {
+        rollupMetadata = getFirstLastMetadata(rollupMetadata);
+      }
 
       RollupControl__mdt localControl;
       if (rollupMetadata.RollupControl__c != null) {
@@ -2399,6 +2402,33 @@ global without sharing virtual class Rollup {
     }
     rollupConductor.isNoOp = rollupConductor.rollups.isEmpty();
     return rollupConductor;
+  }
+
+  private static Rollup__mdt getFirstLastMetadata(Rollup__mdt meta) {
+    List<RollupOrderBy__mdt> replacementOrderBys;
+    if (meta.RollupOrderBys__r.isEmpty() && meta.OrderByFirstLast__c?.contains(',') == true) {
+      List<String> unparsedOrderBys = meta.OrderByFirstLast__c.split(',');
+      replacementOrderBys = new List<RollupOrderBy__mdt>();
+      for (Integer index = 0; index < unparsedOrderBys.size(); index++) {
+        String unparsedOrderBy = unparsedOrderBys[index];
+        RollupOrderBy__mdt orderBy = new RollupOrderBy__mdt(Ranking__c = index, FieldName__c = unparsedOrderBy.substringBefore(' '));
+        Boolean isAscendingSortOrder = unparsedOrderBy.containsIgnoreCase(RollupMetaPicklists.SortOrder.Ascending);
+        if (isAscendingSortOrder || unparsedOrderBy.containsIgnoreCase(RollupMetaPicklists.SortOrder.Descending)) {
+          orderBy.SortOrder__c = isAscendingSortOrder ? RollupMetaPicklists.SortOrder.Ascending : RollupMetaPicklists.SortOrder.Descending;
+        }
+        Boolean isAscendingNullSortOrder = unparsedOrderBy.containsIgnoreCase(RollupMetaPicklists.NullSortOrder.NullsFirst);
+        if (isAscendingNullSortOrder || unparsedOrderBy.containsIgnoreCase(RollupMetaPicklists.NullSortOrder.NullsLast)) {
+          orderBy.NullSortOrder__c = isAscendingNullSortOrder ? RollupMetaPicklists.NullSortOrder.NullsFirst : RollupMetaPicklists.NullSortOrder.NullsLast;
+        }
+        replacementOrderBys.add(orderBy);
+      }
+    } else if (meta.RollupOrderBys__r.isEmpty()) {
+      replacementOrderBys = new List<RollupOrderBy__mdt>{ new RollupOrderBy__mdt(Ranking__c = 0, FieldName__c = meta.RollupFieldOnCalcItem__c) };
+    }
+    if (replacementOrderBys != null) {
+      meta = Rollup.appendOrderByMetadata(meta, replacementOrderBys);
+    }
+    return meta;
   }
 
   private static Boolean isFullRecalcOp(String baseOperationName) {

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -257,7 +257,7 @@ global without sharing virtual class Rollup {
   }
 
   public virtual String runCalc() {
-    RollupLogger.Instance.log('no-op', LoggingLevel.DEBUG);
+    RollupLogger.Instance.log('no-op!', LoggingLevel.ERROR);
     return 'Not implemented';
   }
 
@@ -305,12 +305,12 @@ global without sharing virtual class Rollup {
   }
 
   protected virtual Map<String, String> customizeToStringEntries(Map<String, String> props) {
+    this.addToMap(props, 'Rollup Metadata', this.metadata);
+    this.addToMap(props, 'Rollup Control', this.rollupControl);
     this.addToMap(props, 'Calc Items', this.calcItems?.size() > 10 ? (Object) '10 items or more ...' : (Object) this.calcItems);
     if (this.oldCalcItems?.isEmpty() == false) {
       this.addToMap(props, 'Old Calc Items', this.oldCalcItems.size() > 10 ? (Object) '10 items or more ...' : (Object) this.oldCalcItems);
     }
-    this.addToMap(props, 'Rollup Metadata', this.metadata);
-    this.addToMap(props, 'Rollup Control', this.rollupControl);
     this.addToMap(props, 'Query Count', this.queryCount);
     return props;
   }
@@ -1574,7 +1574,8 @@ global without sharing virtual class Rollup {
     Boolean hasExceededQueryRowLimit = control?.MaxLookupRowsBeforeBatching__c < Limits.getQueryRows();
     Boolean hasExceededHeapSizeLimit = (Limits.getLimitHeapSize() / 2) < Limits.getHeapSize();
     Boolean hasExceededDMLRowLimit = control?.MaxParentRowsUpdatedAtOnce__c < Limits.getDmlRows();
-    Boolean hasExceededCPUTimeLimit = Limits.getLimitCpuTime() - 3000 < Limits.getCpuTime();
+    Integer intervalTillTimeout = (System.isBatch() || System.isQueueable()) ? 10000 : 3000;
+    Boolean hasExceededCPUTimeLimit = Limits.getLimitCpuTime() - intervalTillTimeout < Limits.getCpuTime();
     Boolean hasExceededLimits =
       hasExceededQueryNumberLimit ||
       hasExceededQueryRowLimit ||

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1474,6 +1474,7 @@ global without sharing virtual class Rollup {
    * Credit for this method (with some tweaking) goes to: https://github.com/tsalb
    */
   global static Rollup__mdt appendOrderByMetadata(Rollup__mdt meta, List<RollupOrderBy__mdt> children) {
+    meta.OrderByFirstLast__c = null;
     String serializedMeta = JSON.serialize(meta).removeEnd('}');
 
     JSONGenerator gen = JSON.createGenerator(false);
@@ -2410,8 +2411,9 @@ global without sharing virtual class Rollup {
       List<String> unparsedOrderBys = meta.OrderByFirstLast__c.split(',');
       replacementOrderBys = new List<RollupOrderBy__mdt>();
       for (Integer index = 0; index < unparsedOrderBys.size(); index++) {
-        String unparsedOrderBy = unparsedOrderBys[index];
-        RollupOrderBy__mdt orderBy = new RollupOrderBy__mdt(Ranking__c = index, FieldName__c = unparsedOrderBy.substringBefore(' '));
+        String unparsedOrderBy = unparsedOrderBys[index].trim();
+        String fieldName = unparsedOrderBy.indexOf(' ') > -1 ? unparsedOrderBy.substringBefore(' ') : unparsedOrderBy;
+        RollupOrderBy__mdt orderBy = new RollupOrderBy__mdt(Ranking__c = index, FieldName__c = fieldName);
         Boolean isAscendingSortOrder = unparsedOrderBy.containsIgnoreCase(RollupMetaPicklists.SortOrder.Ascending);
         if (isAscendingSortOrder || unparsedOrderBy.containsIgnoreCase(RollupMetaPicklists.SortOrder.Descending)) {
           orderBy.SortOrder__c = isAscendingSortOrder ? RollupMetaPicklists.SortOrder.Ascending : RollupMetaPicklists.SortOrder.Descending;

--- a/rollup/core/classes/Rollup.cls-meta.xml
+++ b/rollup/core/classes/Rollup.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -925,9 +925,8 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       Boolean shouldRunSyncDeferred = this.getShouldRunSyncDeferred(rollup);
       Boolean couldRunSync =
         rollup.rollupControl.ShouldRunAs__c == RollupMetaPicklists.ShouldRunAs.Synchronous ||
-        // TODO - look into platform cache replacement for isRunningAsync; this was probably
-        // guilty of causing CPU timeouts on the main thread when an upstream rollup had already
-        // triggered the static bool to flip to true
+        // TODO - fix this, as it's been guilty of causing CPU timeouts on the main thread
+        // when an upstream rollup had already triggered the static bool to flip to true
         ((hasExceededCurrentRollupLimits(rollup.rollupControl) == false) && isRunningAsync) ||
         System.isBatch() && Limits.getQueueableJobs() >= Limits.getLimitQueueableJobs() ||
         this.isSingleRecordSyncUpdate(rollup);

--- a/rollup/core/classes/RollupAsyncProcessor.cls-meta.xml
+++ b/rollup/core/classes/RollupAsyncProcessor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupCalcItemReplacer.cls-meta.xml
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -1075,7 +1075,7 @@ public without sharing abstract class RollupCalculator {
         (metadata.FullRecalculationDefaultNumberValue__c != null
           ? (Object) metadata.FullRecalculationDefaultNumberValue__c
           : (Object) metadata.FullRecalculationDefaultStringValue__c),
-        getFirstLastMetadata(metadata),
+        metadata,
         lookupRecordKey,
         lookupKeyField
       );
@@ -1118,27 +1118,5 @@ public without sharing abstract class RollupCalculator {
       new RollupFirstLastSorter(this.op, this.metadata.RollupOrderBys__r).sort(calcItems);
       this.returnVal = calcItems.isEmpty() ? null : calcItems[0].get(this.opFieldOnCalcItem);
     }
-  }
-
-  private static Rollup__mdt getFirstLastMetadata(Rollup__mdt metadata) {
-    if (metadata.RollupOrderBys__r.isEmpty() && metadata.OrderByFirstLast__c?.contains(',') == true) {
-      List<String> unparsedOrderBys = metadata.OrderByFirstLast__c.split(',');
-      for (Integer index = 0; index < unparsedOrderBys.size(); index++) {
-        String unparsedOrderBy = unparsedOrderBys[index];
-        RollupOrderBy__mdt orderBy = new RollupOrderBy__mdt(Ranking__c = index, FieldName__c = unparsedOrderBy.substringBefore(' '));
-        Boolean isAscendingSortOrder = unparsedOrderBy.containsIgnoreCase(RollupMetaPicklists.SortOrder.Ascending);
-        if (isAscendingSortOrder || unparsedOrderBy.containsIgnoreCase(RollupMetaPicklists.SortOrder.Descending)) {
-          orderBy.SortOrder__c = isAscendingSortOrder ? RollupMetaPicklists.SortOrder.Ascending : RollupMetaPicklists.SortOrder.Descending;
-        }
-        Boolean isAscendingNullSortOrder = unparsedOrderBy.containsIgnoreCase(RollupMetaPicklists.NullSortOrder.NullsFirst);
-        if (isAscendingNullSortOrder || unparsedOrderBy.containsIgnoreCase(RollupMetaPicklists.NullSortOrder.NullsLast)) {
-          orderBy.NullSortOrder__c = isAscendingNullSortOrder ? RollupMetaPicklists.NullSortOrder.NullsFirst : RollupMetaPicklists.NullSortOrder.NullsLast;
-        }
-        metadata.RollupOrderBys__r.add(orderBy);
-      }
-    } else if (metadata.RollupOrderBys__r.isEmpty()) {
-      metadata = Rollup.appendOrderByMetadata(metadata, new List<RollupOrderBy__mdt>{ new RollupOrderBy__mdt(Ranking__c = 0, FieldName__c = metadata.RollupFieldOnCalcItem__c) });
-    }
-    return metadata;
   }
 }

--- a/rollup/core/classes/RollupCalculator.cls-meta.xml
+++ b/rollup/core/classes/RollupCalculator.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupComparer.cls-meta.xml
+++ b/rollup/core/classes/RollupComparer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>53.0</apiVersion>
+	<apiVersion>54.0</apiVersion>
 	<status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupCurrencyInfo.cls-meta.xml
+++ b/rollup/core/classes/RollupCurrencyInfo.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>53.0</apiVersion>
+	<apiVersion>54.0</apiVersion>
 	<status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupDateLiteral.cls-meta.xml
+++ b/rollup/core/classes/RollupDateLiteral.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>53.0</apiVersion>
+	<apiVersion>54.0</apiVersion>
 	<status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupDeferredFullRecalcProcessor.cls-meta.xml
+++ b/rollup/core/classes/RollupDeferredFullRecalcProcessor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>53.0</apiVersion>
+	<apiVersion>54.0</apiVersion>
 	<status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupEvaluator.cls-meta.xml
+++ b/rollup/core/classes/RollupEvaluator.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>53.0</apiVersion>
+	<apiVersion>54.0</apiVersion>
 	<status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFieldInitializer.cls-meta.xml
+++ b/rollup/core/classes/RollupFieldInitializer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFinalizer.cls-meta.xml
+++ b/rollup/core/classes/RollupFinalizer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFirstLastSorter.cls
+++ b/rollup/core/classes/RollupFirstLastSorter.cls
@@ -45,10 +45,18 @@ public without sharing class RollupFirstLastSorter extends RollupComparer {
     return orderByOptions;
   }
 
-  private Integer getSortRanking(SObject objOne, SObject objTwo, RollupOrderBy__mdt orderByOption, RollupFieldInitializer.PicklistController picklistController) {
+  private Integer getSortRanking(
+    SObject objOne,
+    SObject objTwo,
+    RollupOrderBy__mdt orderByOption,
+    RollupFieldInitializer.PicklistController picklistController
+  ) {
+    Integer returnVal = 0;
+    if (String.isBlank(orderByOption.FieldName__c)) {
+      return returnVal;
+    }
     Object potentialFirstVal = this.getFieldValue(objOne, orderByOption.FieldName__c);
     Object potentialSecondVal = this.getFieldValue(objTwo, orderByOption.FieldName__c);
-    Integer returnVal = 0;
     // (from the developer docs): "Default [sort] order is ascending. By default, null values are sorted first."
     if (potentialFirstVal == null && potentialSecondVal != null) {
       return orderByOption.NullSortOrder__c == RollupMetaPicklists.NullSortOrder.NullsFirst ? this.moveTowardFrontOfList : this.moveTowardBackOfList;

--- a/rollup/core/classes/RollupFirstLastSorter.cls-meta.xml
+++ b/rollup/core/classes/RollupFirstLastSorter.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFlowBulkProcessor.cls-meta.xml
+++ b/rollup/core/classes/RollupFlowBulkProcessor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFlowBulkSaver.cls-meta.xml
+++ b/rollup/core/classes/RollupFlowBulkSaver.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFlowFullRecalcDispatcher.cls-meta.xml
+++ b/rollup/core/classes/RollupFlowFullRecalcDispatcher.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls-meta.xml
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger extends Rollup implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.4.0';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.4.1';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupLogger.cls-meta.xml
+++ b/rollup/core/classes/RollupLogger.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupMetaPicklists.cls-meta.xml
+++ b/rollup/core/classes/RollupMetaPicklists.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>53.0</apiVersion>
+  <apiVersion>54.0</apiVersion>
   <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupParentResetProcessor.cls-meta.xml
+++ b/rollup/core/classes/RollupParentResetProcessor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupPlugin.cls-meta.xml
+++ b/rollup/core/classes/RollupPlugin.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupQueryBuilder.cls-meta.xml
+++ b/rollup/core/classes/RollupQueryBuilder.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupRecursionItem.cls-meta.xml
+++ b/rollup/core/classes/RollupRecursionItem.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupRelationshipFieldFinder.cls-meta.xml
+++ b/rollup/core/classes/RollupRelationshipFieldFinder.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>53.0</apiVersion>
+  <apiVersion>54.0</apiVersion>
   <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupSObjectUpdater.cls-meta.xml
+++ b/rollup/core/classes/RollupSObjectUpdater.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupSchedulable.cls-meta.xml
+++ b/rollup/core/classes/RollupSchedulable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>53.0</apiVersion>
+  <apiVersion>54.0</apiVersion>
   <status>Active</status>
 </ApexClass>

--- a/rollup/core/objects/RollupControl__mdt/fields/BatchChunkSize__c.field-meta.xml
+++ b/rollup/core/objects/RollupControl__mdt/fields/BatchChunkSize__c.field-meta.xml
@@ -4,7 +4,7 @@
     <defaultValue>2000</defaultValue>
     <description>The amount of records passed into each batchable job in the event that Rollup batches. Default is 2000, which is the vanilla Salesforce default.</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText>The amount of records passed into each batchable job in the event that Rollup batches. Default is 2000, which is the vanilla Salesforce default.</inlineHelpText>
     <label>Batch Chunk Size</label>
     <precision>18</precision>

--- a/scripts/generatePackage.ps1
+++ b/scripts/generatePackage.ps1
@@ -124,7 +124,7 @@ function Generate() {
 
   Write-Host "Creating package version: $currentPackageVersion ..." -ForegroundColor White
 
-  $createPackageResult = npx sfdx force:package:version:create -p $packageName -w 30 -c -x -n $currentPackageVersion -a $currentPackageName --json | ConvertFrom-Json
+  $createPackageResult = npx sfdx force:package:version:create -p $packageName -w 30 -c -x -n $currentPackageVersion -a $currentPackageName --skipancestorcheck  --json | ConvertFrom-Json
   $currentPackageVersionId = $createPackageResult.result.SubscriberPackageVersionId
   if ($null -eq $currentPackageVersionId) {
     throw $createPackageResult

--- a/scripts/generatePackage.ps1
+++ b/scripts/generatePackage.ps1
@@ -124,7 +124,7 @@ function Generate() {
 
   Write-Host "Creating package version: $currentPackageVersion ..." -ForegroundColor White
 
-  $createPackageResult = npx sfdx force:package:version:create -p $packageName -w 30 -c -x -n $currentPackageVersion -a $currentPackageName --skipancestorcheck  --json | ConvertFrom-Json
+  $createPackageResult = npx sfdx force:package:version:create -p $packageName -w 30 -c -x -n $currentPackageVersion -a $currentPackageName --json | ConvertFrom-Json
   $currentPackageVersionId = $createPackageResult.result.SubscriberPackageVersionId
   if ($null -eq $currentPackageVersionId) {
     throw $createPackageResult

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -104,6 +104,6 @@
         "apex-rollup@1.3.24-0": "04t6g000008Siv4AAC",
         "apex-rollup@1.3.25-0": "04t6g000008Sj00AAC",
         "apex-rollup@1.4.0-0": "04t6g000008Sj8oAAC",
-        "apex-rollup@1.4.1-0": "04t6g000008SjFqAAK"
+        "apex-rollup@1.4.1-0": "04t6g000008SjG5AAK"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -103,6 +103,7 @@
         "apex-rollup@1.3.23-0": "04t6g000008SitNAAS",
         "apex-rollup@1.3.24-0": "04t6g000008Siv4AAC",
         "apex-rollup@1.3.25-0": "04t6g000008Sj00AAC",
-        "apex-rollup@1.4.0-0": "04t6g000008Sj8oAAC"
+        "apex-rollup@1.4.0-0": "04t6g000008Sj8oAAC",
+        "apex-rollup@1.4.1-0": "04t6g000008SjFqAAK"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,8 +5,8 @@
             "package": "apex-rollup",
             "path": "rollup",
             "versionName": "Introducing Rollup Order By CMDT to replace Rollup__mdt.OrderByFirstLast__c - allows for multiple fields when arranging ordering for FIRST and LAST rollups. Bugfixes for grandparent/hierarchy rollups.",
-            "versionNumber": "1.4.0.0",
-            "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
+            "versionNumber": "1.4.1.0",
+            "versionDescription": "Upgrading to Spring 22, Rollup Order By fixes",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
                 "path": "extra-tests"
@@ -82,7 +82,7 @@
     ],
     "namespace": "",
     "sfdcLoginUrl": "https://login.salesforce.com",
-    "sourceApiVersion": "53.0",
+    "sourceApiVersion": "54.0",
     "packageAliases": {
         "apex-rollup": "0Ho6g000000TNcOCAW",
         "Apex Rollup - Custom Logger": "0Ho6g000000Gn8ZCAS",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -104,6 +104,6 @@
         "apex-rollup@1.3.24-0": "04t6g000008Siv4AAC",
         "apex-rollup@1.3.25-0": "04t6g000008Sj00AAC",
         "apex-rollup@1.4.0-0": "04t6g000008Sj8oAAC",
-        "apex-rollup@1.4.1-0": "04t6g000008SjG5AAK"
+        "apex-rollup@1.4.1-0": "04t6g000008SjGKAA0"
     }
 }


### PR DESCRIPTION
* Spring 22 upgrading API version to 54.0
* Fixes issue reported by Katherine West where not all Flow invocable actions were getting their `RollupOrderBy__mdt` added to rollups correctly