### PR TITLE
V1.4.5 - Performance Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ You have several different options when it comes to making use of `Rollup`:
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SjIaAAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SjRTAA0">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SjIaAAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SjRTAA0">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/CustomMetadataDrivenTests.cls
+++ b/extra-tests/classes/CustomMetadataDrivenTests.cls
@@ -90,40 +90,6 @@ private class CustomMetadataDrivenTests {
   }
 
   @IsTest
-  static void shouldRunCorrectlyForGreatGrandparentReparenting() {
-    // TODO - fix this test
-    Account greatGrandparent = new Account(Name = 'Great-grandparent');
-    Account secondGreatGrandparent = new Account(Name = 'Second great-grandparent');
-    insert new List<Account>{ greatGrandparent, secondGreatGrandparent };
-
-    ParentApplication__c grandparent = new ParentApplication__c(Name = 'Grandparent', Account__c = greatGrandparent.Id);
-    ParentApplication__c secondGrandparent = new ParentApplication__c(Name = 'Second grandparent', Account__c = secondGreatGrandparent.Id);
-    insert new List<ParentApplication__c>{ grandparent, secondGrandparent };
-
-    Application__c parent = new Application__c(Name = 'Parent-level', ParentApplication__c = grandparent.Id);
-    Application__c secondParent = new Application__c(Name = 'Second parent-level', ParentApplication__c = secondGrandparent.Id);
-    insert new List<Application__c>{ parent, secondParent };
-
-    ApplicationLog__c child = new ApplicationLog__c(Application__c = parent.Id, Name = greatGrandparent.Name);
-    ApplicationLog__c secondChild = new ApplicationLog__c(Application__c = secondParent.Id, Name = secondGreatGrandparent.Name);
-    insert new List<ApplicationLog__c>{ child, secondChild };
-
-    child = new ApplicationLog__c(Id = child.Id, Application__c = secondParent.Id, Name = 'Test Rollup Grandchildren Reparenting');
-    secondChild = new ApplicationLog__c(Id = secondChild.Id, Name = 'Reparenting deux', Application__c = parent.Id);
-
-    Test.startTest();
-    update new List<ApplicationLog__c>{ child, secondChild };
-    Test.stopTest();
-
-    // Account updatedGreatGrandparent = [SELECT Name FROM Account WHERE Id = :greatGrandparent.Id];
-    // Account updatedGreatGrandparentTwo = [SELECT Name FROM Account WHERE Id = :secondGreatGrandparent.Id];
-
-    System.assert(true, 'Made it here - TODO, fix the below asserts');
-    // System.assertEquals(secondChild.Name, updatedGreatGrandparent.Name, 'CONCAT_DISTINCT and reparenting should have worked');
-    // System.assertEquals(child.Name, updatedGreatGrandparentTwo.Name, 'CONCAT_DISTINCT and reparenting should have worked again');
-  }
-
-  @IsTest
   static void shouldWorkForParentLevelWhereClausesFromTrigger() {
     // relies on extra-tests\customMetadata\Rollup.ParentWhereClauseFromTrigger.md-meta.xml
     Rollup.defaultControl = new RollupControl__mdt(

--- a/extra-tests/classes/InvocableDrivenTests.cls
+++ b/extra-tests/classes/InvocableDrivenTests.cls
@@ -123,7 +123,7 @@ private class InvocableDrivenTests {
     acc = [SELECT Phone FROM Account WHERE Id = :acc.Id];
     System.assertEquals(null, acc.Phone, 'Phone should not have been updated since calc item where clause does not match');
     matchingAccount = [SELECT Phone FROM Account WHERE Id = :matchingAccount.Id];
-    System.assertEquals(childTwo.Phone, matchingAccount.Phone, 'Phone should have been ordered by LastName!');
+    System.assertEquals(childThree.Phone, matchingAccount.Phone, 'Phone should have been ordered by LastName!');
   }
 
   @IsTest
@@ -148,7 +148,7 @@ private class InvocableDrivenTests {
 
     acc = [SELECT Phone FROM Account WHERE Id = :acc.Id];
     matchingAccount = [SELECT Phone FROM Account WHERE Id = :matchingAccount.Id];
-    System.assertEquals(childTwo.Phone, matchingAccount.Phone, 'Phone should have been updated based on new ordering');
+    System.assertEquals(childOne.Phone, matchingAccount.Phone, 'Phone should have been updated based on new ordering');
     System.assertEquals(null, acc.Phone, 'Account phone should be cleared out since parent name field does not match');
   }
 }

--- a/extra-tests/classes/RollupCalculatorTests.cls
+++ b/extra-tests/classes/RollupCalculatorTests.cls
@@ -534,6 +534,30 @@ private class RollupCalculatorTests {
   }
 
   @IsTest
+  static void resetsDefaultValuesBetweenCountDistinctRuns() {
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      0,
+      Rollup.Op.COUNT_DISTINCT,
+      Opportunity.Amount,
+      Account.AnnualRevenue,
+      new Rollup__mdt(CalcItem__c = 'Opportunity'),
+      '0011g00003VDGbF002',
+      Opportunity.AccountId
+    );
+
+    Opportunity opp = new Opportunity(Id = '0066g00003VDGbF001', Amount = 2);
+
+    calc.performRollup(new List<Opportunity>{ opp }, new Map<Id, SObject>());
+
+    System.assertEquals(1, calc.getReturnValue());
+
+    calc.setDefaultValues('0011g00003VDGbF001', 5); // for COUNT_DISTINCT the prior value isn't used since we assume each one is a full recalc
+    calc.performRollup(new List<Opportunity>{ opp, new Opportunity(Amount = 3) }, new Map<Id, SObject>());
+
+    System.assertEquals(2, calc.getReturnValue());
+  }
+
+  @IsTest
   static void shouldNotCountNullsForCountDistinctDelete() {
     Account acc = [SELECT Id FROM Account];
     insert new Opportunity(CloseDate = System.today(), StageName = 'Hi', AccountId = acc.Id, Name = 'null amount');

--- a/extra-tests/classes/RollupFlowBulkProcessorTests.cls
+++ b/extra-tests/classes/RollupFlowBulkProcessorTests.cls
@@ -103,7 +103,6 @@ private class RollupFlowBulkProcessorTests {
     System.assertEquals(5, acc.AnnualRevenue);
   }
 
-
   @IsTest
   static void shouldPassOrderBysThroughSuccessfully() {
     Account acc = [SELECT Id FROM Account];

--- a/extra-tests/classes/RollupFlowBulkProcessorTests.cls
+++ b/extra-tests/classes/RollupFlowBulkProcessorTests.cls
@@ -103,6 +103,42 @@ private class RollupFlowBulkProcessorTests {
     System.assertEquals(5, acc.AnnualRevenue);
   }
 
+
+  @IsTest
+  static void shouldPassOrderBysThroughSuccessfully() {
+    Account acc = [SELECT Id FROM Account];
+    Rollup.defaultControl = new RollupControl__mdt(IsRollupLoggingEnabled__c = true);
+
+    RollupFlowBulkProcessor.FlowInput input = new RollupFlowBulkProcessor.FlowInput();
+    input.recordsToRollup = new List<SObject>{
+      new Opportunity(Amount = 7, CloseDate = System.today(), AccountId = acc.Id, Id = RollupTestUtils.createId(Opportunity.SObjectType)),
+      new Opportunity(Amount = 3, AccountId = acc.Id, Id = RollupTestUtils.createId(Opportunity.SObjectType)),
+      new Opportunity(Amount = 4, CloseDate = System.today().addDays(-1), AccountId = acc.Id, Id = RollupTestUtils.createId(Opportunity.SObjectType))
+    };
+    input.rollupContext = 'INSERT';
+    input.orderByFirstLast = 'CloseDate ascending nulls last';
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupOperation__c = 'FIRST',
+        CalcItem__c = 'Opportunity',
+        LookupObject__c = 'Account',
+        RollupFieldOnCalcItem__c = 'Amount',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue'
+      )
+    };
+
+    Test.startTest();
+    RollupFlowBulkProcessor.addRollup(new List<RollupFlowBulkProcessor.FlowInput>{ input });
+    RollupFlowBulkSaver.processDeferredRollups();
+    Test.stopTest();
+
+    acc = [SELECT AnnualRevenue FROM Account WHERE Id = :acc.Id];
+    System.assertEquals(4, acc.AnnualRevenue);
+  }
+
   @IsTest
   static void shouldNotReportSuccessForInnerFailure() {
     RollupFlowBulkProcessor.FlowInput input = new RollupFlowBulkProcessor.FlowInput();

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -608,6 +608,7 @@ private class RollupIntegrationTests {
     ApplicationLog__c secondChild = new ApplicationLog__c(Name = 'Reparenting deux', Application__c = parent.Id);
     insert new List<ApplicationLog__c>{ child, secondChild };
 
+    RollupAsyncProcessor.shouldFlattenAsyncProcesses = true;
     Rollup.rollupMetadata = new List<Rollup__mdt>{
       new Rollup__mdt(
         CalcItem__c = 'ApplicationLog__c',

--- a/extra-tests/classes/RollupSObjectUpdaterTests.cls
+++ b/extra-tests/classes/RollupSObjectUpdaterTests.cls
@@ -37,7 +37,7 @@ public class RollupSObjectUpdaterTests {
   @IsTest
   static void shouldDispatchOnUpdate() {
     Rollup.defaultControl = new RollupControl__mdt(IsRollupLoggingEnabled__c = true);
-    // replicated dispatch plugin existing
+    // replicate the existence of a dispatch plugin
     RollupPlugin.pluginMocks = new List<RollupPlugin__mdt>{ new RollupPlugin__mdt(DeveloperName = RollupSObjectUpdater.DISPATCH_NAME) };
     RollupPlugin.parameterMock = new RollupPluginParameter__mdt(Value__c = DispatcherMock.class.getName());
     RollupSObjectUpdater updater = new RollupSObjectUpdater();
@@ -45,6 +45,23 @@ public class RollupSObjectUpdaterTests {
     updater.doUpdate(new List<SObjecT>{ new Account() });
 
     System.assertEquals(true, dispatcherMockWasCalled);
+  }
+
+  @IsTest
+  static void shouldSortBySObjectTypePriorToUpdate() {
+    Account one = new Account(Name = RollupSObjectUpdaterTests.class.getName());
+    Individual two = new Individual(LastName = 'Two');
+    Account three = new Account(Name = 'Three');
+    Individual four = new Individual(LastName = 'Four');
+    List<SObject> records = new List<SObject>{ one, two, three, four };
+    insert records;
+
+    new RollupSObjectUpdater().doUpdate(records);
+
+    System.assertEquals(one, records[0]);
+    System.assertEquals(three, records[1]);
+    System.assertEquals(two, records[2]);
+    System.assertEquals(four, records[3]);
   }
 
   public class DispatcherMock implements RollupSObjectUpdater.IDispatcher {

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -1047,9 +1047,19 @@ private class RollupTests {
     Rollup.apexContext = TriggerOperation.AFTER_INSERT;
 
     Test.startTest();
-    Rollup.concatFromApex(ContactPointAddress.Name, ContactPointAddress.ParentId, Account.Id, Account.AccountNumber, Account.SObjectType, null, null, new List<RollupOrderBy__mdt>{
-      new RollupOrderBy__mdt(FieldName__c = 'PreferenceRank', SortOrder__c = RollupMetaPicklists.SortOrder.Ascending, Ranking__c = 0)
-    }).runCalc();
+    Rollup.concatFromApex(
+        ContactPointAddress.Name,
+        ContactPointAddress.ParentId,
+        Account.Id,
+        Account.AccountNumber,
+        Account.SObjectType,
+        null,
+        null,
+        new List<RollupOrderBy__mdt>{
+          new RollupOrderBy__mdt(FieldName__c = 'PreferenceRank', SortOrder__c = RollupMetaPicklists.SortOrder.Ascending, Ranking__c = 0)
+        }
+      )
+      .runCalc();
     Test.stopTest();
 
     System.assertEquals(1, mock.Records.size(), 'Records should have been populated CONCAT AFTER_INSERT');
@@ -1072,6 +1082,24 @@ private class RollupTests {
     System.assertEquals(1, mock.Records.size(), 'Records should have been populated CONCAT_DISTINCT AFTER_INSERT');
     Account updatedAcc = (Account) mock.Records[0];
     System.assertEquals('hello another string, test string', updatedAcc.AccountNumber, 'CONCAT_DISTINCT AFTER_INSERT should only add unique values');
+  }
+
+  @IsTest
+  static void shouldDistinctifyForConcatDistinct() {
+    ContactPointAddress cpa = new ContactPointAddress(Name = 'apples, oranges, pears');
+    ContactPointAddress secondCpa = new ContactPointAddress(Name = 'apples, pears');
+    ContactPointAddress thirdCpa = new ContactPointAddress(Name = 'apples, oranges, plums, peaches');
+
+    RollupTestUtils.DMLMock mock = RollupTestUtils.loadAccountIdMock(new List<ContactPointAddress>{ cpa, secondCpa, thirdCpa });
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+
+    Test.startTest();
+    Rollup.concatDistinctFromApex(ContactPointAddress.Name, ContactPointAddress.ParentId, Account.Id, Account.Name, Account.SObjectType, '').runCalc();
+    Test.stopTest();
+
+    System.assertEquals(1, mock.Records.size(), 'Records should have been populated CONCAT_DISTINCT AFTER_INSERT');
+    Account updatedAcc = (Account) mock.Records[0];
+    System.assertEquals('apples, oranges, peaches, pears, plums', updatedAcc.Name, 'CONCAT_DISTINCT AFTER_INSERT should only add unique values');
   }
 
   @IsTest
@@ -3165,9 +3193,7 @@ private class RollupTests {
     insert clearedParent;
 
     Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
-    Rollup.oldRecordsMap = new Map<Id, Account>{
-      clearedParent.Id => new Account(ParentId = acc.Id, AnnualRevenue = 25, Id = clearedParent.Id)
-    };
+    Rollup.oldRecordsMap = new Map<Id, Account>{ clearedParent.Id => new Account(ParentId = acc.Id, AnnualRevenue = 25, Id = clearedParent.Id) };
     Rollup.shouldRun = true;
     Rollup.rollupMetadata = new List<Rollup__mdt>{
       new Rollup__mdt(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -2454,7 +2454,7 @@ global without sharing virtual class Rollup {
 
   private static Rollup__mdt getFirstLastMetadata(Rollup__mdt meta) {
     List<RollupOrderBy__mdt> replacementOrderBys;
-    if (meta.RollupOrderBys__r.isEmpty() && meta.OrderByFirstLast__c?.contains(',') == true) {
+    if (meta.RollupOrderBys__r.isEmpty() && String.isNotBlank(meta.OrderByFirstLast__c)) {
       List<String> unparsedOrderBys = meta.OrderByFirstLast__c.split(',');
       replacementOrderBys = new List<RollupOrderBy__mdt>();
       for (Integer index = 0; index < unparsedOrderBys.size(); index++) {

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -645,7 +645,9 @@ global without sharing virtual class Rollup {
           localRollups.add(rollupConductor);
         }
         if (wrapper.flowInput.shouldRunSync) {
-          rollupConductor.rollupControl.ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.Synchronous;
+          for (Rollup roll : rollupConductor.rollups) {
+            roll.rollupControl.ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.Synchronous;
+          }
         }
         RollupLogger.Instance.log(logMessage, rollupConductor, LoggingLevel.DEBUG);
       }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -19,9 +19,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   private List<SObject> lookupItems;
   private Integer stackDepth = 0;
 
-  private static Boolean isRunningAsync = false;
   @TestVisible
   private static Boolean shouldRunAsBatch = false;
+  @TestVisible
+  private static Boolean shouldFlattenAsyncProcesses;
 
   private enum CollectionType {
     DICTIONARY,
@@ -69,10 +70,8 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
     protected override Map<String, String> customizeToStringEntries(Map<String, String> props) {
       props = super.customizeToStringEntries(props);
-
       this.addToMap(props, 'Rollup Metadata', this.rollupInfo);
       this.addToMap(props, 'Query String', this.queryString);
-
       return props;
     }
 
@@ -277,7 +276,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   public virtual void execute(Database.BatchableContext context, List<SObject> lookupItems) {
-    isRunningAsync = true;
     for (Integer index = this.rollups.size() - 1; index >= 0; index--) {
       RollupAsyncProcessor roll = this.rollups[index];
       if (lookupItems.getSObjectType() != roll.lookupObj) {
@@ -448,7 +446,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
 
     public void execute(System.QueueableContext qc) {
-      isRunningAsync = true;
       System.attachFinalizer(new RollupFinalizer());
       this.process(this.rollups);
       this.logFinish();
@@ -480,8 +477,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   protected RollupAsyncProcessor getDelegatedFullRecalcRollup(List<Rollup__mdt> rollupInfo, List<SObject> calcItems, FullRecalcProcessor fullRecalcProcessor) {
-    // if we're already queued / batched, free to start running "sync"
-    isRunningAsync = System.isBatch() || System.isQueueable();
     RollupAsyncProcessor processor = this.getAsyncRollup(rollupInfo, this.calcItemType, calcItems, new Map<Id, SObject>(), null, this.invokePoint);
     processor.isFullRecalc = true;
     processor.fullRecalcProcessor = fullRecalcProcessor;
@@ -928,10 +923,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       Boolean shouldRunSyncDeferred = this.getShouldRunSyncDeferred(rollup);
       Boolean couldRunSync =
         rollup.rollupControl.ShouldRunAs__c == RollupMetaPicklists.ShouldRunAs.Synchronous ||
-        // TODO - fix this, as it's been guilty of causing CPU timeouts on the main thread
-        // when an upstream rollup had already triggered the static bool to flip to true
-        ((hasExceededCurrentRollupLimits(rollup.rollupControl) == false) && isRunningAsync) ||
-        System.isBatch() && Limits.getQueueableJobs() >= Limits.getLimitQueueableJobs() ||
+        (this.getIsRunningAsync() && hasExceededCurrentRollupLimits(rollup.rollupControl) == false) ||
         this.isSingleRecordSyncUpdate(rollup);
 
       if (rollup.rollupControl.ShouldAbortRun__c || this.rollupControl.ShouldAbortRun__c) {
@@ -1264,5 +1256,9 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       roll.fullRecalcProcessor?.storeParentResetField(roll, lookupRecord);
     }
     RollupLogger.Instance.log(logKey + ' record after rolling up:', lookupRecord, LoggingLevel.DEBUG);
+  }
+
+  private Boolean getIsRunningAsync() {
+    return System.isBatch() || System.isQueueable() || shouldFlattenAsyncProcesses == true;
   }
 }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -1048,6 +1048,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       this.retrieveAdditionalCalcItems(calcItemsByLookupField, rollup);
     }
 
+    RollupCalculator calc;
     for (Integer index = lookupItems.size() - 1; index >= 0; index--) {
       SObject lookupRecord = lookupItems[index];
       if (lookupRecord.getSObjectType() != rollup.lookupObj) {
@@ -1068,9 +1069,8 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
         this.winnowCalcItemsAndCheckReparenting(rollup, localCalcItems, oldLookupItems);
 
-        // Check for changed values
         Object priorVal = lookupRecord.get(rollup.opFieldOnLookupObject);
-        Object newVal = this.calculateNewRollupVal(rollup, localCalcItems, lookupRecord, priorVal, key, rollup.lookupFieldOnCalcItem);
+        Object newVal = this.calculateNewRollupVal(calc, rollup, localCalcItems, lookupRecord, priorVal, key, rollup.lookupFieldOnCalcItem);
         this.conditionallyPerformUpdate(priorVal, newVal, lookupRecord, rollup, recordsToUpdate, updater, 'lookup');
       }
     }
@@ -1164,6 +1164,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   private Object calculateNewRollupVal(
+    RollupCalculator rollupCalc,
     RollupAsyncProcessor roll,
     List<SObject> calcItems,
     SObject lookupRecord,
@@ -1171,18 +1172,23 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     String lookupRecordKey,
     SObjectField lookupKeyField
   ) {
-    RollupCalculator rollupCalc = RollupCalculator.Factory.getCalculator(
-      priorVal,
-      roll.op,
-      roll.opFieldOnCalcItem,
-      roll.opFieldOnLookupObject,
-      roll.metadata,
-      lookupRecordKey,
-      lookupKeyField
-    );
-    rollupCalc.setFullRecalc(roll.isFullRecalc);
-    rollupCalc.setEvaluator(roll.eval);
-    rollupCalc.setCDCUpdate(this.isCDCUpdate);
+    if (rollupCalc == null) {
+      rollupCalc = RollupCalculator.Factory.getCalculator(
+        priorVal,
+        roll.op,
+        roll.opFieldOnCalcItem,
+        roll.opFieldOnLookupObject,
+        roll.metadata,
+        lookupRecordKey,
+        lookupKeyField
+      );
+      rollupCalc.setFullRecalc(roll.isFullRecalc);
+      rollupCalc.setEvaluator(roll.eval);
+      rollupCalc.setCDCUpdate(this.isCDCUpdate);
+    } else {
+      rollupCalc.setDefaultValues(lookupRecordKey, priorVal);
+    }
+
     rollupCalc.setMultiCurrencyInfo(lookupRecord);
     rollupCalc.performRollup(calcItems, this.oldCalcItems);
     return rollupCalc.getReturnValue();
@@ -1198,6 +1204,23 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     if (oldLookupItems.isEmpty()) {
       return;
     }
+
+    Op deleteOp = Rollup.Op.valueOf('DELETE_' + getBaseOperationName(roll.op.name()));
+    RollupAsyncProcessor oldLookupsRollup = getProcessor(
+      new FilterResults(),
+      roll.opFieldOnCalcItem,
+      roll.lookupFieldOnCalcItem,
+      roll.lookupFieldOnLookupObject,
+      roll.opFieldOnLookupObject,
+      roll.lookupObj,
+      roll.calcItemType,
+      deleteOp,
+      this.invokePoint,
+      this.rollupControl,
+      roll.metadata
+    );
+    RollupCalculator calc;
+
     for (SObject lookupRecord : lookupItems) {
       if (lookupRecord.getSObjectType() != roll.lookupObj) {
         continue;
@@ -1212,26 +1235,11 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
           continue;
         }
 
-        Op deleteOp = Rollup.Op.valueOf('DELETE_' + getBaseOperationName(roll.op.name()));
-
-        RollupAsyncProcessor oldLookupsRollup = getProcessor(
-          new FilterResults(),
-          roll.opFieldOnCalcItem,
-          roll.lookupFieldOnCalcItem,
-          roll.lookupFieldOnLookupObject,
-          roll.opFieldOnLookupObject,
-          roll.lookupObj,
-          roll.calcItemType,
-          deleteOp,
-          this.invokePoint,
-          this.rollupControl,
-          roll.metadata
-        );
         oldLookupsRollup.calcItems = reparentedCalcItems;
 
         RollupLogger.Instance.log('reparenting operation:', oldLookupsRollup, LoggingLevel.DEBUG);
 
-        Object newVal = this.calculateNewRollupVal(oldLookupsRollup, reparentedCalcItems, lookupRecord, priorVal, key, roll.lookupFieldOnCalcItem);
+        Object newVal = this.calculateNewRollupVal(calc, oldLookupsRollup, reparentedCalcItems, lookupRecord, priorVal, key, roll.lookupFieldOnCalcItem);
 
         this.conditionallyPerformUpdate(priorVal, newVal, lookupRecord, roll, recordsToUpdate, updater, 'reparented');
       }

--- a/rollup/core/classes/RollupCalcItemReplacer.cls
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls
@@ -174,7 +174,7 @@ public without sharing class RollupCalcItemReplacer {
 
   @SuppressWarnings('PMD.UnusedLocalVariable')
   private void replaceCalcItemsWithParentWhereClauses(List<SObject> calcItems) {
-    if (calcItems.isEmpty()) {
+    if (calcItems.isEmpty() || this.queryFields.containsKey(calcItems[0].getSObjectType()) == false) {
       return;
     }
     SObjectType calcItemType = calcItems[0].getSObjectType();

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -5,15 +5,16 @@ public without sharing abstract class RollupCalculator {
   private Boolean isRecursiveRecalc = false;
   private Boolean isFullRecalc = false;
 
+  private final Object defaultVal;
   protected final SObjectField opFieldOnCalcItem;
   protected final SObjectField opFieldOnLookupObject;
   protected final SObjectField lookupKeyField;
   protected final Rollup.Op op;
   protected final Rollup__mdt metadata;
-  protected final String lookupKeyQuery;
-  protected final String lookupRecordKey;
   protected final Boolean isChangedFieldCalc;
 
+  protected String lookupKeyQuery;
+  protected String lookupRecordKey;
   protected Rollup.Evaluator eval;
   protected Boolean shouldShortCircuit = false;
   protected Object returnVal;
@@ -94,28 +95,33 @@ public without sharing abstract class RollupCalculator {
   ) {
     this.opFieldOnLookupObject = opFieldOnLookupObject;
     this.opFieldOnCalcItem = opFieldOnCalcItem;
-    this.lookupRecordKey = lookupRecordKey;
-    this.lookupKeyField = lookupKeyField;
     this.op = op;
     this.metadata = metadata;
-
-    if (defaultVal != null) {
-      this.returnVal = defaultVal;
-    } else {
-      this.returnVal = priorVal == null ? RollupFieldInitializer.Current.getDefaultValue(opFieldOnLookupObject) : priorVal;
-    }
-    this.lookupKeyQuery =
-      lookupKeyField +
-      ' = \'' +
-      lookupRecordKey +
-      '\'' +
-      (String.isBlank(metadata.CalcItemWhereClause__c) ? '' : ' AND (' + metadata.CalcItemWhereClause__c + ')');
+    this.lookupKeyField = lookupKeyField;
+    this.defaultVal = defaultVal;
+    this.setDefaultValues(lookupRecordKey, priorVal);
     this.isMultiCurrencyRollup =
       UserInfo.isMultiCurrencyOrganization() &&
       (this.opFieldOnCalcItem?.getDescribe().getType() == DisplayType.CURRENCY ||
       this.opFieldOnLookupObject?.getDescribe().getType() == DisplayType.CURRENCY);
     this.isChangedFieldCalc = String.isNotBlank(this.metadata.ChangedFieldsOnCalcItem__c);
   }
+
+  public virtual void setDefaultValues(String lookupRecordKey, Object priorVal) {
+    this.lookupRecordKey = lookupRecordKey;
+    if (this.defaultVal != null) {
+      this.returnVal = this.defaultVal;
+    } else {
+      this.returnVal = priorVal == null ? RollupFieldInitializer.Current.getDefaultValue(this.opFieldOnLookupObject) : priorVal;
+    }
+    this.lookupKeyQuery =
+      this.lookupKeyField +
+      ' = \'' +
+      lookupRecordKey +
+      '\'' +
+      (String.isBlank(metadata.CalcItemWhereClause__c) ? '' : ' AND (' + metadata.CalcItemWhereClause__c + ')');
+  }
+
   public virtual Object getReturnValue() {
     return this.returnVal;
   }
@@ -365,8 +371,8 @@ public without sharing abstract class RollupCalculator {
   }
 
   private inherited sharing class CountDistinctRollupCalculator extends RollupCalculator {
-    private final Set<Object> distinctValues;
-    private final Boolean isIdCount;
+    private final Set<Object> distinctValues = new Set<Object>();
+    private Boolean isIdCount;
     public CountDistinctRollupCalculator(
       Object priorVal,
       Rollup.Op op,
@@ -377,7 +383,11 @@ public without sharing abstract class RollupCalculator {
       SObjectField lookupKeyField
     ) {
       super(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata.FullRecalculationDefaultNumberValue__c, metadata, lookupRecordKey, lookupKeyField);
-      this.distinctValues = new Set<Object>();
+    }
+
+    public override void setDefaultValues(String lookupRecordKey, Object priorVal) {
+      super.setDefaultValues(lookupRecordKey, priorVal);
+      this.distinctValues.clear();
       this.isIdCount = this.opFieldOnCalcItem.getDescribe().getName() == 'Id';
       Object defaultVal = RollupFieldInitializer.Current.getDefaultValue(opFieldOnLookupObject);
       if (defaultVal != 0 && this.returnVal != defaultVal && this.isIdCount == false) {
@@ -460,6 +470,10 @@ public without sharing abstract class RollupCalculator {
       SObjectField lookupKeyField
     ) {
       super(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata.FullRecalculationDefaultNumberValue__c, metadata, lookupRecordKey, lookupKeyField);
+    }
+
+    public override void setDefaultValues(String lookupRecordKey, Object priorVal) {
+      super.setDefaultValues(lookupRecordKey, priorVal);
       this.returnDecimal = (Decimal) this.returnVal;
     }
 
@@ -774,11 +788,15 @@ public without sharing abstract class RollupCalculator {
       String customConcatDelimiter
     ) {
       super(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata.FullRecalculationDefaultStringValue__c, metadata, lookupRecordKey, lookupKeyField);
-      this.stringVal = (String) this.returnVal;
       if (String.isNotBlank(customConcatDelimiter)) {
         this.concatDelimiter = customConcatDelimiter + ' ';
       }
       this.isConcatDistinct = this.op.name().contains(Rollup.Op.CONCAT_DISTINCT.name());
+    }
+
+    public override void setDefaultValues(String lookupRecordKey, Object priorVal) {
+      super.setDefaultValues(lookupRecordKey, priorVal);
+      this.stringVal = (String) this.returnVal;
     }
 
     protected override void setReturnValue() {

--- a/rollup/core/classes/RollupFlowBulkProcessor.cls
+++ b/rollup/core/classes/RollupFlowBulkProcessor.cls
@@ -100,6 +100,11 @@ global without sharing class RollupFlowBulkProcessor {
               : meta.GrandparentRelationshipFieldPath__c;
             input.rollupToUltimateParent = flowInput.rollupToUltimateParent != null ? flowInput.rollupToUltimateParent : meta.RollupToUltimateParent__c;
             input.ultimateParentLookup = flowInput.ultimateParentLookup != null ? flowInput.ultimateParentLookup : meta.UltimateParentLookup__c;
+            input.orderByFirstLast = flowInput.orderByFirstLast != null ? flowInput.orderByFirstLast : '';
+            for (RollupOrderBy__mdt orderBy : meta.RollupOrderBys__r) {
+              input.orderByFirstLast += orderBy.FieldName__c + ' ' + orderBy.NullSortOrder__c + ' ' + orderBy.SortOrder__c + ',';
+            }
+            input.orderByFirstLast = input.orderByFirstLast.removeEnd(',');
             // metadata values that don't get overridden
             input.lookupFieldOnCalcItem = meta.LookupFieldOnCalcItem__c;
             input.lookupFieldOnOpObject = meta.LookupFieldOnLookupObject__c;

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger extends Rollup implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.4.4';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.4.5';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupSObjectUpdater.cls
+++ b/rollup/core/classes/RollupSObjectUpdater.cls
@@ -1,6 +1,7 @@
 public without sharing virtual class RollupSObjectUpdater {
   @TestVisible
   private static final String DISPATCH_NAME = 'RollupDispatch';
+  private static final SObjectSorter SORTER = new SObjectSorter();
 
   private final Schema.SObjectField fieldToken;
   private final List<IDispatcher> dispatchers;
@@ -24,7 +25,7 @@ public without sharing virtual class RollupSObjectUpdater {
     // getting updated is a no-op, but the addition of the logging item is annoying ...
     if (recordsToUpdate.isEmpty() == false) {
       RollupLogger.Instance.log('updating the following records:', recordsToUpdate, LoggingLevel.FINE);
-      recordsToUpdate.sort();
+      SORTER.sort(recordsToUpdate);
       Database.DMLOptions dmlOptions = new Database.DMLOptions();
       dmlOptions.AllowFieldTruncation = true;
       Database.update(recordsToUpdate, dmlOptions);
@@ -91,6 +92,22 @@ public without sharing virtual class RollupSObjectUpdater {
     IDispatcher dispatcher = (IDispatcher) Type.forName(typeName)?.newInstance();
     if (dispatcher != null) {
       dispatchers.add(dispatcher);
+    }
+  }
+
+  private class SObjectSorter extends RollupComparer {
+    public override Integer compare(Object first, Object second) {
+      Integer returnVal = 0;
+      if (first instanceof SObject && second instanceof SObject) {
+        String firstSObjectType = String.valueOf(((SObject) first).getSObjectType());
+        String secondSObjectType = String.valueOf(((SObject) second).getSObjectType());
+        if (firstSObjectType > secondSObjectType) {
+          returnVal = this.moveTowardBackOfList;
+        } else if (secondSObjectType > firstSObjectType) {
+          returnVal = this.moveTowardFrontOfList;
+        }
+      }
+      return returnVal;
     }
   }
 }

--- a/scripts/generatePackage.ps1
+++ b/scripts/generatePackage.ps1
@@ -39,13 +39,16 @@ function Update-Package-Install-Links {
   git add $filePath -f
 }
 
-
 function Get-Is-Version-Promoted {
   param ($versionNumber, $packageName)
   $promotedPackageVersions = (npx sfdx force:package:version:list --released --packages $packageName --json | ConvertFrom-Json).result | Select-Object -ExpandProperty Version
-  $isPackagePromoted = $promotedPackageVersions.Contains($versionNumber)
-  Write-Host "Is $versionNumber for $packageName promoted? $isPackagePromoted" -ForegroundColor Yellow
-  return $isPackagePromoted
+  if ($null -eq $promotedPackageVersions) {
+    return $false
+  } else {
+    $isPackagePromoted = $promotedPackageVersions.Contains($versionNumber)
+    Write-Host "Is $versionNumber for $packageName promoted? $isPackagePromoted" -ForegroundColor Yellow
+    return $isPackagePromoted
+  }
 }
 
 function Get-Package-JSON {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -104,6 +104,7 @@
         "apex-rollup@1.4.1-0": "04t6g000008SjGKAA0",
         "apex-rollup@1.4.2-0": "04t6g000008SjHhAAK",
         "apex-rollup@1.4.3-0": "04t6g000008SjHwAAK",
-        "apex-rollup@1.4.4-0": "04t6g000008SjIaAAK"
+        "apex-rollup@1.4.4-0": "04t6g000008SjIaAAK",
+        "apex-rollup@1.4.5-0": "04t6g000008SjRTAA0"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,9 +4,9 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Fixes query issue with top-level OR clauses in full recalculations",
-            "versionNumber": "1.4.4.0",
-            "versionDescription": "Upgrading to Spring 22, Rollup Order By fixes",
+            "versionName": "Scripting updates pulled back from salesforce-round-robin, rollup calculator uses less memory/CPU time now",
+            "versionNumber": "1.4.5.0",
+            "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
                 "path": "extra-tests"


### PR DESCRIPTION
* (Tentatively) fixes #262 by implementing two CPU quality-of-life changes:
  * Caching for `RollupCalculator`:
    * **Old process**
       - each parent item gets its own `RollupCalculator`
       - each `RollupCalculator` is only used once 
    * **New process**
       - `RollupCalculator` gets initialized for first parent item
       - subsequent parent items have their default values re-initialized; the same `RollupCalculator` is cached and re-used for each parent item for any given rollup operation
  * Removed static variable in `RollupAsyncProcessor` that was causing downstream rollups to start in the same thread as an already-async rollup
* Fixes #265 by correctly passing through rollup order bys when called via `RollupFlowBulkProcessor`
* Fixes issue where not all rollups flagged to run sync would properly run in the expected cadence
* Fixes #261 (hopefully for good?) by implementing custom sorting for passed-in records to avoid the out of the box list sorting, which occasionally produces a BigDecimal sorting error