### PR TITLE
V1.4.13 - Full Recalc Improvements & Bugfixes

### DIFF
--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -27,7 +27,7 @@ private class RollupFullRecalcTests {
       new List<Rollup__mdt>(),
       null,
       '',
-      new Set<Id>(),
+      new Set<String>(),
       Rollup.InvocationPoint.FROM_APEX
     );
     List<RollupAsyncProcessor> processors = new List<RollupAsyncProcessor>{
@@ -187,7 +187,122 @@ private class RollupFullRecalcTests {
   }
 
   @IsTest
-  static void shouldPerformFullRecalcWithGrandparentHierarchy() {
+  static void shouldPerformFullRecalcWithGrandparentHierarchyApex() {
+    Rollup.onlyUseMockMetadata = true;
+    Account acc = [SELECT Id FROM Account];
+    Account childAccount = new Account(Name = 'Hierarchy child', ParentId = acc.Id);
+    insert childAccount;
+    ParentApplication__c parentApp = new ParentApplication__c(Account__c = childAccount.Id, Name = 'Link to child account');
+    ParentApplication__c secondParentApp = new ParentApplication__c(Account__c = acc.Id, Name = 'Linked directly to parent account');
+    insert new List<ParentApplication__c>{ parentApp, secondParentApp };
+
+    // ensure that both a top-level child item linked only to the ultimate parent and one linked to the hierarchy child is included
+    List<Application__c> apps = new List<Application__c>{
+      new Application__c(Engagement_Score__c = 1000, ParentApplication__c = parentApp.Id, Name = 'Linked to Child Parent App'),
+      new Application__c(Engagement_Score__c = 1000, ParentApplication__c = secondParentApp.Id, Name = 'Linked to Direct Parent App')
+    };
+    insert apps;
+
+    List<Rollup__mdt> metadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'Application__c',
+        LookupObject__c = 'Account',
+        RollupToUltimateParent__c = true,
+        LookupFieldOnCalcItem__c = 'ParentApplication__c',
+        UltimateParentLookup__c = 'ParentId',
+        RollupOperation__c = 'SUM',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupFieldOnCalcItem__c = 'Engagement_Score__c',
+        LookupFieldOnLookupObject__c = 'Id',
+        GrandparentRelationshipFieldPath__c = 'ParentApplication__r.Account__r.AnnualRevenue'
+      )
+    };
+
+    Test.startTest();
+    Rollup.performBulkFullRecalc(metadata, Rollup.InvocationPoint.FROM_LWC.name());
+    Test.stopTest();
+
+    Account updatedAcc = [SELECT Id, AnnualRevenue FROM Account WHERE Id = :acc.Id];
+    System.assertEquals(2000, updatedAcc.AnnualRevenue, 'Apex grandparent rollup should fully recalc');
+  }
+
+  @IsTest
+  static void supportsOneToManyFullRecalcInMiddleOfChain() {
+    Rollup.onlyUseMockMetadata = true;
+    Account acc = [SELECT Id FROM Account];
+    Individual indy = new Individual(LastName = 'Indy');
+    insert indy;
+    Contact con = new Contact(LastName = 'One To Many Child', AccountId = acc.Id, IndividualId = indy.Id);
+    insert con;
+
+    ParentApplication__c parentApp = new ParentApplication__c(Account__c = acc.Id, Name = 'One');
+    ParentApplication__c secondParentApp = new ParentApplication__c(Account__c = acc.Id, Name = 'Two');
+    insert new List<ParentApplication__c>{ parentApp, secondParentApp };
+
+    List<Application__c> apps = new List<Application__c>{
+      new Application__c(Engagement_Score__c = 1000, ParentApplication__c = parentApp.Id, Name = 'App One'),
+      new Application__c(Engagement_Score__c = 1000, ParentApplication__c = secondParentApp.Id, Name = 'App Two')
+    };
+    insert apps;
+
+    List<Rollup__mdt> metadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'Application__c',
+        LookupObject__c = 'Individual',
+        LookupFieldOnCalcItem__c = 'ParentApplication__c',
+        RollupOperation__c = 'SUM',
+        RollupFieldOnLookupObject__c = 'ConsumerCreditScore',
+        RollupFieldOnCalcItem__c = 'Engagement_Score__c',
+        LookupFieldOnLookupObject__c = 'Id',
+        GrandparentRelationshipFieldPath__c = 'ParentApplication__r.Account__r.Contacts.Individual.ConsumerCreditScore',
+        OneToManyGrandparentFields__c = 'Contact.AccountId'
+      )
+    };
+
+    Test.startTest();
+    Rollup.performBulkFullRecalc(metadata, Rollup.InvocationPoint.FROM_LWC.name());
+    Test.stopTest();
+
+    Individual updatedIndy = [SELECT Id, ConsumerCreditScore FROM Individual WHERE Id = :indy.Id];
+    System.assertEquals(2000, updatedIndy.ConsumerCreditScore, 'Apex grandparent rollup should fully recalc with one to many field path');
+  }
+
+  @IsTest
+  static void supportsOneToManyAtBeginningOfChain() {
+    Rollup.onlyUseMockMetadata = true;
+    Account acc = [SELECT Id, AnnualRevenue FROM Account];
+    acc.AnnualRevenue = 67;
+    update acc;
+
+    Individual indy = new Individual(LastName = 'Indy');
+    insert indy;
+    Contact con = new Contact(LastName = 'One To Many Child', AccountId = acc.Id, IndividualId = indy.Id);
+    insert con;
+
+    List<Rollup__mdt> metadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'Account',
+        LookupObject__c = 'Individual',
+        LookupFieldOnCalcItem__c = 'Id',
+        RollupOperation__c = 'SUM',
+        RollupFieldOnLookupObject__c = 'ConsumerCreditScore',
+        RollupFieldOnCalcItem__c = 'AnnualRevenue',
+        LookupFieldOnLookupObject__c = 'Id',
+        GrandparentRelationshipFieldPath__c = 'Contacts.Individual.ConsumerCreditScore',
+        OneToManyGrandparentFields__c = 'Contact.AccountId'
+      )
+    };
+
+    Test.startTest();
+    Rollup.performBulkFullRecalc(metadata, Rollup.InvocationPoint.FROM_LWC.name());
+    Test.stopTest();
+
+    Individual updatedIndy = [SELECT Id, ConsumerCreditScore FROM Individual WHERE Id = :indy.Id];
+    System.assertEquals(acc.AnnualRevenue, updatedIndy.ConsumerCreditScore, 'Apex grandparent rollup should fully recalc with one to many field path');
+  }
+
+  @IsTest
+  static void shouldPerformFullRecalcWithGrandparentHierarchyFlow() {
     Rollup.onlyUseMockMetadata = true;
     Account acc = [SELECT Id FROM Account];
     Account childAccount = new Account(Name = 'Hierarchy child', ParentId = acc.Id);
@@ -1376,7 +1491,7 @@ private class RollupFullRecalcTests {
         )
       },
       ContactPointAddress.SObjectType,
-      new Set<Id>(),
+      new Set<String>(),
       null
     );
 
@@ -1592,7 +1707,8 @@ private class RollupFullRecalcTests {
     Account nonMatching = new Account(Name = 'Non-matching', AnnualRevenue = 5);
     insert nonMatching;
 
-    insert new Opportunity(Amount = 5, AccountId = acc.Id, CloseDate = System.today(), StageName = 'A', Name = 'Matching opp');
+    Opportunity opp = new Opportunity(Amount = 15, AccountId = acc.Id, CloseDate = System.today(), StageName = 'A', Name = 'Matching opp');
+    insert opp;
 
     Test.startTest();
     Rollup.performFullRecalculation(
@@ -1612,6 +1728,6 @@ private class RollupFullRecalcTests {
     nonMatching = [SELECT Id, AnnualRevenue FROM Account WHERE Id = :nonMatching.Id];
     System.assertEquals(null, nonMatching.AnnualRevenue, 'Non matching account should have been cleared');
     acc = [SELECT Id, AnnualRevenue FROM Account WHERE Id = :acc.Id];
-    System.assertEquals(5, acc.AnnualRevenue);
+    System.assertEquals(opp.Amount, acc.AnnualRevenue);
   }
 }

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -1584,4 +1584,33 @@ private class RollupFullRecalcTests {
     acc = [SELECT AnnualRevenue FROM Account];
     System.assertEquals(8, acc.AnnualRevenue);
   }
+
+  @IsTest
+  static void parentLevelResetAffectsAllParents() {
+    Account acc = [SELECT Id, Name FROM Account];
+    Account nonMatching = new Account(Name = 'Non-matching', AnnualRevenue = 5);
+    insert nonMatching;
+
+    insert new Opportunity(Amount = 5, AccountId = acc.Id, CloseDate = System.today(), StageName = 'A', Name = 'Matching opp');
+
+    Test.startTest();
+    Rollup.performFullRecalculation(
+      new Rollup__mdt(
+        CalcItem__c = 'Opportunity',
+        LookupObject__c = 'Account',
+        RollupFieldOnCalcItem__c = 'Amount',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'SUM',
+        CalcItemWhereClause__c = 'Account.Name != \'' + nonMatching.Name + '\''
+      )
+    );
+    Test.stopTest();
+
+    nonMatching = [SELECT Id, AnnualRevenue FROM Account WHERE Id = :nonMatching.Id];
+    System.assertEquals(null, nonMatching.AnnualRevenue, 'Non matching account should have been cleared');
+    acc = [SELECT Id, AnnualRevenue FROM Account WHERE Id = :acc.Id];
+    System.assertEquals(5, acc.AnnualRevenue);
+  }
 }

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -1376,7 +1376,8 @@ private class RollupFullRecalcTests {
         )
       },
       ContactPointAddress.SObjectType,
-      new Set<Id>()
+      new Set<Id>(),
+      null
     );
 
     fullRecalc.execute(null, new List<ContactPointAddress>{ cpas[0] });

--- a/extra-tests/classes/RollupParentResetProcessorTests.cls
+++ b/extra-tests/classes/RollupParentResetProcessorTests.cls
@@ -6,7 +6,7 @@ private class RollupParentResetProcessorTests {
       new List<Rollup__mdt>{ new Rollup__mdt(RollupFieldOnLookupObject__c = 'Description', LookupObject__c = 'Account') },
       Account.SObjectType,
       'SELECT Id\nFROM Account WHERE Id != null',
-      new Set<Id>(),
+      new Set<String>(),
       null
     );
 
@@ -26,7 +26,7 @@ private class RollupParentResetProcessorTests {
       new List<Rollup__mdt>(),
       Account.SObjectType,
       'SELECT Id\nFROM Account WHERE Id != null',
-      new Set<Id>(),
+      new Set<String>(),
       null
     );
 
@@ -46,7 +46,7 @@ private class RollupParentResetProcessorTests {
       new List<Rollup__mdt>{ new Rollup__mdt(RollupFieldOnLookupObject__c = 'AnnualRevenue', LookupObject__c = 'Account') },
       Account.SObjectType,
       'SELECT Id\nFROM Account WHERE Id != null',
-      new Set<Id>(),
+      new Set<String>(),
       null
     );
     processor.runCalc(); // this one is valid
@@ -55,7 +55,7 @@ private class RollupParentResetProcessorTests {
       new List<Rollup__mdt>{ new Rollup__mdt(RollupFieldOnLookupObject__c = 'Description', LookupObject__c = 'Account') },
       Account.SObjectType,
       'SELECT Id\nFROM Account WHERE Id != null',
-      new Set<Id>(),
+      new Set<String>(),
       null
     );
 

--- a/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.html
+++ b/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.html
@@ -92,16 +92,16 @@
           >
           </lightning-input>
           <div>
-            <lightning-input
+            <lightning-combobox
               data-id="RollupOperation__c"
               class="slds-col slds-form-element slds-form-element_horizontal"
-              type="text"
-              label="Rollup Operation Name (SUM/MIN/MAX/COUNT/COUNT_DISTINCT/CONCAT/CONCAT_DISTINCT/AVERAGE/FIRST/LAST)"
               name="RollupOperation__c"
-              oncommit={handleChange}
+              label="Rollup Operation Name"
+              value={rollupOperation}
+              options={rollupOperationValues}
+              onchange={handleChange}
               required
-            >
-            </lightning-input>
+            ></lightning-combobox>
             <template if:true={isFirstLast}>
               <div>
                 <c-rollup-order-by data-id="RollupOrderBys__r"></c-rollup-order-by>
@@ -117,6 +117,29 @@
             oncommit={handleChange}
           >
           </lightning-input>
+          <div class="slds-grid">
+            <lightning-input
+              data-id="GrandparentRelationshipFieldPath__c"
+              class="slds-col slds-form-element slds-form-element_horizontal"
+              type="text"
+              label="Grandparent Relationship Field Path (optional)"
+              name="GrandparentRelationshipFieldPath__c"
+              oncommit={handleChange}
+            >
+            </lightning-input>
+            <lightning-input
+              data-id="OneToManyGrandparentFields__c"
+              class="slds-col slds-form-element slds-form-element_horizontal"
+              type="text"
+              label="One To Many Grandparent Fields (optional)"
+              name="OneToManyGrandparentFields__c"
+              oncommit={handleChange}
+            >
+            </lightning-input>
+            <lightning-helptext
+              content="Use ObjectApiName.FieldName (or ObjectApiName__c.CustomField__c for custom objects and fields). Can be a comma-separated list for multiple junction object hops"
+            ></lightning-helptext>
+          </div>
           <div class="slds-grid">
             <lightning-input
               data-id="SplitConcatDelimiterOnCalcItem__c"

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -167,7 +167,7 @@ global without sharing virtual class Rollup {
   }
 
   private class RollupMetadata {
-    public final Set<Id> recordIds = new Set<Id>();
+    public final Set<String> recordIds = new Set<String>();
     public final Set<String> queryFields = new Set<String>();
     public final List<Rollup__mdt> metadata = new List<Rollup__mdt>();
     public String whereClause = '';
@@ -370,7 +370,7 @@ global without sharing virtual class Rollup {
 
     Integer amountOfCalcItems = 0;
     Set<String> objIds = new Set<String>(); // will always be present as a bind var, below
-    Set<Id> recordIds = new Set<Id>(); // always empty, here, but necessary for the "getCountFromDb" call
+    Set<String> recordIds = new Set<String>(); // always empty, here, but necessary for the "getCountFromDb" call
     Map<SObjectType, RollupMetadata> childToMetaWrapper = new Map<SObjectType, RollupMetadata>();
     String potentialWhereClause = '';
     String delimiter = ' ||| ';
@@ -466,6 +466,15 @@ global without sharing virtual class Rollup {
   @AuraEnabled
   global static String performFullRecalculation(Rollup__mdt meta) {
     return performSerializedFullRecalculation(JSON.serialize(meta));
+  }
+
+  @AuraEnabled
+  public static List<String> getRollupOperationValues() {
+    List<String> picklistValues = new List<String>();
+    for (Schema.PicklistEntry entry : Rollup__mdt.RollupOperation__c.getDescribe().getPicklistValues()) {
+      picklistValues.add(entry.getValue());
+    }
+    return picklistValues;
   }
 
   global class FlowInput {
@@ -2053,20 +2062,20 @@ global without sharing virtual class Rollup {
     List<Rollup__mdt> matchingMeta,
     Integer amountOfCalcItems,
     String queryString,
-    Set<Id> recordIds,
+    Set<String> recordIds,
     SObjectType calcItemType,
     InvocationPoint invokePoint
   ) {
     for (Rollup__mdt meta : matchingMeta) {
       meta.IsFullRecordSet__c = true;
     }
-    Boolean shouldQueue =
-      amountOfCalcItems != RollupQueryBuilder.SENTINEL_COUNT_VALUE &&
-      amountOfCalcItems < getSingleControlOrDefault(RollupControl__mdt.DeveloperName, CONTROL_ORG_DEFAULTS, defaultControl).MaxLookupRowsBeforeBatching__c;
     RollupAsyncProcessor.FullRecalcProcessor parentResetProcessor;
     SObjectType parentType = RollupFieldInitializer.Current.getSObjectFromName(matchingMeta[0].LookupObject__c).getSObjectType();
     String parentQuery = RollupQueryBuilder.Current.getQuery(parentType, new List<String>{ 'Id' }, 'Id', '!=');
     parentResetProcessor = new RollupParentResetProcessor(matchingMeta, parentType, parentQuery, recordIds, invokePoint);
+    Boolean shouldQueue =
+      amountOfCalcItems != RollupQueryBuilder.SENTINEL_COUNT_VALUE &&
+      amountOfCalcItems < parentResetProcessor.rollupControl.MaxLookupRowsBeforeBatching__c;
     if (amountOfCalcItems == 0 && matchingMeta.isEmpty() == false && isFullRecalcApp) {
       return parentResetProcessor;
     } else if (invokePoint == InvocationPoint.FROM_SINGULAR_PARENT_RECALC_LWC) {
@@ -2207,7 +2216,7 @@ global without sharing virtual class Rollup {
   private class QueryWrapper {
     private Boolean hasQuery = false;
     private String query;
-    public final Set<Id> recordIds = new Set<Id>();
+    public final Set<String> recordIds = new Set<String>();
     private final List<String> stringifiedRecordIds = new List<String>();
     private QueryWrapper() {
     }
@@ -2275,7 +2284,7 @@ global without sharing virtual class Rollup {
     return getCountFromDb(countQuery, objIds, null);
   }
 
-  public static Integer getCountFromDb(String countQuery, Set<String> objIds, Set<Id> recordIds) {
+  public static Integer getCountFromDb(String countQuery, Set<String> objIds, Set<String> recordIds) {
     if (countQuery.contains('ALL ROWS')) {
       countQuery = countQuery.replace('ALL ROWS', '');
     }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -27,6 +27,7 @@ global without sharing virtual class Rollup {
   private static Boolean isCDC = false;
   private static Boolean isDeferralAllowed = true;
   private static Boolean isFullRecalcApp = false;
+  private static String currentJobId;
 
   protected final RollupControl__mdt rollupControl;
   protected final InvocationPoint invokePoint;
@@ -281,6 +282,10 @@ global without sharing virtual class Rollup {
     isDeferralAllowed = value;
   }
 
+  protected void setCurrentJobId(String jobId) {
+    currentJobId = jobId;
+  }
+
   protected RollupAsyncProcessor getAsyncRollup(
     List<Rollup__mdt> rollupOperations,
     SObjectType sObjectType,
@@ -440,6 +445,9 @@ global without sharing virtual class Rollup {
 
   @AuraEnabled
   global static String getBatchRollupStatus(String jobId) {
+    if (currentJobId != null) {
+      jobId = currentJobId;
+    }
     return [SELECT Status FROM AsyncApexJob WHERE Id = :jobId LIMIT 1]?.Status;
   }
 
@@ -2052,19 +2060,24 @@ global without sharing virtual class Rollup {
     for (Rollup__mdt meta : matchingMeta) {
       meta.IsFullRecordSet__c = true;
     }
-    Rollup instance = new Rollup(invokePoint);
     Boolean shouldQueue =
       amountOfCalcItems != RollupQueryBuilder.SENTINEL_COUNT_VALUE &&
-      amountOfCalcItems < instance.rollupControl.MaxLookupRowsBeforeBatching__c;
+      amountOfCalcItems < getSingleControlOrDefault(RollupControl__mdt.DeveloperName, CONTROL_ORG_DEFAULTS, defaultControl).MaxLookupRowsBeforeBatching__c;
+    RollupAsyncProcessor.FullRecalcProcessor parentResetProcessor;
+    SObjectType parentType = RollupFieldInitializer.Current.getSObjectFromName(matchingMeta[0].LookupObject__c).getSObjectType();
+    String parentQuery = RollupQueryBuilder.Current.getQuery(parentType, new List<String>{ 'Id' }, 'Id', '!=');
+    parentResetProcessor = new RollupParentResetProcessor(matchingMeta, parentType, parentQuery, recordIds, invokePoint);
     if (amountOfCalcItems == 0 && matchingMeta.isEmpty() == false && isFullRecalcApp) {
-      SObjectType parentType = RollupFieldInitializer.Current.getSObjectFromName(matchingMeta[0].LookupObject__c).getSObjectType();
-      String parentQuery = RollupQueryBuilder.Current.getQuery(parentType, new List<String>{ 'Id' }, 'Id', '!=');
-      return new RollupParentResetProcessor(matchingMeta, parentType, parentQuery, recordIds, invokePoint);
-    } else if (shouldQueue) {
-      return new RollupDeferredFullRecalcProcessor(matchingMeta, calcItemType, queryString, recordIds, invokePoint);
+      return parentResetProcessor;
+    } else if (invokePoint == InvocationPoint.FROM_SINGULAR_PARENT_RECALC_LWC) {
+      parentResetProcessor = null;
+    }
+
+    if (shouldQueue) {
+      return new RollupDeferredFullRecalcProcessor(matchingMeta, calcItemType, queryString, recordIds, invokePoint, parentResetProcessor);
     } else {
       String queryWithOrderBy = (queryString + getFullRecalcQueryString(matchingMeta));
-      return new RollupFullBatchRecalculator(queryWithOrderBy, invokePoint, matchingMeta, calcItemType, recordIds);
+      return new RollupFullBatchRecalculator(queryWithOrderBy, invokePoint, matchingMeta, calcItemType, recordIds, parentResetProcessor);
     }
   }
 

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -56,8 +56,20 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     protected final Set<Id> recordIds;
     protected final Set<Id> objIds = new Set<Id>(); // necessary; there's a bind variable in the query string
     private final Set<String> previouslyResetParents = new Set<String>();
+    private final FullRecalcProcessor postProcessor;
 
     public FullRecalcProcessor(String queryString, InvocationPoint invokePoint, List<Rollup__mdt> rollupInfo, SObjectType calcItemType, Set<Id> recordIds) {
+      this(queryString, invokePoint, rollupInfo, calcItemType, recordIds, null);
+    }
+
+    public FullRecalcProcessor(
+      String queryString,
+      InvocationPoint invokePoint,
+      List<Rollup__mdt> rollupInfo,
+      SObjectType calcItemType,
+      Set<Id> recordIds,
+      FullRecalcProcessor postProcessor
+    ) {
       super(invokePoint);
       this.isFullRecalc = true;
       this.isNoOp = true; // consumers should either opt out of this or have it be set properly downstream
@@ -65,6 +77,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       this.queryString = queryString;
       this.rollupInfo = rollupInfo;
       this.recordIds = recordIds;
+      this.postProcessor = postProcessor;
       this.overrideRollupControl();
     }
 
@@ -79,12 +92,23 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       return String.valueOf(this.rollupInfo);
     }
 
+    protected void finish() {
+      if (this.postProcessor != null) {
+        RollupLogger.Instance.log('Starting post-full recalc processor', this.postProcessor, LoggingLevel.DEBUG);
+        // chain jobs together so that if recalc job is being tracked within the Recalc Rollups app,
+        // job continuity is established between the full recalc and then any downstream job that runs
+        // (as the postProcessor)
+        this.setCurrentJobId(this.postProcessor.runCalc());
+      }
+    }
+
     private Boolean parentRollupFieldHasBeenReset(RollupAsyncProcessor processor, SObject parent) {
       return this.previouslyResetParents.contains(this.getKey(processor, parent));
     }
 
     private void storeParentResetField(RollupAsyncProcessor processor, SObject parent) {
       this.previouslyResetParents.add(this.getKey(processor, parent));
+      this.postProcessor?.recordIds.add(parent.Id);
     }
 
     private String getKey(RollupAsyncProcessor processor, SObject parent) {
@@ -273,6 +297,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
   public virtual void finish(Database.BatchableContext context) {
     this.logFinish();
+    this.fullRecalcProcessor?.finish();
   }
 
   public virtual override String runCalc() {
@@ -427,6 +452,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     public void execute(System.QueueableContext qc) {
       System.attachFinalizer(new RollupFinalizer());
       this.process(this.rollups);
+      this.fullRecalcProcessor?.finish();
       this.logFinish();
     }
   }
@@ -464,6 +490,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       innerRoll.isFullRecalc = true;
       innerRoll.calcItems = calcItems;
     }
+    this.fullRecalcProcessor = fullRecalcProcessor;
     return processor;
   }
 

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -53,21 +53,17 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   public abstract without sharing class FullRecalcProcessor extends QueueableProcessor {
     protected final String queryString;
     protected final List<Rollup__mdt> rollupInfo;
-    protected final Set<Id> recordIds;
-    protected final Set<Id> objIds = new Set<Id>(); // necessary; there's a bind variable in the query string
+    protected final Set<String> recordIds;
+    protected final Set<String> objIds = new Set<String>(); // necessary; there's a bind variable in the query string
     private final Set<String> previouslyResetParents = new Set<String>();
     private final FullRecalcProcessor postProcessor;
-
-    public FullRecalcProcessor(String queryString, InvocationPoint invokePoint, List<Rollup__mdt> rollupInfo, SObjectType calcItemType, Set<Id> recordIds) {
-      this(queryString, invokePoint, rollupInfo, calcItemType, recordIds, null);
-    }
 
     public FullRecalcProcessor(
       String queryString,
       InvocationPoint invokePoint,
       List<Rollup__mdt> rollupInfo,
       SObjectType calcItemType,
-      Set<Id> recordIds,
+      Set<String> recordIds,
       FullRecalcProcessor postProcessor
     ) {
       super(invokePoint);
@@ -102,17 +98,22 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       }
     }
 
+    protected Boolean parentRollupFieldHasBeenReset(Rollup__mdt meta, SObject parent) {
+      return this.previouslyResetParents.contains(this.getKey(meta.RollupFieldOnLookupObject__c, parent));
+    }
+
     private Boolean parentRollupFieldHasBeenReset(RollupAsyncProcessor processor, SObject parent) {
-      return this.previouslyResetParents.contains(this.getKey(processor, parent));
+      return this.previouslyResetParents.contains(this.getKey(String.valueOf(processor.opFieldOnLookupObject), parent));
     }
 
     private void storeParentResetField(RollupAsyncProcessor processor, SObject parent) {
-      this.previouslyResetParents.add(this.getKey(processor, parent));
+      this.previouslyResetParents.add(this.getKey(String.valueOf(processor.opFieldOnLookupObject), parent));
       this.postProcessor?.recordIds.add(parent.Id);
+      this.postProcessor?.storeParentResetField(processor, parent);
     }
 
-    private String getKey(RollupAsyncProcessor processor, SObject parent) {
-      return String.valueOf(processor.opFieldOnLookupObject) + parent.Id;
+    private String getKey(String fieldKey, SObject parent) {
+      return fieldKey + parent.Id;
     }
 
     private void overrideRollupControl() {

--- a/rollup/core/classes/RollupDeferredFullRecalcProcessor.cls
+++ b/rollup/core/classes/RollupDeferredFullRecalcProcessor.cls
@@ -4,9 +4,10 @@ public without sharing class RollupDeferredFullRecalcProcessor extends RollupAsy
     SObjectType calcItemType,
     String queryString,
     Set<Id> recordIds,
-    InvocationPoint invokePoint
+    InvocationPoint invokePoint,
+    FullRecalcProcessor postProcessor
   ) {
-    super(queryString, invokePoint, matchingMeta, calcItemType, recordIds);
+    super(queryString, invokePoint, matchingMeta, calcItemType, recordIds, postProcessor);
   }
 
   public override String runCalc() {

--- a/rollup/core/classes/RollupDeferredFullRecalcProcessor.cls
+++ b/rollup/core/classes/RollupDeferredFullRecalcProcessor.cls
@@ -3,7 +3,7 @@ public without sharing class RollupDeferredFullRecalcProcessor extends RollupAsy
     List<Rollup__mdt> matchingMeta,
     SObjectType calcItemType,
     String queryString,
-    Set<Id> recordIds,
+    Set<String> recordIds,
     InvocationPoint invokePoint,
     FullRecalcProcessor postProcessor
   ) {

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -6,7 +6,7 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupA
     InvocationPoint invokePoint,
     List<Rollup__mdt> rollupInfo,
     SObjectType calcItemType,
-    Set<Id> recordIds,
+    Set<String> recordIds,
     FullRecalcProcessor postProcessor
   ) {
     super(queryString, invokePoint, rollupInfo, calcItemType, recordIds, postProcessor);
@@ -68,7 +68,7 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupA
       CalcItemBag bag = local.get(lookupKey);
       this.statefulLookupToCalcItems.put(lookupKey, bag);
       lookupToCalcItems.put(lookupKey, bag);
-      this.recordIds.add((Id) lookupKey);
+      this.recordIds.add(lookupKey);
     }
   }
 }

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -6,9 +6,10 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupA
     InvocationPoint invokePoint,
     List<Rollup__mdt> rollupInfo,
     SObjectType calcItemType,
-    Set<Id> recordIds
+    Set<Id> recordIds,
+    FullRecalcProcessor postProcessor
   ) {
-    super(queryString, invokePoint, rollupInfo, calcItemType, recordIds);
+    super(queryString, invokePoint, rollupInfo, calcItemType, recordIds, postProcessor);
     this.statefulLookupToCalcItems = new Map<String, CalcItemBag>();
   }
 
@@ -67,6 +68,7 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupA
       CalcItemBag bag = local.get(lookupKey);
       this.statefulLookupToCalcItems.put(lookupKey, bag);
       lookupToCalcItems.put(lookupKey, bag);
+      this.recordIds.add((Id) lookupKey);
     }
   }
 }

--- a/rollup/core/classes/RollupParentResetProcessor.cls
+++ b/rollup/core/classes/RollupParentResetProcessor.cls
@@ -30,7 +30,7 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
     Set<Id> recordIds,
     InvocationPoint invokePoint
   ) {
-    super(getRefinedQueryString(queryString, matchingMeta), invokePoint, matchingMeta, calcItemType, recordIds);
+    super(getRefinedQueryString(queryString, matchingMeta), invokePoint, matchingMeta, calcItemType, recordIds, null);
     this.overridesRunCalc = true;
     this.isNoOp = false;
     this.shouldSortToFront = true;
@@ -40,6 +40,7 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
     this.isProcessed = true;
     // reset isValidRun flag properly
     getRefinedQueryString(this.queryString, this.rollupInfo);
+    this.objIds.addAll(this.recordIds);
     String processId = this.getNoProcessId();
     if (isValidRun == false) {
       return processId;

--- a/rollup/core/classes/RollupParentResetProcessor.cls
+++ b/rollup/core/classes/RollupParentResetProcessor.cls
@@ -27,7 +27,7 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
     List<Rollup__mdt> matchingMeta,
     SObjectType calcItemType,
     String queryString,
-    Set<Id> recordIds,
+    Set<String> recordIds,
     InvocationPoint invokePoint
   ) {
     super(getRefinedQueryString(queryString, matchingMeta), invokePoint, matchingMeta, calcItemType, recordIds, null);
@@ -70,7 +70,9 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
     RollupLogger.Instance.log('resetting parent fields for: ' + calcItems.size() + ' items', LoggingLevel.DEBUG);
     for (SObject parentItem : calcItems) {
       for (Rollup__mdt rollupMeta : this.rollupInfo) {
-        parentItem.put(rollupMeta.RollupFieldOnLookupObject__c, null);
+        if (this.parentRollupFieldHasBeenReset(rollupMeta, parentItem) == false) {
+          parentItem.put(rollupMeta.RollupFieldOnLookupObject__c, null);
+        }
       }
     }
     this.getDML().doUpdate(calcItems);

--- a/rollup/core/classes/RollupRelationshipFieldFinder.cls
+++ b/rollup/core/classes/RollupRelationshipFieldFinder.cls
@@ -303,15 +303,18 @@ public without sharing class RollupRelationshipFieldFinder {
     this.populateRelationshipNameToWhereClauses(baseSObjectType);
     // cache the latest records through in case we need to continue later
     this.recommencementRecords = records;
+    String priorLookup = this.currentRelationshipName;
     this.currentRelationshipName = this.getCurrentRelationshipName(baseSObjectType);
 
     String relationshipObject = this.getChildRelationshipFromType(baseSObjectType, this.currentRelationshipName);
     if (this.oneToManyParts.containsKey(relationshipObject)) {
-      records = this.getJunctionRecords(records, relationshipObject);
+      priorLookup = priorLookup == null ? this.oneToManyParts.get(relationshipObject) : priorLookup.replace('__r', '__c');
+      this.setFirstRunFlags(records);
+      records = this.getJunctionRecords(records, relationshipObject, priorLookup);
       baseSObjectType = records.isEmpty() ? baseSObjectType : records.get(0).getSObjectType();
       relationshipObject = this.getChildRelationshipFromType(baseSObjectType, this.currentRelationshipName);
       if (this.oneToManyParts.containsKey(relationshipObject)) {
-        return this.getParents(records);
+        return this.recurseThroughObjectChain(records, baseSObjectType);
       }
     }
 
@@ -336,18 +339,23 @@ public without sharing class RollupRelationshipFieldFinder {
     }
 
     String nextFieldToLookup = this.relationshipParts[0].replace('__r', '__c');
-    SObjectType nextSObjectType = firstId.getSObjectType();
-    Map<String, SObjectField> nextFieldMap = nextSObjectType.getDescribe().fields.getMap();
-    SObjectField nextFieldToken = this.getField(nextFieldMap, nextFieldToLookup);
+    baseSObjectType = firstId.getSObjectType();
+    relationshipObject = this.getChildRelationshipFromType(baseSObjectType, nextFieldToLookup);
+    if (this.oneToManyParts.containsKey(relationshipObject)) {
+      return this.recurseThroughObjectChain(records, baseSObjectType);
+    }
+
+    fieldMap = baseSObjectType.getDescribe().fields.getMap();
+    field = this.getField(fieldMap, nextFieldToLookup);
 
     Set<String> fieldNames = new Set<String>();
-    if (nextSObjectType == this.ultimateParent) {
+    if (baseSObjectType == this.ultimateParent) {
       fieldNames.addAll(this.uniqueFinalFieldNames);
       if (this.metadata.RollupToUltimateParent__c == true) {
-        this.populateHierarchicalLookupFields(fieldNames, this.getField(nextFieldMap, this.metadata.UltimateParentLookup__c));
+        this.populateHierarchicalLookupFields(fieldNames, this.getField(fieldMap, this.metadata.UltimateParentLookup__c));
       }
     } else {
-      fieldNames.add(nextFieldToken.getDescribe().getName());
+      fieldNames.add(field.getDescribe().getName());
     }
     if (fieldNames.contains('Id') == false) {
       fieldNames.add('Id');
@@ -355,9 +363,9 @@ public without sharing class RollupRelationshipFieldFinder {
 
     // NB - we only support one route through polymorphic fields such as Task.WhoId and Task.WhatId for this sort of thing
     String query = this.appendAdditionalWhereClauses(
-      RollupQueryBuilder.Current.getQuery(nextSObjectType, new List<String>(fieldNames), 'Id', '='),
+      RollupQueryBuilder.Current.getQuery(baseSObjectType, new List<String>(fieldNames), 'Id', '='),
       currentRelationshipName,
-      nextFieldMap
+      fieldMap
     );
     this.setFirstRunFlags(records);
 
@@ -611,7 +619,7 @@ public without sharing class RollupRelationshipFieldFinder {
   }
 
   @SuppressWarnings('PMD.ApexSOQLInjection, PMD.UnusedLocalVariable')
-  private List<SObject> getJunctionRecords(List<SObject> records, String junctionObjectName) {
+  private List<SObject> getJunctionRecords(List<SObject> records, String junctionObjectName, String priorLookup) {
     SObject junctionObject = RollupFieldInitializer.Current.getSObjectFromName(junctionObjectName);
     String oneToManyFieldName = this.oneToManyParts.get(junctionObjectName);
     this.oneToManyParts.remove(junctionObjectName);
@@ -627,7 +635,11 @@ public without sharing class RollupRelationshipFieldFinder {
       oneToManyFieldName,
       '='
     );
-    List<SObject> objIds = records;
+    Set<Id> objIds = new Set<Id>();
+    for (SObject record : records) {
+      priorLookup = record.getPopulatedFieldsAsMap().containsKey(priorLookup) ? priorLookup : 'Id';
+      objIds.add((Id) record.get(priorLookup));
+    }
     records = Database.query(query);
 
     Map<String, SObjectField> fieldMap = sObjectType.getDescribe().fields.getMap();

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Remove inherited sharing in favor of always explicitly using without sharing. Added missing SOQL date literals",
-            "versionNumber": "1.4.12.0",
+            "versionName": "Make parent-reset calculator more reliable when used in conjunction with full recalcs",
+            "versionNumber": "1.4.13.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
* Fixed up a few edge cases associated with full recalcs done in conjunction with the new `One To Many Grandparent Fields` junction object rollup functionality - some of these were brought up today in the discussion on #282 
* Fixed a _long_ outstanding bug where full recalcs done through the Full Recalc App would not clear rolled-up values from parents without any matching children. This has been on my TODO list for ... 7 months, so it was nice to finally address the issue!
* Updated the full recalc singular version app to use a picklist when selecting the `Rollup Operation` field (@jongpie deserves a shoutout for this suggestion - so obvious in retrospect!). Took the chance while in the component to add a few lines of pesky code coverage that had long proven elusive to obtain.