### PR TITLE
v1.5.0 - Support Grandparent Rollups From Full Recalc Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Create fast, scalable custom rollups driven by Custom Metadata in your Salesforc
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sk7CAAS">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sk7WAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sk7CAAS">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sk7WAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>
@@ -46,7 +46,7 @@ You have several different options when it comes to making use of Apex Rollup:
 | [Custom Metadata-driven rollups](#cmdt-based-rollup-solution)          | Install with _one line of Apex code_                                                |
 | [Flow-driven rollups](#flow--process-builder-invocable)                | There are several Readme & Wiki sections dedicated specifically to setting up Flows |
 | [Full Recalculations](#calculating-rollups-after-install)              | Useful especially upon first install to prepopulate the existing rollup values      |
-| [From the included LWC button](#using-the-parent-record-recalc-button) | Gets embedded on a parent record's flexipage. Grandparent rollups not yet supported |
+| [From the included LWC button](#using-the-parent-record-recalc-button) | Gets embedded on a parent record's flexipage. Grandparent rollups supported         |
 | [Via Scheduled Job](#scheduled-jobs)                                   | Use Anonymous Apex or Scheduled Flow to setup                                       |
 
 ## CMDT-based Rollup Solution
@@ -291,7 +291,7 @@ There is an included Lightning Web Component (LWC) that will show up in the "Cus
 - The button _will_ display even if a given parent record has no matching children associated with the rollup(s) in question.
 - This particular rollup runs synchronously, so it won't eat into your Asynchronous Job limits for the day; it also refreshes any Aura/page-layout sections of the page (LWC-based sections of the page should update automatically).
 - Editing `Rollup__mdt` records with a parent record's page open can lead to unexpected behavior. This is because the `Rollup__mdt` records are cached on page load, so any updates made to those records will require a page refresh prior to clicking the `Recalc Rollup` button
-- Triggering recalcs from a grandparent record for a grandparent rollup currently not supported
+- Triggering recalcs from a grandparent record is supported, but polymorphic grandparents (for example, and Account rollup that starts from Task -> Opportunity -> Account through the `WhatId` is not yet supported).
 
 ## Scheduled Jobs
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Create fast, scalable custom rollups driven by Custom Metadata in your Salesforc
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sk7WAAS">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sk8FAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sk7WAAS">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sk8FAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -48,8 +48,13 @@ private class RollupFullRecalcTests {
   @IsTest
   static void shouldPerformFullRecalcFromFlowChildren() {
     Account acc = [SELECT Id FROM Account];
-    // ensure another matching item exists outside of the passed in list
-    insert new ContactPointAddress(PreferenceRank = 500, ParentId = acc.Id, Name = 'One');
+    Account secondParent = new Account(Name = 'Second', AnnualRevenue = 10);
+    insert secondParent;
+    insert new List<ContactPointAddress>{
+      // ensure another matching item exists outside of the passed in list
+      new ContactPointAddress(PreferenceRank = 500, ParentId = acc.Id, Name = 'One'),
+      new ContactPointAddress(PreferenceRank = secondParent.AnnualRevenue.intValue(), ParentId = secondParent.Id, Name = 'Two')
+    };
 
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{ new ContactPointAddress(PreferenceRank = 1000, ParentId = acc.Id, Name = 'Two') };
     insert cpas;
@@ -64,8 +69,10 @@ private class RollupFullRecalcTests {
     System.assertEquals('SUCCESS', flowOutputs[0].message);
     System.assertEquals(true, flowOutputs[0].isSuccess);
 
-    Account updatedAcc = [SELECT Id, AnnualRevenue FROM Account];
+    Account updatedAcc = [SELECT Id, AnnualRevenue FROM Account WHERE Id = :acc.Id];
     System.assertEquals(1500, updatedAcc.AnnualRevenue, 'SUM REFRESH from flow should fully recalc');
+    Account updatedSecondParent = [SELECT Id, AnnualRevenue FROM Account WHERE Id = :secondParent.Id];
+    System.assertEquals(secondParent.AnnualRevenue, updatedSecondParent.AnnualRevenue, 'Out of scope parent values should not have been affected');
   }
 
   @IsTest
@@ -179,7 +186,7 @@ private class RollupFullRecalcTests {
     };
 
     Test.startTest();
-    Rollup.performBulkFullRecalc(metadata, Rollup.InvocationPoint.FROM_LWC.name());
+    Rollup.performBulkFullRecalc(metadata, Rollup.InvocationPoint.FROM_FULL_RECALC_LWC.name());
     Test.stopTest();
 
     acc = [SELECT Id, AnnualRevenue FROM Account WHERE Id = :acc.Id];
@@ -219,7 +226,7 @@ private class RollupFullRecalcTests {
     };
 
     Test.startTest();
-    Rollup.performBulkFullRecalc(metadata, Rollup.InvocationPoint.FROM_LWC.name());
+    Rollup.performBulkFullRecalc(metadata, Rollup.InvocationPoint.FROM_FULL_RECALC_LWC.name());
     Test.stopTest();
 
     Account updatedAcc = [SELECT Id, AnnualRevenue FROM Account WHERE Id = :acc.Id];
@@ -260,7 +267,7 @@ private class RollupFullRecalcTests {
     };
 
     Test.startTest();
-    Rollup.performBulkFullRecalc(metadata, Rollup.InvocationPoint.FROM_LWC.name());
+    Rollup.performBulkFullRecalc(metadata, Rollup.InvocationPoint.FROM_FULL_RECALC_LWC.name());
     Test.stopTest();
 
     Individual updatedIndy = [SELECT Id, ConsumerCreditScore FROM Individual WHERE Id = :indy.Id];
@@ -294,7 +301,7 @@ private class RollupFullRecalcTests {
     };
 
     Test.startTest();
-    Rollup.performBulkFullRecalc(metadata, Rollup.InvocationPoint.FROM_LWC.name());
+    Rollup.performBulkFullRecalc(metadata, Rollup.InvocationPoint.FROM_FULL_RECALC_LWC.name());
     Test.stopTest();
 
     Individual updatedIndy = [SELECT Id, ConsumerCreditScore FROM Individual WHERE Id = :indy.Id];
@@ -757,7 +764,7 @@ private class RollupFullRecalcTests {
     Map<String, List<Rollup__mdt>> calcItemToMetadata = Rollup.getRollupMetadataByCalcItem();
 
     Test.startTest();
-    Rollup.performBulkFullRecalc(calcItemToMetadata.get('ContactPointAddress'), Rollup.InvocationPoint.FROM_LWC.name());
+    Rollup.performBulkFullRecalc(calcItemToMetadata.get('ContactPointAddress'), Rollup.InvocationPoint.FROM_FULL_RECALC_LWC.name());
     Test.stopTest();
 
     acc = [SELECT AnnualRevenue FROM Account];
@@ -1118,6 +1125,40 @@ private class RollupFullRecalcTests {
   }
 
   @IsTest
+  static void grandparentRollupsCanUseSingularParentRecalcButton() {
+    RollupGrandparent__c grandparent = new RollupGrandparent__c();
+    insert grandparent;
+
+    RollupParent__c parent = new RollupParent__c(Name = 'Parent', RollupGrandparent__c = grandparent.Id);
+    insert parent;
+
+    insert new List<RollupChild__c>{
+      new RollupChild__c(RollupParent__c = parent.Id, NumberField__c = 1),
+      new RollupChild__c(RollupParent__c = parent.Id, NumberField__c = 1),
+      new RollupChild__c(RollupParent__c = parent.Id, NumberField__c = 1)
+    };
+
+    List<Rollup__mdt> metas = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'RollupChild__c',
+        RollupFieldOnCalcItem__c = 'NumberField__c',
+        LookupFieldOnCalcItem__c = 'RollupParent__c',
+        LookupObject__c = 'RollupGrandparent__c',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AmountFromChildren__c',
+        RollupOperation__c = 'SUM',
+        CalcItemWhereClause__c = ' ||| RollupParent__r.RollupGrandparent__r.Id = \'' + grandparent.Id + '\'',
+        GrandparentRelationshipFieldPath__c = 'RollupParent__r.RollupGrandparent__r.AmountFromChildren__c'
+      )
+    };
+
+    Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_SINGULAR_PARENT_RECALC_LWC.name());
+
+    grandparent = [SELECT AmountFromChildren__c FROM RollupGrandparent__c WHERE Id = :grandparent.Id];
+    System.assertEquals(3, grandparent.AmountFromChildren__c);
+  }
+
+  @IsTest
   static void shouldNotBlowUpOnMassiveQuery() {
     String endOfWhereClause = '2'.repeat(100001);
     Rollup__mdt meta = new Rollup__mdt(
@@ -1265,7 +1306,7 @@ private class RollupFullRecalcTests {
     };
 
     Test.startTest();
-    Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_LWC.name());
+    Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_FULL_RECALC_LWC.name());
     Test.stopTest();
 
     acc = [SELECT AnnualRevenue FROM Account WHERE Id = :acc.Id];
@@ -1344,7 +1385,7 @@ private class RollupFullRecalcTests {
     };
 
     Test.startTest();
-    Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_LWC.name());
+    Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_FULL_RECALC_LWC.name());
     Test.stopTest();
 
     List<Account> accounts = [SELECT AccountNumber, AnnualRevenue, Name FROM Account];
@@ -1394,7 +1435,7 @@ private class RollupFullRecalcTests {
     };
 
     Test.startTest();
-    Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_LWC.name());
+    Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_FULL_RECALC_LWC.name());
     Test.stopTest();
 
     List<Account> accounts = [SELECT AccountNumber, AnnualRevenue, Name FROM Account];
@@ -1445,7 +1486,7 @@ private class RollupFullRecalcTests {
     };
 
     Test.startTest();
-    Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_LWC.name());
+    Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_FULL_RECALC_LWC.name());
     Test.stopTest();
 
     List<Account> accounts = [SELECT AnnualRevenue, Name FROM Account];
@@ -1532,7 +1573,7 @@ private class RollupFullRecalcTests {
     };
 
     Test.startTest();
-    Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_LWC.name());
+    Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_FULL_RECALC_LWC.name());
     Test.stopTest();
 
     acc = [SELECT AnnualRevenue FROM Account];
@@ -1609,7 +1650,7 @@ private class RollupFullRecalcTests {
     };
 
     Test.startTest();
-    Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_LWC.name());
+    Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_FULL_RECALC_LWC.name());
     Test.stopTest();
 
     // only one of the records will have been updated since the query limit will have led to an
@@ -1661,7 +1702,7 @@ private class RollupFullRecalcTests {
     };
 
     Test.startTest();
-    Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_LWC.name());
+    Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_FULL_RECALC_LWC.name());
     Test.stopTest();
 
     // only one of the records will have been updated since the query limit will have led to an

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -1267,7 +1267,6 @@ private class RollupIntegrationTests {
 
   @IsTest
   static void shouldNotIncludeNullForCountDistinct() {
-    // TODO fixme
     Account acc = [SELECT Id, Name, AnnualRevenue FROM Account];
 
     ContactPointAddress cpa = new ContactPointAddress(ParentId = acc.Id, Name = 'Testing CPA COUNT_DISTINCT null PreferenceRank');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.4.13",
+  "version": "1.5.0",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/plugins/ExtraCodeCoverage/README.md
+++ b/plugins/ExtraCodeCoverage/README.md
@@ -1,11 +1,11 @@
 # Extra Code Coverage
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sk13AAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sk7gAAC">
   <img alt="Deploy to Salesforce"
        src="../../media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sk13AAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sk7gAAC">
   <img alt="Deploy to Salesforce Sandbox"
        src="../../media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup/app/lwc/recalculateParentRollupFlexipage/__tests__/recalculateParentRollupFlexipage.test.js
+++ b/rollup/app/lwc/recalculateParentRollupFlexipage/__tests__/recalculateParentRollupFlexipage.test.js
@@ -29,6 +29,10 @@ function flushPromises() {
   return new Promise(resolve => setTimeout(resolve, 0));
 }
 
+// instead of passing the mock down through several promise layers
+// we'll keep it in the outer scope
+const mockFunction = jest.fn();
+
 describe('recalc parent rollup from flexipage tests', () => {
   beforeEach(() => {
     getRollupMetadataByCalcItem.mockResolvedValue(mockMetadata);
@@ -103,10 +107,6 @@ describe('recalc parent rollup from flexipage tests', () => {
     expect(parentRecalcEl.shadowRoot.querySelector('div')).toBeTruthy();
   });
 
-  // instead of passing the mock down through several promise layers
-  // we'll keep it in the outer scope
-  const mockFunction = jest.fn();
-
   it('should send CMDT to apex with parent record id when clicked', async () => {
     // set up pseudo-Aura on global window
     Object.defineProperty(global.window, '$A', {
@@ -118,7 +118,6 @@ describe('recalc parent rollup from flexipage tests', () => {
         }
       }
     });
-
     const parentRecalcEl = createElement('c-recalculate-parent-rollup-flexipage', {
       is: RecalculateParentRollupFlexipage
     });
@@ -150,5 +149,31 @@ describe('recalc parent rollup from flexipage tests', () => {
 
     // validate that aura refresh was called
     expect(mockFunction).toHaveBeenCalled();
+  });
+
+  it('should properly massage delimited parent Id string for grandparent rollups', async () => {
+    const parentRecalcEl = createElement('c-recalculate-parent-rollup-flexipage', {
+      is: RecalculateParentRollupFlexipage
+    });
+
+    const FAKE_RECORD_ID = '00100000000001';
+    const matchingMetadata = mockMetadata[Object.keys(mockMetadata)[0]];
+    delete matchingMetadata[0].CalcItem__r;
+    matchingMetadata[0].GrandparentRelationshipFieldPath__c = 'RollupParent__r.RollupGrandparent__r.Name';
+    matchingMetadata[0].LookupObject__c = 'RollupGrandparent__c';
+    parentRecalcEl.objectApiName = matchingMetadata[0].LookupObject__c;
+    parentRecalcEl.recordId = FAKE_RECORD_ID;
+    document.body.appendChild(parentRecalcEl);
+    await flushPromises().then(() => {
+      parentRecalcEl.shadowRoot.querySelector('lightning-button').click();
+    });
+    await flushPromises();
+
+    matchingMetadata[0].CalcItemWhereClause__c = " ||| RollupParent__r.RollupGrandparent__r.Id = '" + FAKE_RECORD_ID + "'";
+    expect(parentRecalcEl.shadowRoot.querySelector('lightning-spinner')).toBeFalsy();
+    expect(performSerializedBulkFullRecalc.mock.calls[0][0]).toEqual({
+      serializedMetadata: JSON.stringify(matchingMetadata),
+      invokePointName: 'FROM_SINGULAR_PARENT_RECALC_LWC'
+    });
   });
 });

--- a/rollup/app/lwc/recalculateParentRollupFlexipage/__tests__/recalculateParentRollupFlexipage.test.js
+++ b/rollup/app/lwc/recalculateParentRollupFlexipage/__tests__/recalculateParentRollupFlexipage.test.js
@@ -43,6 +43,7 @@ describe('recalc parent rollup from flexipage tests', () => {
       document.body.removeChild(document.body.firstChild);
     }
     jest.clearAllMocks();
+    mockMetadata.Contact[0].CalcItemWhereClause__c = ''; // ensure state is reset properly
   });
 
   it('should handle error on load gracefully', async () => {

--- a/rollup/app/lwc/recalculateParentRollupFlexipage/recalculateParentRollupFlexipage.js
+++ b/rollup/app/lwc/recalculateParentRollupFlexipage/recalculateParentRollupFlexipage.js
@@ -57,7 +57,10 @@ export default class RecalculateParentRollupFlexipage extends LightningElement {
   }
 
   _addMatchingMetadata(metadata) {
-    const equalsParent = metadata.LookupFieldOnCalcItem__c + " = '" + this.recordId + "'";
+    const parentLookup = metadata.GrandparentRelationshipFieldPath__c
+      ? metadata.GrandparentRelationshipFieldPath__c.substring(0, metadata.GrandparentRelationshipFieldPath__c.lastIndexOf('.')) + '.Id'
+      : metadata.LookupFieldOnCalcItem__c;
+    const equalsParent = parentLookup + " = '" + this.recordId + "'";
 
     if (metadata.CalcItemWhereClause__c && metadata.CalcItemWhereClause__c.length > 0) {
       metadata.CalcItemWhereClause__c = metadata.CalcItemWhereClause__c + DELIMITER + equalsParent;

--- a/rollup/app/lwc/rollupForceRecalculation/__tests__/rollupForceRecalculation.test.js
+++ b/rollup/app/lwc/rollupForceRecalculation/__tests__/rollupForceRecalculation.test.js
@@ -169,7 +169,10 @@ describe('Rollup force recalc tests', () => {
         .then(() => {
           const expectedList = mockMetadata['Contact'];
           delete expectedList[0]['CalcItem__r.QualifiedApiName'];
-          expect(performSerializedBulkFullRecalc.mock.calls[0][0]).toEqual({ serializedMetadata: JSON.stringify(expectedList), invokePointName: 'FROM_LWC' });
+          expect(performSerializedBulkFullRecalc.mock.calls[0][0]).toEqual({
+            serializedMetadata: JSON.stringify(expectedList),
+            invokePointName: 'FROM_FULL_RECALC_LWC'
+          });
         })
     );
   });

--- a/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js
+++ b/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js
@@ -122,7 +122,7 @@ export default class RollupForceRecalculation extends LightningElement {
 
         const localMetas = [...this.selectedRows];
         this._getMetadataWithChildrenRecords(localMetas);
-        jobId = await performSerializedBulkFullRecalc({ serializedMetadata: JSON.stringify(localMetas), invokePointName: 'FROM_LWC' });
+        jobId = await performSerializedBulkFullRecalc({ serializedMetadata: JSON.stringify(localMetas), invokePointName: 'FROM_FULL_RECALC_LWC' });
       } else {
         this._getMetadataWithChildrenRecords([this.metadata]);
         jobId = await performSerializedFullRecalculation({

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -212,7 +212,7 @@ global without sharing virtual class Rollup {
     FROM_APEX,
     FROM_INVOCABLE,
     FROM_SCHEDULED,
-    FROM_LWC,
+    FROM_FULL_RECALC_LWC,
     FROM_SINGULAR_PARENT_RECALC_LWC,
     FROM_STATIC_LOGGER,
     FROM_SCHEDULED_FLOW
@@ -351,7 +351,7 @@ global without sharing virtual class Rollup {
   }
 
   /**
-   * v1.3.25 to v1.4.0 introduced a child CMDT relationship: Rollup__mdt.RollupOrderBys__r
+   * Rollup__mdt has a child CMDT relationship: Rollup__mdt.RollupOrderBys__r
    * Unfortunately, data passed between the frontend and backend strips out child relationship values
    * (even when they were set and initialized via the backend itself!). In order to avoid a breaking change
    * on this method, it instead delegates to the new one.
@@ -454,13 +454,11 @@ global without sharing virtual class Rollup {
   /**
    * Sending metadata from the frontend LWCs omits
    * the RollupOrderBys__r children unless it's sent serialized (using the same
-   * child object format used in the "appendOrderByMetadata"). As with "performBulkFullRecalc",
-   * the original "performFullRecalculation" is kept to avoid breaking changes
-   * between v1.3.25 and v1.4.0
+   * child object format used in the "appendOrderByMetadata").
    */
   @AuraEnabled
   global static String performSerializedFullRecalculation(String metadata) {
-    return performSerializedBulkFullRecalc('[' + metadata + ']', InvocationPoint.FROM_LWC.name());
+    return performSerializedBulkFullRecalc('[' + metadata + ']', InvocationPoint.FROM_FULL_RECALC_LWC.name());
   }
 
   @AuraEnabled
@@ -2045,14 +2043,7 @@ global without sharing virtual class Rollup {
     }
     RollupEvaluator.WhereFieldEvaluator whereEval = RollupEvaluator.getWhereEval(fullRecalcMeta.wrapper.toString(), fullRecalcMeta.calcItemType);
     wrappedMeta.queryFields.addAll(getQueryFieldsFromMetadata(fullRecalcMeta.meta, whereEval));
-    if (
-      wrappedMeta.whereClause.contains(':recordIds') == false &&
-      wrappedMeta.recordIds.isEmpty() == false &&
-      // TODO - it would be nice to support the singular recalc button with grandparent rollups
-      // but doing so requires that we validate the query ahead of time (to remove errors with trying to filter on
-      // polymorphic fields). as it stands, this guard clause is a little TOO safe
-      String.isBlank(fullRecalcMeta.meta.GrandparentRelationshipFieldPath__c)
-    ) {
+    if (wrappedMeta.whereClause.contains(':recordIds') == false && wrappedMeta.recordIds.isEmpty() == false) {
       String additionalClause = (String.isNotBlank(wrappedMeta.whereClause) ? ' AND ' : '') + fullRecalcMeta.meta.LookupFieldOnCalcItem__c + ' = :recordIds';
       wrappedMeta.whereClause += additionalClause;
     }
@@ -2078,7 +2069,7 @@ global without sharing virtual class Rollup {
       amountOfCalcItems < parentResetProcessor.rollupControl.MaxLookupRowsBeforeBatching__c;
     if (amountOfCalcItems == 0 && matchingMeta.isEmpty() == false && isFullRecalcApp) {
       return parentResetProcessor;
-    } else if (invokePoint == InvocationPoint.FROM_SINGULAR_PARENT_RECALC_LWC) {
+    } else if (invokePoint != InvocationPoint.FROM_FULL_RECALC_LWC) {
       parentResetProcessor = null;
     }
 

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -636,7 +636,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   private Boolean isValidAdditionalCalcItemRetrieval(RollupAsyncProcessor roll) {
-    if ((roll.isFullRecalc == false && roll.metadata.IsFullRecordSet__c == false) || String.isNotBlank(roll.metadata.GrandparentRelationshipFieldPath__c)) {
+    if ((roll.isFullRecalc == false && roll.metadata.IsFullRecordSet__c == false)) {
       return false;
     } else if (roll.op?.name().contains('DELETE') == true) {
       // full recalc rollups won't have an op, hence the safe navigation above

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger extends Rollup implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.4.13';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.0';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
   private static Boolean disabledMessageHasBeenLogged = false;

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -104,6 +104,6 @@
         "apex-rollup@1.4.11-0": "04t6g000008Sk1IAAS",
         "apex-rollup@1.4.12-0": "04t6g000008Sk1rAAC",
         "apex-rollup@1.4.13-0": "04t6g000008Sk7CAAS",
-        "apex-rollup@1.5.0-0": "04t6g000008Sk7WAAS"
+        "apex-rollup@1.5.0-0": "04t6g000008Sk8FAAS"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Make parent-reset calculator more reliable when used in conjunction with full recalcs",
-            "versionNumber": "1.4.13.0",
+            "versionName": "Minor verision bump to reflect breaking changes between 1.4.10 and versions up to 1.4.13. Added preliminary support for using parent recalc button with grandparent rollups.",
+            "versionNumber": "1.5.0.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -71,11 +71,11 @@
             "path": "plugins\\ExtraCodeCoverage",
             "package": "Apex Rollup - Extra Code Coverage",
             "versionName": "Updating code coverage",
-            "versionNumber": "0.0.9.0",
+            "versionNumber": "0.0.10.0",
             "default": false,
             "dependencies": [
                 {
-                    "package": "apex-rollup@1.4.11-0"
+                    "package": "apex-rollup@1.5.0-0"
                 }
             ]
         }
@@ -89,11 +89,9 @@
         "Apex Rollup - Custom Logger@0.0.11-0": "04t6g000008SirvAAC",
         "Apex Rollup - Custom Logger@0.0.12-0": "04t6g000008SjqIAAS",
         "Apex Rollup - Extra Code Coverage": "0Ho6g000000GnCWCA0",
-        "Apex Rollup - Extra Code Coverage@0.0.5-0": "04t6g000008SizvAAC",
-        "Apex Rollup - Extra Code Coverage@0.0.6-0": "04t6g000008Sj8jAAC",
-        "Apex Rollup - Extra Code Coverage@0.0.7-0": "04t6g000008SjIVAA0",
         "Apex Rollup - Extra Code Coverage@0.0.8-0": "04t6g000008SjuzAAC",
         "Apex Rollup - Extra Code Coverage@0.0.9-0": "04t6g000008Sk13AAC",
+        "Apex Rollup - Extra Code Coverage@0.0.10-0": "04t6g000008Sk7gAAC",
         "Apex Rollup - Nebula Logger": "0Ho6g000000Gn8PCAS",
         "Apex Rollup - Nebula Logger@0.0.5-0": "04t6g000008Si1BAAS",
         "Apex Rollup - Nebula Logger@0.0.6-0": "04t6g000008SiisAAC",
@@ -102,12 +100,10 @@
         "Apex Rollup - Rollup Callback@0.0.3-0": "04t6g000008Sis0AAC",
         "Nebula Logger - Unlocked Package@4.5.2-0-plugin-framework-enhancements": "04t5Y0000027FNaQAM",
         "apex-rollup": "0Ho6g000000TNcOCAW",
-        "apex-rollup@1.4.7-0": "04t6g000008SjYzAAK",
-        "apex-rollup@1.4.8-0": "04t6g000008SjuVAAS",
-        "apex-rollup@1.4.9-0": "04t6g000008SjufAAC",
         "apex-rollup@1.4.10-0": "04t6g000008Sjv4AAC",
         "apex-rollup@1.4.11-0": "04t6g000008Sk1IAAS",
         "apex-rollup@1.4.12-0": "04t6g000008Sk1rAAC",
-        "apex-rollup@1.4.13-0": "04t6g000008Sk7CAAS"
+        "apex-rollup@1.4.13-0": "04t6g000008Sk7CAAS",
+        "apex-rollup@1.5.0-0": "04t6g000008Sk7WAAS"
     }
 }


### PR DESCRIPTION
* Fixes #176 (finally!!) by adding support for grandparent rollups from the singular full recalc button on (grand)parent records. Fixes an issue with full recalcs clearing values incorrectly on occasion.
* Bumps minor version to reflect some possible breaking changes discussed in #298
* Fixes an issue with some full recalc code paths where other parents' rollup values could get inadvertently cleared. The parent reset logic is now solely contained within code paths called from the full recalc application.