### PR TITLE
V1.5.1 - MIN/MAX on Date Fields Bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Create fast, scalable custom rollups driven by Custom Metadata in your Salesforc
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sk8FAAS">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sk8KAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sk8FAAS">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sk8KAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupCalculatorTests.cls
+++ b/extra-tests/classes/RollupCalculatorTests.cls
@@ -1183,7 +1183,25 @@ private class RollupCalculatorTests {
 
     calc.performRollup(new List<Task>{ t }, new Map<Id, SObject>{ t.Id => new Task(ActivityDate = today) });
 
-    System.assertEquals(t.ActivityDate, calc.getReturnValue(), 'Should be nulled out if no matching minimum');
+    System.assertEquals(t.ActivityDate, calc.getReturnValue(), 'Should correctly find minimum');
+  }
+
+  @IsTest
+  static void dateMinDoesNotBlowUpOnNullValue() {
+    Date firstPossibleDate = Date.newInstance(1970, 1, 1);
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      firstPossibleDate,
+      Rollup.Op.MIN,
+      Opportunity.CloseDate, // not a "MIN"-able field in SOQL; crucial for this test
+      Opportunity.CloseDate,
+      new Rollup__mdt(CalcItem__c = 'Opportunity'),
+      RollupTestUtils.createId(Opportunity.SObjectType),
+      Opportunity.Name
+    );
+
+    calc.performRollup(new List<SObject>(), new Map<Id, SObject>());
+
+    System.assertEquals(null, calc.getReturnValue());
   }
 
   @IsTest

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -1798,15 +1798,6 @@ private class RollupIntegrationTests {
     System.assertEquals(250, updatedAcc.NumberOfEmployees, 'Number of employees should also have been decremented');
   }
 
-  @IsTest
-  static void returnsPicklistEntriesCorrectlyToFrontend() {
-    List<String> expectedValues = new List<String>();
-    for (Schema.PicklistEntry entry : Rollup__mdt.RollupOperation__c.getDescribe().getPicklistValues()) {
-      expectedValues.add(entry.getValue());
-    }
-    System.assertEquals(expectedValues, Rollup.getRollupOperationValues());
-  }
-
   /** Schedulable tests */
   @IsTest
   static void shouldThrowExceptionForBadQuery() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/app/lwc/recalculateParentRollupFlexipage/__tests__/recalculateParentRollupFlexipage.test.js
+++ b/rollup/app/lwc/recalculateParentRollupFlexipage/__tests__/recalculateParentRollupFlexipage.test.js
@@ -32,10 +32,12 @@ function flushPromises() {
 // instead of passing the mock down through several promise layers
 // we'll keep it in the outer scope
 const mockFunction = jest.fn();
+let metadata;
 
 describe('recalc parent rollup from flexipage tests', () => {
   beforeEach(() => {
-    getRollupMetadataByCalcItem.mockResolvedValue(mockMetadata);
+    metadata = JSON.parse(JSON.stringify(mockMetadata));
+    getRollupMetadataByCalcItem.mockResolvedValue(metadata);
     performSerializedBulkFullRecalc.mockReset();
   });
   afterEach(() => {
@@ -43,17 +45,15 @@ describe('recalc parent rollup from flexipage tests', () => {
       document.body.removeChild(document.body.firstChild);
     }
     jest.clearAllMocks();
-    mockMetadata.Contact[0].CalcItemWhereClause__c = ''; // ensure state is reset properly
   });
 
   it('should handle error on load gracefully', async () => {
-    getRollupMetadataByCalcItem.mockReset();
     getRollupMetadataByCalcItem.mockRejectedValue('error!');
 
     const parentRecalcEl = createElement('c-recalculate-parent-rollup-flexipage', {
       is: RecalculateParentRollupFlexipage
     });
-    parentRecalcEl.objectApiName = mockMetadata[Object.keys(mockMetadata)[0]][0].LookupObject__c;
+    parentRecalcEl.objectApiName = metadata[Object.keys(metadata)[0]][0].LookupObject__c;
     document.body.appendChild(parentRecalcEl);
 
     return flushPromises().then(() => {
@@ -63,7 +63,7 @@ describe('recalc parent rollup from flexipage tests', () => {
 
   it('should not render anything if object api name has no match for parent in retrieved metadata', async () => {
     const fakeObjectName = 'Lead';
-    expect(mockMetadata[fakeObjectName]).toBeFalsy();
+    expect(metadata[fakeObjectName]).toBeFalsy();
 
     const parentRecalcEl = createElement('c-recalculate-parent-rollup-flexipage', {
       is: RecalculateParentRollupFlexipage
@@ -81,7 +81,7 @@ describe('recalc parent rollup from flexipage tests', () => {
       is: RecalculateParentRollupFlexipage
     });
 
-    parentRecalcEl.objectApiName = mockMetadata[Object.keys(mockMetadata)[0]][0].LookupObject__c;
+    parentRecalcEl.objectApiName = metadata[Object.keys(metadata)[0]][0].LookupObject__c;
     document.body.appendChild(parentRecalcEl);
 
     return flushPromises().then(() => {
@@ -96,7 +96,7 @@ describe('recalc parent rollup from flexipage tests', () => {
     });
 
     const FAKE_RECORD_ID = '00100000000001';
-    const matchingMetadata = mockMetadata[Object.keys(mockMetadata)[0]];
+    const matchingMetadata = metadata[Object.keys(metadata)[0]];
     delete matchingMetadata[0].CalcItem__r;
     parentRecalcEl.objectApiName = matchingMetadata[0].LookupObject__c;
     parentRecalcEl.recordId = FAKE_RECORD_ID;
@@ -124,7 +124,7 @@ describe('recalc parent rollup from flexipage tests', () => {
     });
 
     const FAKE_RECORD_ID = '00100000000001';
-    const matchingMetadata = mockMetadata[Object.keys(mockMetadata)[0]];
+    const matchingMetadata = metadata[Object.keys(metadata)[0]];
     delete matchingMetadata[0].CalcItem__r;
     parentRecalcEl.objectApiName = matchingMetadata[0].LookupObject__c;
     parentRecalcEl.recordId = FAKE_RECORD_ID;
@@ -158,7 +158,7 @@ describe('recalc parent rollup from flexipage tests', () => {
     });
 
     const FAKE_RECORD_ID = '00100000000001';
-    const matchingMetadata = mockMetadata[Object.keys(mockMetadata)[0]];
+    const matchingMetadata = metadata[Object.keys(metadata)[0]];
     delete matchingMetadata[0].CalcItem__r;
     matchingMetadata[0].GrandparentRelationshipFieldPath__c = 'RollupParent__r.RollupGrandparent__r.Name';
     matchingMetadata[0].LookupObject__c = 'RollupGrandparent__c';

--- a/rollup/app/lwc/rollupForceRecalculation/__tests__/rollupForceRecalculation.test.js
+++ b/rollup/app/lwc/rollupForceRecalculation/__tests__/rollupForceRecalculation.test.js
@@ -3,6 +3,7 @@ import { getObjectInfo } from 'lightning/uiObjectInfoApi';
 import performSerializedFullRecalculation from '@salesforce/apex/Rollup.performSerializedFullRecalculation';
 import performSerializedBulkFullRecalc from '@salesforce/apex/Rollup.performSerializedBulkFullRecalc';
 import getBatchRollupStatus from '@salesforce/apex/Rollup.getBatchRollupStatus';
+import getRollupMetadataByCalcItem from '@salesforce/apex/Rollup.getRollupMetadataByCalcItem';
 
 import { mockMetadata } from '../../__mockData__';
 import RollupForceRecalculation from 'c/rollupForceRecalculation';
@@ -17,7 +18,7 @@ jest.mock(
   '@salesforce/apex/Rollup.getRollupMetadataByCalcItem',
   () => {
     return {
-      default: () => mockMetadata
+      default: jest.fn()
     };
   },
   { virtual: true }
@@ -53,6 +54,9 @@ function setElementValue(element, value, isCombobox = false) {
 }
 
 describe('Rollup force recalc tests', () => {
+  beforeEach(() => {
+    getRollupMetadataByCalcItem.mockResolvedValue(mockMetadata);
+  });
   afterEach(() => {
     while (document.body.firstChild) {
       document.body.removeChild(document.body.firstChild);

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -466,15 +466,6 @@ global without sharing virtual class Rollup {
     return performSerializedFullRecalculation(JSON.serialize(meta));
   }
 
-  @AuraEnabled
-  public static List<String> getRollupOperationValues() {
-    List<String> picklistValues = new List<String>();
-    for (Schema.PicklistEntry entry : Rollup__mdt.RollupOperation__c.getDescribe().getPicklistValues()) {
-      picklistValues.add(entry.getValue());
-    }
-    return picklistValues;
-  }
-
   global class FlowInput {
     @InvocableVariable(label='Calc Item Calc Field' description='The API Name of the field on each of the records passed in to rollup.' required=true)
     global String rollupFieldOnCalcItem;

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -673,7 +673,7 @@ public without sharing abstract class RollupCalculator {
 
     public override Object getReturnValue() {
       Object superReturnVal = super.getReturnValue();
-      return superReturnVal == 0 ? this.defaultVal : ((Datetime) superReturnVal).dateGmt();
+      return superReturnVal == 0 ? this.defaultVal : ((Datetime) superReturnVal)?.dateGmt();
     }
   }
 

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger extends Rollup implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.0';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.1';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
   private static Boolean disabledMessageHasBeenLogged = false;

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Minor verision bump to reflect breaking changes between 1.4.10 and versions up to 1.4.13. Added preliminary support for using parent recalc button with grandparent rollups.",
-            "versionNumber": "1.5.0.0",
+            "versionName": "Reduced code surrounding the display of Rollup Operation picklist values for the full recalc app.",
+            "versionNumber": "1.5.1.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Reduced code surrounding the display of Rollup Operation picklist values for the full recalc app.",
+            "versionName": "Reduced code surrounding the display of Rollup Operation picklist values for the full recalc app. Fixed NPE exposed when trying to MIN on Date fields with no matching items.",
             "versionNumber": "1.5.1.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -104,6 +104,7 @@
         "apex-rollup@1.4.11-0": "04t6g000008Sk1IAAS",
         "apex-rollup@1.4.12-0": "04t6g000008Sk1rAAC",
         "apex-rollup@1.4.13-0": "04t6g000008Sk7CAAS",
-        "apex-rollup@1.5.0-0": "04t6g000008Sk8FAAS"
+        "apex-rollup@1.5.0-0": "04t6g000008Sk8FAAS",
+        "apex-rollup@1.5.1-0": "04t6g000008Sk8KAAS"
     }
 }


### PR DESCRIPTION
* Fixes #303 by properly handling potentially null dates on MIN/MAX operations
* Reduced code in Full Recalc app associated with retrieving `Rollup__mdt.RollupOperation__c` picklist values