### PR TITLE
V1.5.3 - One To Many rollup adjustments, MIN/MAX bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 Create fast, scalable custom rollups driven by Custom Metadata in your Salesforce org with Apex Rollup. As seen on [Replacing DLRS With Custom Rollup](https://www.jamessimone.net/blog/joys-of-apex/replacing-dlrs-with-custom-rollup/) and on [Unofficial SF](https://unofficialsf.com/from-james-simone-create-powerful-rollups-in-your-flows-with-a-single-perform-rollup-action/) - if you are looking to replace DLRS with Apex Rollup, [we have a whole migration section for you](#migrating-from-dlrs)!
 
+Please note that there are _toggleable_ dropdown sections used frequently in this document. Keep your eyes peeled for sections entitled "Expand for ...", as tapping on those will produce much more in the way of documentation.
+
+As well, don't miss [the Wiki](../../wiki), which includes more advanced information available on many topics.
+
 ## Deployment & Setup
 
 <a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sk93AAC">
@@ -291,7 +295,7 @@ There is an included Lightning Web Component (LWC) that will show up in the "Cus
 - The button _will_ display even if a given parent record has no matching children associated with the rollup(s) in question.
 - This particular rollup runs synchronously, so it won't eat into your Asynchronous Job limits for the day; it also refreshes any Aura/page-layout sections of the page (LWC-based sections of the page should update automatically).
 - Editing `Rollup__mdt` records with a parent record's page open can lead to unexpected behavior. This is because the `Rollup__mdt` records are cached on page load, so any updates made to those records will require a page refresh prior to clicking the `Recalc Rollup` button
-- Triggering recalcs from a grandparent record is supported, but polymorphic grandparents (for example, and Account rollup that starts from Task -> Opportunity -> Account through the `WhatId` is not yet supported).
+- Triggering recalcs from a grandparent record is supported, but polymorphic grandparents (for example, an Account rollup that starts from Task -> Opportunity -> Account through the `WhatId` is not yet supported).
 
 ## Scheduled Jobs
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sk93AAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkBEAA0">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Sk93AAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkBEAA0">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ In either case, the SOQL query needs to correspond to either the parent or the c
 <details>
   <summary>Expand for Grandparent rollup info</summary>
 
-[Check out the Wiki article for more information on Grandparent rollups](<../../wiki/Configuring-Grandparent-(or-Greater)-Rollups>), or follow along here -
+[Check out the Wiki article for more information on Grandparent rollups](<../../wiki/Configuring-Grandparent-(or-Greater)-Rollups>), the [Wiki article for Ultimate Parent Rollups](../../wiki/Configuring-Hierarchy-Ultimate-Parent-Rollups) or follow along here -
 
 It's not all that uncommon, especially with custom objects, to get into the practice of rolling up values from one object merely so that _another_ parent object can receive _those_ rolled up values; that is to say, we occasionally use intermediate objects in order to roll values up from a grandchild record to a grandparent (and there's no need to stop there; it's totally possible to want to roll up values from great-grandchildren to the great-grandparent record, and so on). Apex Rollup offers the never-before-seen functionality of skipping the intermediate records so that you can go directly to the ultimate parent object. This is supported through the invocable rollup actions, as well as through the CMDT-based rollup approach by filling out the optional field `Grandparent Relationship Field Path`:
 
@@ -348,7 +348,7 @@ In this example, there are four objects in scope:
 - if you are using `Grandparent Relationship Field Path` with a polymorphic standard field like `Task.WhatId` or `Task.WhoId`, you should also supply a `Calc Item Where Clause` to ensure you are filtering the calculation items to only be related to one type of parent at a time (eg: your `Calc Item Where Clause` would look like `What.Type = 'Account'`)
 - grandparent rollups respect [SOQL's map relationship-field hopping of 5 levels](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_relationships_query_limits.htm):
 
-> In each specified relationship, no more than five levels can be specified in a child-to-parent relationship. For example, Contact.Account.Owner.FirstName (three levels)
+> In each specified relationship, no more than five levels can be specified in a child-to-parent relationship. For example, `Contact.Account.Owner.FirstName` would be three levels.
 
 While the base architecture for retrieving grand(or greater)parent items has no technical limit on the number of relationship field hops that can be made, correctly re-triggering the rollup calculations after an intermediate object has been updated made it necessary to respect this limit (for now).
 

--- a/extra-tests/classes/RollupCalculatorTests.cls
+++ b/extra-tests/classes/RollupCalculatorTests.cls
@@ -1350,6 +1350,52 @@ private class RollupCalculatorTests {
     System.assertEquals(null, calc.getReturnValue());
   }
 
+  @IsTest
+  static void properlyConvertsDownstreamTypesToDecimals() {
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      System.today().addDays(-10),
+      Rollup.Op.MAX,
+      Opportunity.CloseDate,
+      Contact.BirthDate,
+      new Rollup__mdt(CalcItem__c = 'Opportunity'),
+      RollupTestUtils.createId(Contact.SObjectType),
+      Opportunity.Name
+    );
+
+    Object newDefaultValue = System.today();
+    calc.setDefaultValues(RollupTestUtils.createId(Contact.SObjectType), newDefaultValue);
+
+    System.assertEquals(newDefaultValue, calc.getReturnValue());
+
+    calc = RollupCalculator.Factory.getCalculator(
+      System.now().addDays(-10),
+      Rollup.Op.MAX,
+      Opportunity.CloseDate,
+      Contact.BirthDate,
+      new Rollup__mdt(CalcItem__c = 'Opportunity'),
+      RollupTestUtils.createId(Contact.SObjectType),
+      Opportunity.Name
+    );
+    newDefaultValue = System.now();
+    calc.setDefaultValues(RollupTestUtils.createId(Contact.SObjectType), newDefaultValue);
+
+    System.assertEquals(newDefaultValue, calc.getReturnValue());
+
+    calc = RollupCalculator.Factory.getCalculator(
+      Time.newInstance(0, 0, 0, 0),
+      Rollup.Op.MAX,
+      Opportunity.CloseDate,
+      Contact.BirthDate,
+      new Rollup__mdt(CalcItem__c = 'Opportunity'),
+      RollupTestUtils.createId(Contact.SObjectType),
+      Opportunity.Name
+    );
+    newDefaultValue = Time.newInstance(1, 0, 0, 0);
+    calc.setDefaultValues(RollupTestUtils.createId(Contact.SObjectType), newDefaultValue);
+
+    System.assertEquals(newDefaultValue, calc.getReturnValue());
+  }
+
   // Factory tests
 
   @IsTest

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -591,6 +591,51 @@ private class RollupIntegrationTests {
   }
 
   @IsTest
+  static void performsRollupWhenIntermediateOneToManyChildrenUpdated() {
+    Rollup.onlyUseMockMetadata = true;
+    Account acc = [SELECT Id, AnnualRevenue FROM Account];
+    acc.AnnualRevenue = 47;
+    update acc;
+    Account initialParent = new Account(Name = 'Initial', AnnualRevenue = acc.AnnualRevenue);
+    insert initialParent;
+
+    Individual indy = new Individual(LastName = 'Indy');
+    insert indy;
+    Contact con = new Contact(LastName = 'One To Many Child', AccountId = acc.Id, IndividualId = indy.Id);
+    insert con;
+
+    RollupAsyncProcessor.shouldFlattenAsyncProcesses = true;
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'Account',
+        LookupObject__c = 'Individual',
+        LookupFieldOnCalcItem__c = 'Id',
+        RollupOperation__c = 'SUM',
+        RollupFieldOnLookupObject__c = 'ConsumerCreditScore',
+        RollupFieldOnCalcItem__c = 'AnnualRevenue',
+        LookupFieldOnLookupObject__c = 'Id',
+        GrandparentRelationshipFieldPath__c = 'Contacts.Individual.ConsumerCreditScore',
+        OneToManyGrandparentFields__c = 'Contact.AccountId'
+      )
+    };
+    Rollup.shouldRun = true;
+    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
+    Rollup.records = new List<Contact>{ con };
+    Rollup.oldRecordsMap = new Map<Id, Contact>{ con.Id => new Contact(Id = con.Id, AccountId = initialParent.Id) };
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Individual updatedIndy = [SELECT Id, ConsumerCreditScore FROM Individual WHERE Id = :indy.Id];
+    System.assertEquals(
+      acc.AnnualRevenue,
+      updatedIndy.ConsumerCreditScore,
+      'Apex grandparent rollup should run with reparenting change to intermediate records'
+    );
+  }
+
+  @IsTest
   static void shouldRunGrandparentRollupsWhenIntermediateObjectsAreUpdatedFromApex() {
     Account greatGrandparent = new Account(Name = 'Great-grandparent');
     Account secondGreatGrandparent = new Account(Name = 'Second great-grandparent');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1831,7 +1831,7 @@ global without sharing virtual class Rollup {
           meta.CalcItemWhereClause__c
         );
       } else if (isIntermediateRollupForGrandparent) {
-        queryWrapper = getIntermediateGrandparentQueryWrapper(meta.GrandparentRelationshipFieldPath__c, calcItems, oldCalcItems);
+        queryWrapper = getIntermediateGrandparentQueryWrapper(meta, calcItems, oldCalcItems);
       }
 
       if (queryWrapper != null) {
@@ -2171,18 +2171,27 @@ global without sharing virtual class Rollup {
     throw ex;
   }
 
-  private static QueryWrapper getIntermediateGrandparentQueryWrapper(String grandparentFieldPath, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
+  private static QueryWrapper getIntermediateGrandparentQueryWrapper(Rollup__mdt meta, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
     if (isCDC) {
       return new QueryWrapper();
     }
 
     SObjectType sObjectType = calcItems[0].getSObjectType();
-    SObjectField fieldToken = getPartOfGrandparentChain(grandparentFieldPath, sObjectType);
+    SObjectField fieldToken = getPartOfGrandparentChain(meta, sObjectType);
     String relationshipName = fieldToken.getDescribe().getRelationshipName();
-    Integer relationshipIndex = grandparentFieldPath.indexOf(relationshipName) + relationshipName.length();
-    String priorFieldPath = grandparentFieldPath.substring(0, relationshipIndex) + '.Id';
-    QueryWrapper wrapper = new QueryWrapper('', priorFieldPath);
+    Integer relationshipIndex = meta.GrandparentRelationshipFieldPath__c.indexOf(relationshipName) + relationshipName.length();
+    String priorFieldPath = meta.GrandparentRelationshipFieldPath__c.substring(0, relationshipIndex) + '.Id';
+    if (meta.OneToManyGrandparentFields__c != null && meta.OneToManyGrandparentFields__c.contains(fieldToken.getDescribe().getName())) {
+      List<String> fieldPathTuples = meta.OneToManyGrandparentFields__c.split(',');
+      for (String fieldPathTuple : fieldPathTuples) {
+        if (fieldToken.getDescribe().getName().equalsIgnoreCase(fieldPathTuple.substringAfter('.'))) {
+          priorFieldPath = 'Id';
+          break;
+        }
+      }
+    }
 
+    QueryWrapper wrapper = new QueryWrapper('', priorFieldPath);
     for (SObject calcItem : calcItems) {
       SObject oldCalcItem = oldCalcItems.containsKey(calcItem.Id) ? oldCalcItems.get(calcItem.Id) : calcItem;
       String currentLookup = (String) calcItem.get(fieldToken);
@@ -2345,7 +2354,7 @@ global without sharing virtual class Rollup {
     for (Integer index = rollupMetadatas.size() - 1; index >= 0; index--) {
       Rollup__mdt meta = rollupMetadatas[index];
       if (String.isNotBlank(meta.GrandparentRelationshipFieldPath__c)) {
-        if (getPartOfGrandparentChain(meta.GrandparentRelationshipFieldPath__c, sObjectType) != null) {
+        if (getPartOfGrandparentChain(meta, sObjectType) != null) {
           continue;
         } else if (isNotTriggeredByMatchingObject(meta, sObjectName)) {
           rollupMetadatas.remove(index);
@@ -2366,15 +2375,24 @@ global without sharing virtual class Rollup {
       (meta.IsRollupStartedFromParent__c && sObjectName != meta.LookupObject__c);
   }
 
-  private static SObjectField getPartOfGrandparentChain(String grandParentFieldPath, SObjectType sObjectType) {
-    List<String> validRelationshipNames = grandParentFieldPath.split('\\.');
+  private static SObjectField getPartOfGrandparentChain(Rollup__mdt meta, SObjectType sObjectType) {
+    List<String> validRelationshipNames = meta.GrandparentRelationshipFieldPath__c.split('\\.');
     // remove the last field since it's not a relationship
-    validRelationshipNames.remove(validRelationShipNames.size() - 1);
-    DescribeSObjectResult describeObject = sObjectType.getDescribe();
-    List<SObjectField> fieldTokens = describeObject.fields.getMap().values();
-    for (SObjectField fieldToken : fieldTokens) {
-      if (validRelationshipNames.contains(fieldToken.getDescribe().getRelationshipName())) {
+    validRelationshipNames.remove(validRelationshipNames.size() - 1);
+    for (SObjectField fieldToken : sObjectType.getDescribe().fields.getMap().values()) {
+      if (fieldToken.getDescribe().getRelationshipName() == null) {
+        continue;
+      } else if (validRelationshipNames.contains(fieldToken.getDescribe().getRelationshipName())) {
         return fieldToken;
+      } else if (String.isNotBlank(meta.OneToManyGrandparentFields__c)) {
+        List<SObjectType> parents = fieldToken.getDescribe().getReferenceTo();
+        for (SObjectType parent : parents) {
+          for (ChildRelationship child : parent.getDescribe().getChildRelationships()) {
+            if (validRelationshipNames.contains(child.getRelationshipName())) {
+              return fieldToken;
+            }
+          }
+        }
       }
     }
     return null;

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -473,7 +473,7 @@ public without sharing abstract class RollupCalculator {
       super(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata.FullRecalculationDefaultNumberValue__c, metadata, lookupRecordKey, lookupKeyField);
     }
 
-    public override void setDefaultValues(String lookupRecordKey, Object priorVal) {
+    public virtual override void setDefaultValues(String lookupRecordKey, Object priorVal) {
       super.setDefaultValues(lookupRecordKey, priorVal);
       this.returnDecimal = (Decimal) this.returnVal;
     }
@@ -628,6 +628,13 @@ public without sharing abstract class RollupCalculator {
       return superReturnVal;
     }
 
+    public virtual override void setDefaultValues(String lookupRecordKey, Object priorVal) {
+      if (priorVal instanceof Datetime) {
+        priorVal = ((Datetime) priorVal).getTime();
+      }
+      super.setDefaultValues(lookupRecordKey, priorVal);
+    }
+
     protected virtual override Decimal getDecimalOrDefault(Object potentiallyUnitializedDecimal) {
       if (potentiallyUnitializedDecimal == null) {
         return RollupFieldInitializer.Current.defaultDateTime.getTime();
@@ -649,8 +656,6 @@ public without sharing abstract class RollupCalculator {
   }
 
   private without sharing class DateRollupCalculator extends DatetimeRollupCalculator {
-    // for Date, it's not necessary to override the "getDecimalOrDefault" method in DatetimeRollupCalculator
-    // because the conversion only happens in "getReturnValue"
     public DateRollupCalculator(
       Object priorVal,
       Rollup.Op op,
@@ -669,6 +674,13 @@ public without sharing abstract class RollupCalculator {
         lookupRecordKey,
         lookupKeyField
       );
+    }
+
+    public override void setDefaultValues(String lookupRecordKey, Object priorVal) {
+      if (priorVal instanceof Date) {
+        priorVal = Datetime.newInstanceGmt((Date) priorVal, Time.newInstance(0, 0, 0, 0)).getTime();
+      }
+      super.setDefaultValues(lookupRecordKey, priorVal);
     }
 
     public override Object getReturnValue() {
@@ -696,6 +708,13 @@ public without sharing abstract class RollupCalculator {
         lookupRecordKey,
         lookupKeyField
       );
+    }
+
+    public override void setDefaultValues(String lookupRecordKey, Object priorVal) {
+      if (priorVal instanceof Time) {
+        priorVal = Datetime.newInstanceGmt(RollupFieldInitializer.Current.defaultDateTime.dateGmt(), (Time) priorVal);
+      }
+      super.setDefaultValues(lookupRecordKey, priorVal);
     }
 
     public override Object getReturnValue() {

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger extends Rollup implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.2';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.3';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
   private static Boolean disabledMessageHasBeenLogged = false;

--- a/rollup/core/classes/RollupRelationshipFieldFinder.cls
+++ b/rollup/core/classes/RollupRelationshipFieldFinder.cls
@@ -516,42 +516,32 @@ public without sharing class RollupRelationshipFieldFinder {
   }
 
   private void retrieveAdditionalHierarchyRecords(List<SObject> records, Set<Id> objIds) {
-    String whereClause = 'Id != :records';
     if (this.metadata.RollupToUltimateParent__c == false) {
       return;
-    } else if (records.isEmpty()) {
-      List<SObject> otherMatchingParentRecords = this.performQuery(
-        this.ultimateParent,
-        new List<String>{ this.metadata.UltimateParentLookup__c, 'Id' },
-        this.metadata.UltimateParentLookup__c,
-        '=',
-        objIds,
-        whereClause,
-        records
-      );
-      if (otherMatchingParentRecords.isEmpty() == false) {
-        this.retrieveAdditionalHierarchyRecords(otherMatchingParentRecords, objIds);
-      }
-    } else {
-      Set<Id> additionalParentIds = new Set<Id>();
+    }
+
+    String whereClause = 'Id != :records';
+    List<String> queryFields = new List<String>{ 'Id', this.metadata.UltimateParentLookup__c };
+    if (records.isEmpty() == false) {
+      objIds = new Set<Id>();
       for (SObject otherMatchingParent : records) {
-        additionalParentIds.add(otherMatchingParent.Id);
-        this.trackTraversalIds(otherMatchingParent.Id, (Id) otherMatchingParent.get(this.metadata.UltimateParentLookup__c), null, additionalParentIds);
+        objIds.add(otherMatchingParent.Id);
+        this.trackTraversalIds(otherMatchingParent.Id, (Id) otherMatchingParent.get(this.metadata.UltimateParentLookup__c), null, objIds);
       }
-      List<SObject> otherPotentialParents = this.performQuery(
-        this.ultimateParent,
-        new List<String>{ this.metadata.UltimateParentLookup__c, 'Id' },
-        this.metadata.UltimateParentLookup__c,
-        '=',
-        additionalParentIds,
-        whereClause,
-        records
-      );
-      if (otherPotentialParents.isEmpty()) {
-        this.retrieveAdditionalCalcItems();
-      } else {
-        this.retrieveAdditionalHierarchyRecords(otherPotentialParents, additionalParentIds);
-      }
+    }
+    List<SObject> otherPotentialParents = this.performQuery(
+      this.ultimateParent,
+      queryFields,
+      this.metadata.UltimateParentLookup__c,
+      '=',
+      objIds,
+      whereClause,
+      records
+    );
+    if (otherPotentialParents.isEmpty()) {
+      this.retrieveAdditionalCalcItems();
+    } else {
+      this.retrieveAdditionalHierarchyRecords(otherPotentialParents, objIds);
     }
   }
 
@@ -574,9 +564,11 @@ public without sharing class RollupRelationshipFieldFinder {
       Set<String> queryFields = new Set<String>{
         this.metadata.LookupFieldOnCalcItem__c,
         this.metadata.RollupFieldOnCalcItem__c,
-        this.metadata.OrderByFirstLast__c,
-        this.metadata.UltimateParentLookup__c
+        this.metadata.OrderByFirstLast__c
       };
+      if (childType == this.ultimateParent) {
+        queryFields.add(this.metadata.UltimateParentLookup__c);
+      }
       queryFields.addAll(RollupEvaluator.getWhereEval(this.metadata.CalcItemWhereClause__c, childType).getQueryFields());
       String query = RollupQueryBuilder.Current.getQuery(childType, new List<String>(queryFields), this.metadata.LookupFieldOnCalcItem__c, '=');
       query += '\nAND Id != :records';

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Added case-insensitivity to RollupEvaluator",
-            "versionNumber": "1.5.2.0",
+            "versionName": "Added ability to perform parent-level recalc using LWC button for one-to-many grandparent rollups",
+            "versionNumber": "1.5.3.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -106,6 +106,7 @@
         "apex-rollup@1.4.13-0": "04t6g000008Sk7CAAS",
         "apex-rollup@1.5.0-0": "04t6g000008Sk8FAAS",
         "apex-rollup@1.5.1-0": "04t6g000008Sk8KAAS",
-        "apex-rollup@1.5.2-0": "04t6g000008Sk93AAC"
+        "apex-rollup@1.5.2-0": "04t6g000008Sk93AAC",
+        "apex-rollup@1.5.3-0": "04t6g000008SkBEAA0"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Added ability to perform parent-level recalc using LWC button for one-to-many grandparent rollups",
+            "versionName": "Fixed a bug with Ultimate Parent rollups occasionally querying the ultimate parent field too soon, quality of life updates for intermediate object changes correctly triggering One To Many rollups",
             "versionNumber": "1.5.3.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",


### PR DESCRIPTION
* Updated documentation in README, and added link to Wiki there
* Fixes #306 by preventing Ultimate Parent rollups from incorrectly querying the `UltimateParentLookup__c` before arriving at the parent-level object
* Fixes #307 by correctly passing subclasses of RollupCalculator.DecimalRollupCalculator the converted values for Date, Datetime, and Time instances