### PR TITLE
V1.5.4 - Customize How Parent-Level Records Are Updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -984,6 +984,22 @@ You can use the included `Rollup Plugin Parameter` CMDT record `Logging Debug Le
 
 - If you need to generate additional test code coverage for `apex-rollup` (which might be necessary in a highly declarative org), you can install the [Extra Code Coverage plugin](plugins/ExtraCodeCoverage), which automatically gets updated any time I make changes to tests here.
 
+- To customize how updates are made to the parent-level records in Rollup, create a `Rollup Plugin` custom metadata record with the name field set to `RollupCustomUpdater`. Create an Apex class with the same name and implement the `IUpdater` interface from `RollupSObjectUpdater`:
+
+```java
+public class RollupCustomUpdater implements RollupSObjectUpdater.IUpdater {
+  public void performUpdate(List<SObject> recordsToUpdate, Database.DMLOptions options) {
+      // do whatever you'd like, and don't forget to commit using
+      // something like Database.update!
+      // assuming you have a TriggerHandler framework with a static "disable" method
+      // to bypass other logic
+      TriggerHandler.disable();
+      Database.update(recordsToUpdate, options);
+      TriggerHandler.enable();
+    }
+}
+```
+
 ## Commit History
 
 This repository comes after the result of [dozens of commits](https://github.com/jamessimone/apex-mocks-stress-test/commits/rollup) on my working repository. You can view the full history of the evolution of Apex Rollup there.

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkBEAA0">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkJdAAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkBEAA0">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkJdAAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -18,7 +18,6 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
     ' NOT IN ' => ' != ',
     ' not like ' => ' !like ',
     ' NOT LIKE ' => ' !like ',
-    ' <> ' => ' != ',
     ' in ' => ' = ',
     ' IN ' => ' = ',
     ' LIKE ' => ' like ',
@@ -622,7 +621,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       }
 
       switch on this.criteria {
-        when '=', '!=' {
+        when '=', '!=', '<>' {
           if (this.hasValues == false) {
             isEqual = String.isBlank(storedValue);
           } else {
@@ -633,7 +632,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
               }
             }
           }
-          isEqual = this.criteria == '!=' ? !isEqual : isEqual;
+          isEqual = this.criteria == '=' ? isEqual : !isEqual;
         }
         when 'like', '!like' {
           // like/not like have to be handled separately because it's the storedValue

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger extends Rollup implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.3';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.4';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
   private static Boolean disabledMessageHasBeenLogged = false;

--- a/rollup/core/classes/RollupPlugin.cls
+++ b/rollup/core/classes/RollupPlugin.cls
@@ -5,7 +5,7 @@ public without sharing class RollupPlugin {
   private static RollupPluginParameter__mdt parameterMock;
 
   public RollupPlugin__mdt getInstance(String developerNameOrId) {
-    return pluginMocks != null ? pluginMocks[0] : RollupPlugin__mdt.getInstance(developerNameOrId);
+    return pluginMocks != null && pluginMocks.isEmpty() == false ? pluginMocks.remove(0) : RollupPlugin__mdt.getInstance(developerNameOrId);
   }
 
   public List<RollupPlugin__mdt> getInstances() {

--- a/rollup/core/classes/RollupSObjectUpdater.cls
+++ b/rollup/core/classes/RollupSObjectUpdater.cls
@@ -1,4 +1,5 @@
 public without sharing virtual class RollupSObjectUpdater {
+  private static final String UPDATER_NAME = 'RollupCustomUpdater';
   @TestVisible
   private static final String DISPATCH_NAME = 'RollupDispatch';
   private static final SObjectSorter SORTER = new SObjectSorter();
@@ -11,6 +12,10 @@ public without sharing virtual class RollupSObjectUpdater {
 
   public interface IDispatcher {
     void dispatch(List<SObject> records);
+  }
+
+  public interface IUpdater {
+    void performUpdate(List<SObject> recordsToUpdate, Database.DMLOptions options);
   }
 
   public RollupSObjectUpdater() {
@@ -42,7 +47,7 @@ public without sharing virtual class RollupSObjectUpdater {
       if (this.rollupControl.ShouldDuplicateRulesBeIgnored__c != false) {
         dmlOptions.DuplicateRuleHeader.AllowSave = true;
       }
-      Database.update(recordsToUpdate, dmlOptions);
+      this.updateRecords(recordsToUpdate, dmlOptions);
       this.dispatch(recordsToUpdate);
     }
   }
@@ -126,6 +131,12 @@ public without sharing virtual class RollupSObjectUpdater {
     }
   }
 
+  private void updateRecords(List<SObject> recordsToUpdate, Database.DMLOptions options) {
+    RollupPlugin__mdt updaterPlugin = new RollupPlugin().getInstance(UPDATER_NAME);
+    Type updaterType = updaterPlugin != null ? Type.forName(updaterPlugin.DeveloperName) : DefaultUpdater.class;
+    ((IUpdater) updaterType.newInstance()).performUpdate(recordsToUpdate, options);
+  }
+
   private class SObjectSorter extends RollupComparer {
     public override Integer compare(Object first, Object second) {
       Integer returnVal = 0;
@@ -154,6 +165,12 @@ public without sharing virtual class RollupSObjectUpdater {
       RollupSObjectUpdater updater = new RollupSObjectUpdater();
       updater.addRollupControl(this.control);
       new RollupSObjectUpdater().doUpdate(this.records);
+    }
+  }
+
+  private without sharing class DefaultUpdater implements IUpdater {
+    public void performUpdate(List<SObject> recordsToUpdate, Database.DMLOptions options) {
+      Database.update(recordsToUpdate, options);
     }
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Evaluator CPU time improvements",
+            "versionName": "Small RollupEvaluator improvements (hopefully more to come, there), and added Rollup Plugin capability to customize how parent-level records are updated.",
             "versionNumber": "1.5.4.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Fixed a bug with Ultimate Parent rollups occasionally querying the ultimate parent field too soon, quality of life updates for intermediate object changes correctly triggering One To Many rollups",
-            "versionNumber": "1.5.3.0",
+            "versionName": "Evaluator CPU time improvements",
+            "versionNumber": "1.5.4.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -107,6 +107,7 @@
         "apex-rollup@1.5.0-0": "04t6g000008Sk8FAAS",
         "apex-rollup@1.5.1-0": "04t6g000008Sk8KAAS",
         "apex-rollup@1.5.2-0": "04t6g000008Sk93AAC",
-        "apex-rollup@1.5.3-0": "04t6g000008SkBEAA0"
+        "apex-rollup@1.5.3-0": "04t6g000008SkBEAA0",
+        "apex-rollup@1.5.4-0": "04t6g000008SkJdAAK"
     }
 }


### PR DESCRIPTION
* Added support for dynamic handling of rollup updates by subscribers, as discussed in #297 - by default, RollupSObjectUpdater will simply call Database.update(recordsToUpdate, dmlOptions), but by using RollupPlugin__mdt and an entry with DeveloperName 'RollupSObjectUpdater', allow for things like bypassing trigger handlers on update - for more info, see the bullet point under the `Other Rollup Plugins` heading in the README
* Slight optimization in `RollupEvaluator`, with more to come there