### PR TITLE
V1.5.5 - CONCAT_DISTINCT improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkKgAAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkKbAAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkKgAAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkKbAAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkJdAAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkKbAAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkJdAAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkKbAAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkKbAAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkKqAAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkKbAAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkKqAAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkKbAAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkKgAAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkKbAAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkKgAAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -2259,6 +2259,30 @@ private class RollupTests {
   }
 
   @IsTest
+  static void shouldProperlyShortCircuitWhenOldItemMatchesAndNewOneDoesNotConcatDistinct() {
+    Account acc = [SELECT Id FROM Account];
+
+    insert new ContactPointAddress(Name = 'CDC, GDG', ParentId = acc.Id);
+
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{ new ContactPointAddress(Name = 'GDG', ParentId = acc.Id, PreferenceRank = 5) };
+    RollupTestUtils.DMLMock mock = RollupTestUtils.loadMock(cpas);
+    List<Rollup.FlowInput> flowInputs = RollupTestUtils.prepareFlowTest(cpas, 'UPDATE', 'CONCAT_DISTINCT');
+    flowInputs[0].oldRecordsToRollup = new List<SObject>{ new ContactPointAddress(Id = cpas[0].Id, ParentId = acc.Id, Name = 'CDC') };
+    flowInputs[0].rollupFieldOnOpObject = 'Name';
+    flowInputs[0].rollupFieldOnCalcItem = 'Name';
+    flowInputs[0].calcItemWhereClause = 'PreferenceRank != 5';
+    flowInputs[0].splitConcatDelimiterOnCalcItem = true;
+
+    Test.startTest();
+    Rollup.performRollup(flowInputs);
+    Test.stopTest();
+
+    System.assertEquals(1, mock.Records.size(), 'CONCAT_DISTINCT AFTER_UPDATE from flow did not update account');
+    Account updatedAcc = (Account) mock.Records[0];
+    System.assertEquals('CDC, GDG', updatedAcc.Name, 'CONCAT_DISTINCT should have properly pulled all records!');
+  }
+
+  @IsTest
   static void shouldSplitConcatCalcItemsFromFlow() {
     Account acc = [SELECT Id FROM Account];
     acc.Name = 'CDC';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -1037,7 +1037,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
           continue;
         }
 
-        this.winnowCalcItemsAndCheckReparenting(rollup, localCalcItems, oldLookupItems);
+        this.populateReparentedItems(rollup, localCalcItems, oldLookupItems);
 
         // local calculations and reparenting can step on one another (due to full recalculations happening)
         // this guard clause prevents a full recalculation from taking place unnecessarily if a reparenting operation
@@ -1088,26 +1088,13 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
   }
 
-  private void winnowCalcItemsAndCheckReparenting(RollupAsyncProcessor roll, List<SObject> localCalcItems, Map<String, List<SObject>> oldLookupItems) {
+  private void populateReparentedItems(RollupAsyncProcessor roll, List<SObject> localCalcItems, Map<String, List<SObject>> oldLookupItems) {
     for (Integer index = localCalcItems.size() - 1; index >= 0; index--) {
       SObject calcItem = localCalcItems[index];
-      Boolean doesNotMatchCurrentItem = roll.eval.matches(calcItem) == false;
-      if (
-        roll.metadata?.IsFullRecordSet__c == true &&
-        (doesNotMatchCurrentItem && (roll.oldCalcItems.containsKey(calcItem.Id) == false || roll.eval.matches(roll.oldCalcItems.get(calcItem.Id)) == false))
-      ) {
-        // technically it should only be possible for a calc item that doesn't match
-        // to still exist if it is a Full Record Set operation; this gives people the chance
-        // to reset rollup values if none of the records passed in match the eval criteria
-        localCalcItems.remove(index);
+      if (roll.oldCalcItems?.containsKey(calcItem.Id) != true) {
         continue;
       }
-      // Check for reparented records
-      SObject oldCalcItem = roll.oldCalcItems?.get(calcItem.Id);
-      if (oldCalcItem == null) {
-        continue;
-      }
-
+      SObject oldCalcItem = roll.oldCalcItems.get(calcItem.Id);
       String priorLookup = (String) oldCalcItem.get(roll.lookupFieldOnCalcItem);
       // if the lookup wasn't previously populated, there's nothing to update
       if (String.isBlank(priorLookup)) {

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -1037,7 +1037,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
           continue;
         }
 
-        this.winnowCalcItemsAndCheckReparenting(rollup, localCalcItems, oldLookupItems);
+        this.populateReparentedItems(rollup, localCalcItems, oldLookupItems);
 
         // local calculations and reparenting can step on one another (due to full recalculations happening)
         // this guard clause prevents a full recalculation from taking place unnecessarily if a reparenting operation
@@ -1088,26 +1088,13 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
   }
 
-  private void winnowCalcItemsAndCheckReparenting(RollupAsyncProcessor roll, List<SObject> localCalcItems, Map<String, List<SObject>> oldLookupItems) {
+  private void populateReparentedItems(RollupAsyncProcessor roll, List<SObject> localCalcItems, Map<String, List<SObject>> oldLookupItems) {
     for (Integer index = localCalcItems.size() - 1; index >= 0; index--) {
       SObject calcItem = localCalcItems[index];
-      Boolean doesNotMatchCurrentItem = roll.eval.matches(calcItem) == false;
-      if (
-        roll.metadata?.IsFullRecordSet__c == true &&
-        (doesNotMatchCurrentItem && (roll.oldCalcItems.containsKey(calcItem.Id) == false || roll.eval.matches(roll.oldCalcItems.get(calcItem.Id)) == false))
-      ) {
-        // technically it should only be possible for a calc item that doesn't match
-        // to still exist if it is a Full Record Set operation; this gives people the chance
-        // to reset rollup values if none of the records passed in match the eval criteria
-        localCalcItems.remove(index);
+      if (roll.oldCalcItems?.containsKey(calcItem.Id) != true) {
         continue;
       }
-      // Check for reparented records
-      SObject oldCalcItem = roll.oldCalcItems?.get(calcItem.Id);
-      if (oldCalcItem == null) {
-        continue;
-      }
-
+      SObject oldCalcItem = roll.oldCalcItems.get(calcItem.Id);
       String priorLookup = (String) oldCalcItem.get(roll.lookupFieldOnCalcItem);
       // if the lookup wasn't previously populated, there's nothing to update
       if (String.isBlank(priorLookup)) {
@@ -1130,12 +1117,9 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
   }
 
-  private void populateOldLookupItems(String priorLookup, SObject oldCalcItem, Map<String, List<SObject>> oldLookupItems) {
-    if (oldLookupItems.containsKey(priorLookup) == false) {
-      oldLookupItems.put(priorLookup, new List<SObject>{ oldCalcItem });
-    } else {
-      oldLookupItems.get(priorLookup).add(oldCalcItem);
-    }
+  private void populateOldLookupItems(String priorLookup, SObject oldCalcItem, Map<String, List<SObject>> lookupToOldCalcItems) {
+    List<SObject> oldLookupItems = lookupToOldCalcItems.containsKey(priorLookup) ? lookupToOldCalcItems.get(priorLookup) : new List<SObject>{ oldCalcItem };
+    oldLookupItems.add(oldCalcItem);
   }
 
   private RollupCalculator getCalculator(

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -1037,7 +1037,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
           continue;
         }
 
-        this.populateReparentedItems(rollup, localCalcItems, oldLookupItems);
+        this.winnowCalcItemsAndCheckReparenting(rollup, localCalcItems, oldLookupItems);
 
         // local calculations and reparenting can step on one another (due to full recalculations happening)
         // this guard clause prevents a full recalculation from taking place unnecessarily if a reparenting operation
@@ -1088,13 +1088,26 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
   }
 
-  private void populateReparentedItems(RollupAsyncProcessor roll, List<SObject> localCalcItems, Map<String, List<SObject>> oldLookupItems) {
+  private void winnowCalcItemsAndCheckReparenting(RollupAsyncProcessor roll, List<SObject> localCalcItems, Map<String, List<SObject>> oldLookupItems) {
     for (Integer index = localCalcItems.size() - 1; index >= 0; index--) {
       SObject calcItem = localCalcItems[index];
-      if (roll.oldCalcItems?.containsKey(calcItem.Id) != true) {
+      Boolean doesNotMatchCurrentItem = roll.eval.matches(calcItem) == false;
+      if (
+        roll.metadata?.IsFullRecordSet__c == true &&
+        (doesNotMatchCurrentItem && (roll.oldCalcItems.containsKey(calcItem.Id) == false || roll.eval.matches(roll.oldCalcItems.get(calcItem.Id)) == false))
+      ) {
+        // technically it should only be possible for a calc item that doesn't match
+        // to still exist if it is a Full Record Set operation; this gives people the chance
+        // to reset rollup values if none of the records passed in match the eval criteria
+        localCalcItems.remove(index);
         continue;
       }
-      SObject oldCalcItem = roll.oldCalcItems.get(calcItem.Id);
+      // Check for reparented records
+      SObject oldCalcItem = roll.oldCalcItems?.get(calcItem.Id);
+      if (oldCalcItem == null) {
+        continue;
+      }
+
       String priorLookup = (String) oldCalcItem.get(roll.lookupFieldOnCalcItem);
       // if the lookup wasn't previously populated, there's nothing to update
       if (String.isBlank(priorLookup)) {
@@ -1117,9 +1130,12 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
   }
 
-  private void populateOldLookupItems(String priorLookup, SObject oldCalcItem, Map<String, List<SObject>> lookupToOldCalcItems) {
-    List<SObject> oldLookupItems = lookupToOldCalcItems.containsKey(priorLookup) ? lookupToOldCalcItems.get(priorLookup) : new List<SObject>{ oldCalcItem };
-    oldLookupItems.add(oldCalcItem);
+  private void populateOldLookupItems(String priorLookup, SObject oldCalcItem, Map<String, List<SObject>> oldLookupItems) {
+    if (oldLookupItems.containsKey(priorLookup) == false) {
+      oldLookupItems.put(priorLookup, new List<SObject>{ oldCalcItem });
+    } else {
+      oldLookupItems.get(priorLookup).add(oldCalcItem);
+    }
   }
 
   private RollupCalculator getCalculator(

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -497,7 +497,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
   @SuppressWarnings('PMD.UnusedLocalVariable')
   protected virtual void retrieveAdditionalCalcItems(Map<String, CalcItemBag> lookupToCalcItems, RollupAsyncProcessor rollup) {
-    // TODO - incorporate grandparent rollups into this, as well
     if (this.isValidAdditionalCalcItemRetrieval(rollup) == false) {
       return;
     }

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -154,6 +154,7 @@ public without sharing abstract class RollupCalculator {
       }
     }
     List<SObject> localCalcItems = this.winnowItems(calcItems, oldCalcItems);
+    System.debug(localCalcItems);
     if (this.op.name().contains(Rollup.Op.CONCAT.name()) && this.metadata.RollupOrderBys__r.isEmpty() == false) {
       new RollupFirstLastSorter(Rollup.Op.FIRST, this.metadata.RollupOrderBys__r).sort(localCalcItems);
     }

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -154,7 +154,6 @@ public without sharing abstract class RollupCalculator {
       }
     }
     List<SObject> localCalcItems = this.winnowItems(calcItems, oldCalcItems);
-    System.debug(localCalcItems);
     if (this.op.name().contains(Rollup.Op.CONCAT.name()) && this.metadata.RollupOrderBys__r.isEmpty() == false) {
       new RollupFirstLastSorter(Rollup.Op.FIRST, this.metadata.RollupOrderBys__r).sort(localCalcItems);
     }

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -154,6 +154,7 @@ public without sharing abstract class RollupCalculator {
       }
     }
     List<SObject> localCalcItems = this.winnowItems(calcItems, oldCalcItems);
+    System.debug(localCalcItems);
     if (this.op.name().contains(Rollup.Op.CONCAT.name()) && this.metadata.RollupOrderBys__r.isEmpty() == false) {
       new RollupFirstLastSorter(Rollup.Op.FIRST, this.metadata.RollupOrderBys__r).sort(localCalcItems);
     }
@@ -889,7 +890,7 @@ public without sharing abstract class RollupCalculator {
       if (String.isBlank(existingVal)) {
         return;
       } else if (this.isConcatDistinct) {
-        this.shouldShortCircuit = true;
+        this.shouldShortCircuit = this.op.name().contains('DELETE');
         this.handleConcatDistinctDelete(calcItem);
       } else {
         this.stringVal = this.replaceWithDelimiter(this.stringVal, existingVal, '');
@@ -971,23 +972,7 @@ public without sharing abstract class RollupCalculator {
     }
 
     private Boolean shouldConcat(String newVal) {
-      Boolean shouldConcat = false;
-      Boolean hasVal = String.isNotBlank(newVal);
-      if (this.isConcatDistinct == false && hasVal) {
-        shouldConcat = true;
-      } else if (this.isConcatDistinct && hasVal) {
-        List<String> existingVals = this.stringVal.split(this.concatDelimiter);
-        Boolean matches = false;
-        for (String existingVal : existingVals) {
-          matches = existingVal == newVal;
-          if (matches) {
-            break;
-          }
-        }
-        shouldConcat = matches == false;
-      }
-
-      return shouldConcat;
+      return String.isNotBlank(newVal);
     }
 
     private String concatWithDelimiter(String newVal) {

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger extends Rollup implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.4';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.5';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
   private static Boolean disabledMessageHasBeenLogged = false;

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Small RollupEvaluator improvements (hopefully more to come, there), and added Rollup Plugin capability to customize how parent-level records are updated.",
-            "versionNumber": "1.5.4.0",
+            "versionName": "Fixed an issue reported by Katherine West where CONCAT_DISTINCT was not always properly retrieving additional calc items",
+            "versionNumber": "1.5.5.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -108,6 +108,7 @@
         "apex-rollup@1.5.1-0": "04t6g000008Sk8KAAS",
         "apex-rollup@1.5.2-0": "04t6g000008Sk93AAC",
         "apex-rollup@1.5.3-0": "04t6g000008SkBEAA0",
-        "apex-rollup@1.5.4-0": "04t6g000008SkJdAAK"
+        "apex-rollup@1.5.4-0": "04t6g000008SkJdAAK",
+        "apex-rollup@1.5.5-0": "04t6g000008SkKbAAK"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -109,6 +109,6 @@
         "apex-rollup@1.5.2-0": "04t6g000008Sk93AAC",
         "apex-rollup@1.5.3-0": "04t6g000008SkBEAA0",
         "apex-rollup@1.5.4-0": "04t6g000008SkJdAAK",
-        "apex-rollup@1.5.5-0": "04t6g000008SkKbAAK"
+        "apex-rollup@1.5.5-0": "04t6g000008SkKqAAK"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -109,6 +109,6 @@
         "apex-rollup@1.5.2-0": "04t6g000008Sk93AAC",
         "apex-rollup@1.5.3-0": "04t6g000008SkBEAA0",
         "apex-rollup@1.5.4-0": "04t6g000008SkJdAAK",
-        "apex-rollup@1.5.5-0": "04t6g000008SkKbAAK"
+        "apex-rollup@1.5.5-0": "04t6g000008SkKgAAK"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -109,6 +109,6 @@
         "apex-rollup@1.5.2-0": "04t6g000008Sk93AAC",
         "apex-rollup@1.5.3-0": "04t6g000008SkBEAA0",
         "apex-rollup@1.5.4-0": "04t6g000008SkJdAAK",
-        "apex-rollup@1.5.5-0": "04t6g000008SkKgAAK"
+        "apex-rollup@1.5.5-0": "04t6g000008SkKbAAK"
     }
 }


### PR DESCRIPTION
* Fixed an issue where not all items were considered on update for `CONCAT_DISTINCT` if some of the items didn't match a Calc Item Where Clause
* Made _significant_ performance improvements to:
  *  `CONCAT_DISTINCT` operations with more than one item
  * Pretty much any rollup operation that includes more than one item where a Calc Item Where Clause is used (this is due to removing a duplicated call to `RollupEvaluator` - this was previously necessary to safeguard an obscure "order of operations" that applied when _standard_ Salesforce rollup fields that were in the middle of themselves being recalculated were used in a Calc Item Where Clause