### PR TITLE
V1.5.10 - Parent Records No Longer Updated When No Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkVFAA0">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkVeAAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkVFAA0">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkVeAAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/CustomMetadataDrivenTests.cls
+++ b/extra-tests/classes/CustomMetadataDrivenTests.cls
@@ -138,7 +138,7 @@ private class CustomMetadataDrivenTests {
     System.assertEquals(grandparentTwo.Id, child.RollupParent__r.RollupGrandparent__c);
 
     grandparentOne = [SELECT AmountfromChildren__c FROM RollupGrandParent__c WHERE Id = :grandparentOne.Id];
-    System.assertEquals(0, grandparentOne.AmountfromChildren__c);
+    System.assertEquals(null, grandparentOne.AmountfromChildren__c);
 
     grandparentTwo = [SELECT AmountfromChildren__c FROM RollupGrandParent__c WHERE Id = :grandparentTwo.Id];
     System.assertEquals(child.NumberField__c, grandparentTwo.AmountfromChildren__c);

--- a/extra-tests/classes/CustomMetadataDrivenTests.cls-meta.xml
+++ b/extra-tests/classes/CustomMetadataDrivenTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/InvocableDrivenTests.cls-meta.xml
+++ b/extra-tests/classes/InvocableDrivenTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupCalcItemReplacerTests.cls-meta.xml
+++ b/extra-tests/classes/RollupCalcItemReplacerTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupCalcItemSorterTests.cls-meta.xml
+++ b/extra-tests/classes/RollupCalcItemSorterTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupCalculatorTests.cls
+++ b/extra-tests/classes/RollupCalculatorTests.cls
@@ -11,15 +11,7 @@ private class RollupCalculatorTests {
   @IsTest
   static void shouldReturnNullWhenNoCalcItemsFirst() {
     Rollup__mdt metadata = configureOrderByMetadata(new Rollup__mdt(CalcItem__c = 'Opportunity'), 'CloseDate');
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
-      0,
-      Rollup.Op.FIRST,
-      Opportunity.Amount,
-      Account.AnnualRevenue,
-      metadata,
-      '0011g00003VDGbF002',
-      Account.Id
-    );
+    RollupCalculator calc = getCalculator(0, Rollup.Op.FIRST, Opportunity.Amount, Account.AnnualRevenue, metadata, '0011g00003VDGbF002', Account.Id);
 
     calc.performRollup(new List<Opportunity>(), new Map<Id, SObject>());
 
@@ -29,15 +21,7 @@ private class RollupCalculatorTests {
   @IsTest
   static void shouldReturnFirstValueBasedOnMetadataField() {
     Rollup__mdt metadata = configureOrderByMetadata(new Rollup__mdt(CalcItem__c = 'Opportunity'), 'CloseDate');
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
-      0,
-      Rollup.Op.FIRST,
-      Opportunity.Amount,
-      Account.AnnualRevenue,
-      metadata,
-      '0011g00003VDGbF002',
-      Account.Id
-    );
+    RollupCalculator calc = getCalculator(0, Rollup.Op.FIRST, Opportunity.Amount, Account.AnnualRevenue, metadata, '0011g00003VDGbF002', Account.Id);
 
     // the important part is that the middle item is the one used, to prove that sorting occurred
     // this will be true for all the first/last tests in this class
@@ -56,15 +40,7 @@ private class RollupCalculatorTests {
   @IsTest
   static void shouldReturnLastValueBasedOnMetadataField() {
     Rollup__mdt metadata = configureOrderByMetadata(new Rollup__mdt(CalcItem__c = 'Opportunity'), 'CloseDate');
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
-      0,
-      Rollup.Op.LAST,
-      Opportunity.Amount,
-      Account.AnnualRevenue,
-      metadata,
-      '0011g00003VDGbF002',
-      Account.Id
-    );
+    RollupCalculator calc = getCalculator(0, Rollup.Op.LAST, Opportunity.Amount, Account.AnnualRevenue, metadata, '0011g00003VDGbF002', Account.Id);
 
     calc.performRollup(
       new List<Opportunity>{
@@ -82,15 +58,7 @@ private class RollupCalculatorTests {
   static void shouldReturnFirstValueIfOtherOrderByValueIsNull() {
     Rollup__mdt metadata = configureOrderByMetadata(new Rollup__mdt(CalcItem__c = 'Opportunity'), 'CloseDate');
     metadata.RollupOrderBys__r[0].NullSortOrder__c = RollupMetaPicklists.NullSortOrder.NullsLast;
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
-      0,
-      Rollup.Op.FIRST,
-      Opportunity.Amount,
-      Account.AnnualRevenue,
-      metadata,
-      '0011g00003VDGbF002',
-      Account.Id
-    );
+    RollupCalculator calc = getCalculator(0, Rollup.Op.FIRST, Opportunity.Amount, Account.AnnualRevenue, metadata, '0011g00003VDGbF002', Account.Id);
 
     calc.performRollup(
       new List<Opportunity>{
@@ -107,15 +75,7 @@ private class RollupCalculatorTests {
   @IsTest
   static void shouldReturnMiddleValueForFirst() {
     Rollup__mdt metadata = configureOrderByMetadata(new Rollup__mdt(CalcItem__c = 'Opportunity'), 'CloseDate');
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
-      0,
-      Rollup.Op.FIRST,
-      Opportunity.Amount,
-      Account.AnnualRevenue,
-      metadata,
-      '0011g00003VDGbF002',
-      Account.Id
-    );
+    RollupCalculator calc = getCalculator(0, Rollup.Op.FIRST, Opportunity.Amount, Account.AnnualRevenue, metadata, '0011g00003VDGbF002', Account.Id);
 
     Date today = System.today();
     calc.performRollup(
@@ -134,15 +94,7 @@ private class RollupCalculatorTests {
   static void shouldReturnFirstValueWhenMiddleAndLastAreNull() {
     Rollup__mdt metadata = configureOrderByMetadata(new Rollup__mdt(CalcItem__c = 'Opportunity'), 'CloseDate');
     metadata.RollupOrderBys__r[0].NullSortOrder__c = RollupMetaPicklists.NullSortOrder.NullsLast;
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
-      0,
-      Rollup.Op.FIRST,
-      Opportunity.Amount,
-      Account.AnnualRevenue,
-      metadata,
-      '0011g00003VDGbF002',
-      Account.Id
-    );
+    RollupCalculator calc = getCalculator(0, Rollup.Op.FIRST, Opportunity.Amount, Account.AnnualRevenue, metadata, '0011g00003VDGbF002', Account.Id);
 
     calc.performRollup(
       new List<Opportunity>{
@@ -160,15 +112,7 @@ private class RollupCalculatorTests {
   static void shouldReturnLastValueIfOtherOrderByValueIsNull() {
     Rollup__mdt metadata = configureOrderByMetadata(new Rollup__mdt(CalcItem__c = 'Opportunity'), 'CloseDate');
     metadata.RollupOrderBys__r[0].NullSortOrder__c = RollupMetaPicklists.NullSortOrder.NullsLast;
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
-      0,
-      Rollup.Op.FIRST,
-      Opportunity.Amount,
-      Account.AnnualRevenue,
-      metadata,
-      '0011g00003VDGbF002',
-      Account.Id
-    );
+    RollupCalculator calc = getCalculator(0, Rollup.Op.FIRST, Opportunity.Amount, Account.AnnualRevenue, metadata, '0011g00003VDGbF002', Account.Id);
 
     calc.performRollup(
       new List<Opportunity>{
@@ -185,15 +129,7 @@ private class RollupCalculatorTests {
   @IsTest
   static void shouldNotSortAtAllIfOrderByValuesAreNull() {
     Rollup__mdt metadata = configureOrderByMetadata(new Rollup__mdt(CalcItem__c = 'Opportunity'), 'CloseDate');
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
-      0,
-      Rollup.Op.FIRST,
-      Opportunity.Amount,
-      Account.AnnualRevenue,
-      metadata,
-      '0011g00003VDGbF002',
-      Account.Id
-    );
+    RollupCalculator calc = getCalculator(0, Rollup.Op.FIRST, Opportunity.Amount, Account.AnnualRevenue, metadata, '0011g00003VDGbF002', Account.Id);
 
     List<Opportunity> opps = new List<Opportunity>{
       new Opportunity(Id = '0066g00003VDGbF001', Amount = 1),
@@ -209,15 +145,7 @@ private class RollupCalculatorTests {
   @IsTest
   static void shouldReturnFirstString() {
     Rollup__mdt metadata = configureOrderByMetadata(new Rollup__mdt(CalcItem__c = 'Opportunity'), 'Name');
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
-      0,
-      Rollup.Op.FIRST,
-      Opportunity.Amount,
-      Account.AnnualRevenue,
-      metadata,
-      '0011g00003VDGbF002',
-      Account.Id
-    );
+    RollupCalculator calc = getCalculator(0, Rollup.Op.FIRST, Opportunity.Amount, Account.AnnualRevenue, metadata, '0011g00003VDGbF002', Account.Id);
 
     calc.performRollup(
       new List<Opportunity>{
@@ -234,15 +162,7 @@ private class RollupCalculatorTests {
   @IsTest
   static void shouldReturnLastString() {
     Rollup__mdt metadata = configureOrderByMetadata(new Rollup__mdt(CalcItem__c = 'Opportunity'), 'Name');
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
-      0,
-      Rollup.Op.LAST,
-      Opportunity.Amount,
-      Account.AnnualRevenue,
-      metadata,
-      '0011g00003VDGbF002',
-      Account.Id
-    );
+    RollupCalculator calc = getCalculator(0, Rollup.Op.LAST, Opportunity.Amount, Account.AnnualRevenue, metadata, '0011g00003VDGbF002', Account.Id);
 
     calc.performRollup(
       new List<Opportunity>{
@@ -259,15 +179,7 @@ private class RollupCalculatorTests {
   @IsTest
   static void shouldReturnFirstNumber() {
     Rollup__mdt metadata = configureOrderByMetadata(new Rollup__mdt(CalcItem__c = 'Opportunity'), 'Amount');
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
-      0,
-      Rollup.Op.FIRST,
-      Opportunity.Amount,
-      Account.AnnualRevenue,
-      metadata,
-      '0011g00003VDGbF002',
-      Account.Id
-    );
+    RollupCalculator calc = getCalculator(0, Rollup.Op.FIRST, Opportunity.Amount, Account.AnnualRevenue, metadata, '0011g00003VDGbF002', Account.Id);
 
     calc.performRollup(
       new List<Opportunity>{
@@ -284,15 +196,7 @@ private class RollupCalculatorTests {
   @IsTest
   static void shouldReturnLastNumber() {
     Rollup__mdt metadata = configureOrderByMetadata(new Rollup__mdt(CalcItem__c = 'Opportunity'), 'Amount');
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
-      0,
-      Rollup.Op.LAST,
-      Opportunity.Amount,
-      Account.AnnualRevenue,
-      metadata,
-      '0011g00003VDGbF002',
-      Account.Id
-    );
+    RollupCalculator calc = getCalculator(0, Rollup.Op.LAST, Opportunity.Amount, Account.AnnualRevenue, metadata, '0011g00003VDGbF002', Account.Id);
 
     calc.performRollup(
       new List<Opportunity>{
@@ -309,15 +213,7 @@ private class RollupCalculatorTests {
   @IsTest
   static void regressionShouldRollupFirstLastWithQueriedOrderBy() {
     Rollup__mdt metadata = configureOrderByMetadata(new Rollup__mdt(CalcItem__c = 'Opportunity'), 'Name');
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
-      0,
-      Rollup.Op.FIRST,
-      Opportunity.Amount,
-      Account.AnnualRevenue,
-      metadata,
-      '0011g00003VDGbF002',
-      Account.Id
-    );
+    RollupCalculator calc = getCalculator(0, Rollup.Op.FIRST, Opportunity.Amount, Account.AnnualRevenue, metadata, '0011g00003VDGbF002', Account.Id);
 
     calc.performRollup(
       new List<Opportunity>{
@@ -334,15 +230,7 @@ private class RollupCalculatorTests {
   @IsTest
   static void regressionShouldExcludeCurrentItemsOnFirstLastDelete() {
     Rollup__mdt metadata = configureOrderByMetadata(new Rollup__mdt(CalcItem__c = 'Opportunity'), 'Name');
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
-      0,
-      Rollup.Op.DELETE_FIRST,
-      Opportunity.Amount,
-      Account.AnnualRevenue,
-      metadata,
-      '0011g00003VDGbF002',
-      Account.Id
-    );
+    RollupCalculator calc = getCalculator(0, Rollup.Op.DELETE_FIRST, Opportunity.Amount, Account.AnnualRevenue, metadata, '0011g00003VDGbF002', Account.Id);
 
     calc.performRollup(
       new List<Opportunity>{
@@ -374,15 +262,7 @@ private class RollupCalculatorTests {
       Id = RollupTestUtils.createId(ContactPointAddress.SObjectType)
     );
 
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
-      0,
-      Rollup.Op.FIRST,
-      ContactPointAddress.NAME,
-      Account.Description,
-      metadata,
-      acc.Id,
-      ContactPointAddress.ParentId
-    );
+    RollupCalculator calc = getCalculator(0, Rollup.Op.FIRST, ContactPointAddress.NAME, Account.Description, metadata, acc.Id, ContactPointAddress.ParentId);
     calc.setEvaluator(new RollupEvaluator.WhereFieldEvaluator(metadata.CalcItemWhereClause__c, ContactPointAddress.SObjectType));
 
     calc.performRollup(new List<ContactPointAddress>{ cpa }, new Map<Id, SObject>());
@@ -395,7 +275,7 @@ private class RollupCalculatorTests {
   @IsTest
   static void shouldReturnDefaultWhenNoCalcItemsAverage() {
     Rollup__mdt metadata = configureOrderByMetadata(new Rollup__mdt(CalcItem__c = 'Opportunity'), 'CloseDate');
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       0,
       Rollup.Op.Average,
       Opportunity.Amount,
@@ -413,7 +293,7 @@ private class RollupCalculatorTests {
   @IsTest
   static void shouldNotTryToAverageNull() {
     Rollup__mdt metadata = new Rollup__mdt(CalcItem__c = 'Opportunity');
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       0,
       Rollup.Op.AVERAGE,
       Opportunity.Amount,
@@ -445,7 +325,7 @@ private class RollupCalculatorTests {
 
     Task passedIn = new Task(WhatId = acc.Id, Subject = 'Passed In', CallDurationInSeconds = 3, Id = RollupTestUtils.createId(Task.SObjectType));
 
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       0,
       Rollup.Op.AVERAGE,
       Task.CallDurationInSeconds,
@@ -463,7 +343,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void shouldReturnNewValOnCountChangeIfReparenting() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       0,
       Rollup.Op.UPDATE_COUNT,
       Opportunity.Amount,
@@ -480,7 +360,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void shouldReturnZeroOnFullRecalcIfNoMatchingItemsCount() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       0,
       Rollup.Op.COUNT,
       Opportunity.Amount,
@@ -499,7 +379,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void shouldReturnZeroOnFullRecalcIfNoItemsPresentCount() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       0,
       Rollup.Op.COUNT,
       Opportunity.Amount,
@@ -516,7 +396,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void shouldReturnZeroOnFullRecalcIfNoMatchingItemsCountDistinct() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       0,
       Rollup.Op.COUNT_DISTINCT,
       Opportunity.Amount,
@@ -535,7 +415,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void resetsDefaultValuesBetweenCountDistinctRuns() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       0,
       Rollup.Op.COUNT_DISTINCT,
       Opportunity.Amount,
@@ -561,7 +441,7 @@ private class RollupCalculatorTests {
   static void shouldNotCountNullsForCountDistinctDelete() {
     Account acc = [SELECT Id FROM Account];
     insert new Opportunity(CloseDate = System.today(), StageName = 'Hi', AccountId = acc.Id, Name = 'null amount');
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       0,
       Rollup.Op.DELETE_COUNT_DISTINCT,
       Opportunity.Amount,
@@ -582,7 +462,7 @@ private class RollupCalculatorTests {
     Account acc = [SELECT Id FROM Account];
     insert new Contact(LastName = 'Count Distinct', AccountId = acc.Id);
 
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       3,
       Rollup.Op.DELETE_COUNT_DISTINCT,
       Contact.Id,
@@ -608,7 +488,7 @@ private class RollupCalculatorTests {
     Opportunity newerOpp = opp.clone(true, true);
     newerOpp.Amount = 0;
 
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       1,
       Rollup.Op.UPDATE_COUNT_DISTINCT,
       Opportunity.Id,
@@ -627,7 +507,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void shouldReturnCountIfRollupValueUnchangedButEvalStatusHas() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       0,
       Rollup.Op.UPDATE_COUNT,
       Opportunity.Amount,
@@ -647,7 +527,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void shouldAllowIncrementOnUpdateIfOldValueIsDefault() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       0,
       Rollup.Op.UPDATE_COUNT,
       Opportunity.Name,
@@ -667,7 +547,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void shouldDecrementIfOldCalcItemMatchesAndNewOneDoesNot() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       1,
       Rollup.Op.UPDATE_COUNT,
       Opportunity.Name,
@@ -693,7 +573,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void shouldDecrementBooleanCountProperly() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       1,
       Rollup.Op.UPDATE_COUNT,
       ContactPointAddress.IsPrimary,
@@ -711,7 +591,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void shouldConsiderDateChangesCorrectlyCount() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       1,
       Rollup.Op.UPDATE_COUNT,
       Opportunity.CloseDate,
@@ -731,7 +611,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void mostCalculatesSequentialValuesCorrectly() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       null,
       Rollup.Op.MOST,
       Opportunity.CloseDate,
@@ -756,7 +636,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void shouldReturnNullOnFullRecalcIfNoMatchingItemsSum() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       0,
       Rollup.Op.SUM,
       Opportunity.Amount,
@@ -775,7 +655,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void shouldReturnSumIfRollupValueUnchangedButEvalStatusHas() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       0,
       Rollup.Op.UPDATE_SUM,
       Opportunity.Amount,
@@ -802,7 +682,7 @@ private class RollupCalculatorTests {
     Opportunity newerOpp = opp.clone(true, true);
     newerOpp.Amount = 0;
 
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       5,
       Rollup.Op.UPDATE_SUM,
       Opportunity.Amount,
@@ -824,7 +704,7 @@ private class RollupCalculatorTests {
   @IsTest
   static void shouldReturnDefaultIfNoMatchingItemsPassedConcat() {
     String distinct = 'distinct';
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       distinct,
       Rollup.Op.CONCAT,
       Opportunity.Name,
@@ -846,7 +726,7 @@ private class RollupCalculatorTests {
   static void shouldProperlyRemoveConcatOnUpdateIfOldItemMatchesAndNewOneDoesNot() {
     Opportunity opp = new Opportunity(AccountId = '0011g00003VDGbF002', Id = '0066g00003VDGbF001', Name = 'CDC', Amount = 0);
 
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       'GISS, CDC',
       Rollup.Op.UPDATE_CONCAT,
       Opportunity.Name,
@@ -866,7 +746,7 @@ private class RollupCalculatorTests {
   @IsTest
   static void shouldConcatDistinctProperly() {
     String distinct = 'distinct';
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       distinct,
       Rollup.Op.CONCAT_DISTINCT,
       Opportunity.Name,
@@ -893,7 +773,7 @@ private class RollupCalculatorTests {
     String accountId = '0016g00003VDGbF001';
     String firstVal = '2011';
     String secondVal = '2021';
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       firstVal +
       ', ' +
       secondVal,
@@ -915,7 +795,7 @@ private class RollupCalculatorTests {
   @IsTest
   static void shouldUseCustomConcatDelimiterWhenSupplied() {
     String distinct = 'distinct';
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       distinct,
       Rollup.Op.CONCAT_DISTINCT,
       Opportunity.Name,
@@ -933,7 +813,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void shouldSplitCalcItemsOnConcatDelimiterWhenSupplied() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       '',
       Rollup.Op.CONCAT_DISTINCT,
       Opportunity.Name,
@@ -951,7 +831,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void shouldNotSplitOnConcatDelimiterWhenOnlyBlankValueStillExists() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       '2019, 2020, 2021',
       Rollup.Op.DELETE_CONCAT_DISTINCT,
       Opportunity.Name,
@@ -973,7 +853,7 @@ private class RollupCalculatorTests {
     String toRemove = 'CDC';
     String extantString = 'GISS';
     insert new Opportunity(Name = extantString, CloseDate = System.today(), StageName = 'A', AccountId = acc.Id);
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       toRemove +
       ', ' +
       extantString,
@@ -999,7 +879,7 @@ private class RollupCalculatorTests {
 
     insert new Opportunity(AccountId = acc.Id, StageName = 'hi', CloseDate = System.today(), Name = 'Delete');
 
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       'CDC, Delete',
       Rollup.Op.DELETE_CONCAT_DISTINCT,
       Opportunity.Name,
@@ -1019,7 +899,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void regressionShouldNotBlowUpOnNullPriorValueConcat() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       '',
       Rollup.Op.UPDATE_CONCAT_DISTINCT,
       Opportunity.Name,
@@ -1040,7 +920,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void shouldConcatenateProperlyToMultiSelectPicklist() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       '',
       Rollup.Op.CONCAT,
       Opportunity.Name,
@@ -1066,7 +946,7 @@ private class RollupCalculatorTests {
   @IsTest
   static void shouldMinOnMultiSelectPicklist() {
     Rollup__mdt metadata = new Rollup__mdt();
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       '',
       Rollup.Op.MIN,
       QuickText.Channel,
@@ -1104,7 +984,7 @@ private class RollupCalculatorTests {
     String secondVal = picklistVals[1].getValue();
     String thirdVal = picklistVals[2].getValue();
 
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       firstVal,
       Rollup.Op.CONCAT_DISTINCT,
       QuickText.Channel,
@@ -1137,7 +1017,7 @@ private class RollupCalculatorTests {
     String secondVal = picklistVals[1].getValue();
     String thirdVal = picklistVals[2].getValue();
 
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       firstVal,
       Rollup.Op.CONCAT_DISTINCT,
       QuickText.Channel,
@@ -1172,7 +1052,7 @@ private class RollupCalculatorTests {
     String secondVal = picklistVals[1].getValue();
     String thirdVal = picklistVals[2].getValue();
 
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       firstVal,
       Rollup.Op.CONCAT,
       QuickText.Channel,
@@ -1202,7 +1082,7 @@ private class RollupCalculatorTests {
   static void shouldDefaultToNullIfCurrentItemExcludedAndNoOtherMatchingItemsTime() {
     Time max = Time.newInstance(11, 11, 11, 11);
     Rollup__mdt metadata = new Rollup__mdt(CalcItem__c = 'ContactPointAddress', CalcItemWhereClause__c = 'BestTimeToContactEndTime != ' + String.valueOf(max));
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       max,
       Rollup.Op.UPDATE_MIN,
       ContactPointAddress.BestTimeToContactEndTime,
@@ -1227,7 +1107,7 @@ private class RollupCalculatorTests {
   static void shouldDefaultToCurrentValueOnMinIfNoOtherMatchingItemsDate() {
     Rollup__mdt metadata = new Rollup__mdt();
     Date today = System.today();
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       today,
       Rollup.Op.UPDATE_MIN,
       Task.ActivityDate, // not a "MIN"-able field in SOQL; crucial for this test
@@ -1249,7 +1129,7 @@ private class RollupCalculatorTests {
   @IsTest
   static void dateMinDoesNotBlowUpOnNullValue() {
     Date firstPossibleDate = Date.newInstance(1970, 1, 1);
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       firstPossibleDate,
       Rollup.Op.MIN,
       Opportunity.CloseDate, // not a "MIN"-able field in SOQL; crucial for this test
@@ -1268,7 +1148,7 @@ private class RollupCalculatorTests {
   static void shouldDefaultToCurrentValueOnMinIfNoOtherMatchingItemsTime() {
     Rollup__mdt metadata = new Rollup__mdt();
     Time max = Time.newInstance(11, 11, 11, 11);
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       max,
       Rollup.Op.UPDATE_MIN,
       ContactPointAddress.BestTimeToContactEndTime,
@@ -1289,7 +1169,7 @@ private class RollupCalculatorTests {
   static void shouldCorrectlyUpdateMinIfOnlyMatchingItemChanges() {
     Rollup__mdt metadata = new Rollup__mdt();
     Time max = Time.newInstance(11, 11, 11, 11);
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       max,
       Rollup.Op.UPDATE_MIN,
       ContactPointAddress.BestTimeToContactEndTime,
@@ -1311,7 +1191,7 @@ private class RollupCalculatorTests {
   static void shouldDefaultToCurrentValueOnMaxIfNoOtherMatchingItemsDate() {
     Rollup__mdt metadata = new Rollup__mdt();
     Date today = System.today();
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       today,
       Rollup.Op.UPDATE_MAX,
       Task.ActivityDate, // not a "MAX"-able field in SOQL; crucial for this test
@@ -1341,7 +1221,7 @@ private class RollupCalculatorTests {
     Opportunity newerOpp = opp.clone(true, true);
     newerOpp.Amount = 0;
 
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       5,
       Rollup.Op.UPDATE_MIN,
       Opportunity.Amount,
@@ -1369,7 +1249,7 @@ private class RollupCalculatorTests {
     Opportunity newerOpp = opp.clone(true, true);
     newerOpp.Amount = 0;
 
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       5,
       Rollup.Op.UPDATE_MAX,
       Opportunity.Amount,
@@ -1395,15 +1275,7 @@ private class RollupCalculatorTests {
     insert cas;
 
     Rollup__mdt meta = new Rollup__mdt(CalcItem__c = 'Case', LookupObject__c = 'Account', CalcItemWhereClause__c = 'Description != \'Something\'');
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
-      '',
-      Rollup.Op.CONCAT_DISTINCT,
-      Case.Description,
-      Account.Description,
-      meta,
-      acc.Id,
-      Account.Id
-    );
+    RollupCalculator calc = getCalculator('', Rollup.Op.CONCAT_DISTINCT, Case.Description, Account.Description, meta, acc.Id, Account.Id);
     calc.setEvaluator(RollupEvaluator.getWhereEval(meta.CalcItemWhereClause__c, Case.SObjectType));
     calc.performRollup(new List<Case>{ cas }, new Map<Id, Case>());
 
@@ -1412,7 +1284,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void properlyConvertsDownstreamTypesToDecimals() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       System.today().addDays(-10),
       Rollup.Op.MAX,
       Opportunity.CloseDate,
@@ -1427,30 +1299,29 @@ private class RollupCalculatorTests {
 
     System.assertEquals(newDefaultValue, calc.getReturnValue());
 
-    calc = RollupCalculator.Factory.getCalculator(
-      System.now().addDays(-10),
+    newDefaultValue = System.now();
+    calc = getCalculator(
+      newDefaultValue,
       Rollup.Op.MAX,
       Opportunity.CloseDate,
-      Contact.BirthDate,
+      Event.ActivityDatetime,
       new Rollup__mdt(CalcItem__c = 'Opportunity'),
       RollupTestUtils.createId(Contact.SObjectType),
       Opportunity.Name
     );
-    newDefaultValue = System.now();
-    calc.setDefaultValues(RollupTestUtils.createId(Contact.SObjectType), newDefaultValue);
 
     System.assertEquals(newDefaultValue, calc.getReturnValue());
 
-    calc = RollupCalculator.Factory.getCalculator(
-      Time.newInstance(0, 0, 0, 0),
+    newDefaultValue = Time.newInstance(1, 0, 0, 0);
+    calc = getCalculator(
+      newDefaultValue,
       Rollup.Op.MAX,
       Opportunity.CloseDate,
-      Contact.BirthDate,
+      ContactPointAddress.BestTimeToContactStartTime,
       new Rollup__mdt(CalcItem__c = 'Opportunity'),
       RollupTestUtils.createId(Contact.SObjectType),
       Opportunity.Name
     );
-    newDefaultValue = Time.newInstance(1, 0, 0, 0);
     calc.setDefaultValues(RollupTestUtils.createId(Contact.SObjectType), newDefaultValue);
 
     System.assertEquals(newDefaultValue, calc.getReturnValue());
@@ -1463,7 +1334,7 @@ private class RollupCalculatorTests {
     Exception ex;
 
     try {
-      RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+      RollupCalculator calc = getCalculator(
         Blob.valueOf(''), // unsupported type
         Rollup.Op.CONCAT,
         Opportunity.Name,
@@ -1482,7 +1353,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void shouldNotMixReturnTypesWithBigDecimalUnsortableValues() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       0,
       Rollup.Op.MAX,
       Opportunity.Amount,
@@ -1507,7 +1378,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void shouldRecalcCountDistinctWithoutBigDecimalUnsortableIssue() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       0,
       Rollup.Op.DELETE_COUNT_DISTINCT,
       Opportunity.Amount,
@@ -1532,7 +1403,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void shouldRecalcCountWithoutBigDecimalUnsortableIssue() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       0.00,
       Rollup.Op.COUNT,
       Opportunity.Amount,
@@ -1557,7 +1428,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void shouldRecalcCountUpdateWithoutBigDecimalUnsortableIssue() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       0,
       Rollup.Op.UPDATE_COUNT,
       Opportunity.Amount,
@@ -1583,7 +1454,7 @@ private class RollupCalculatorTests {
   @IsTest
   static void shouldRecalcNullsWithoutBigDecimalUnsortableIssue() {
     Integer oldMax = 2;
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       oldMax,
       Rollup.Op.UPDATE_MAX,
       Opportunity.Amount,
@@ -1617,7 +1488,7 @@ private class RollupCalculatorTests {
 
   @IsTest
   static void shouldSetDecimalsWithoutBigDecimalUnsortableIssue() {
-    RollupCalculator calc = RollupCalculator.Factory.getCalculator(
+    RollupCalculator calc = getCalculator(
       0,
       Rollup.Op.MAX,
       Opportunity.Amount,
@@ -1661,8 +1532,22 @@ private class RollupCalculatorTests {
 
   private class RollupCalcEmptyMock extends RollupCalculator {
     public RollupCalcEmptyMock() {
-      super(0, Rollup.Op.LAST, null, null, null, new Rollup__mdt(), null, null);
+      super(Rollup.Op.LAST, null, null, null, new Rollup__mdt(), null);
     }
+  }
+
+  private static RollupCalculator getCalculator(
+    Object priorVal,
+    Rollup.Op operation,
+    SObjectField calcItemField,
+    SObjectField rollupField,
+    Rollup__mdt meta,
+    String lookupKey,
+    SObjectField lookupField
+  ) {
+    RollupCalculator calc = RollupCalculator.Factory.getCalculator(operation, calcItemField, rollupField, meta, lookupField);
+    calc.setDefaultValues(lookupKey, priorVal);
+    return calc;
   }
 
   private static Rollup__mdt configureOrderByMetadata(Rollup__mdt metadata, String orderByFirstLastFieldName) {

--- a/extra-tests/classes/RollupCalculatorTests.cls
+++ b/extra-tests/classes/RollupCalculatorTests.cls
@@ -359,7 +359,7 @@ private class RollupCalculatorTests {
   }
 
   @IsTest
-  static void shouldReturnZeroOnFullRecalcIfNoMatchingItemsCount() {
+  static void shouldReturnNullOnFullRecalcIfNoMatchingItemsCount() {
     RollupCalculator calc = getCalculator(
       0,
       Rollup.Op.COUNT,
@@ -374,11 +374,11 @@ private class RollupCalculatorTests {
 
     calc.performRollup(new List<Opportunity>{ opp }, new Map<Id, SObject>());
 
-    System.assertEquals(0, calc.getReturnValue());
+    System.assertEquals(null, calc.getReturnValue());
   }
 
   @IsTest
-  static void shouldReturnZeroOnFullRecalcIfNoItemsPresentCount() {
+  static void shouldReturnNullOnFullRecalcIfNoItemsPresentCount() {
     RollupCalculator calc = getCalculator(
       0,
       Rollup.Op.COUNT,
@@ -391,7 +391,7 @@ private class RollupCalculatorTests {
 
     calc.performRollup(new List<SObject>(), new Map<Id, SObject>());
 
-    System.assertEquals(0, calc.getReturnValue());
+    System.assertEquals(null, calc.getReturnValue());
   }
 
   @IsTest
@@ -586,7 +586,7 @@ private class RollupCalculatorTests {
     ContactPointAddress cpa = new ContactPointAddress(IsPrimary = false, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType));
     calc.performRollup(new List<SObject>{ cpa }, new Map<Id, SObject>{ cpa.Id => new ContactPointAddress(IsPrimary = true) });
 
-    System.assertEquals(0, calc.getReturnValue());
+    System.assertEquals(null, calc.getReturnValue());
   }
 
   @IsTest
@@ -696,7 +696,7 @@ private class RollupCalculatorTests {
 
     calc.performRollup(new List<Opportunity>{ newerOpp }, oldOppMap);
 
-    System.assertEquals(0, calc.getReturnValue());
+    System.assertEquals(null, calc.getReturnValue());
   }
 
   // CONCAT tests

--- a/extra-tests/classes/RollupCalculatorTests.cls-meta.xml
+++ b/extra-tests/classes/RollupCalculatorTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupCurrencyInfoTests.cls-meta.xml
+++ b/extra-tests/classes/RollupCurrencyInfoTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupDateLiteralTests.cls-meta.xml
+++ b/extra-tests/classes/RollupDateLiteralTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>54.0</apiVersion>
+	<apiVersion>55.0</apiVersion>
 	<status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupEvaluatorTests.cls-meta.xml
+++ b/extra-tests/classes/RollupEvaluatorTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>54.0</apiVersion>
+  <apiVersion>55.0</apiVersion>
   <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupFieldInitializerTests.cls-meta.xml
+++ b/extra-tests/classes/RollupFieldInitializerTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupFinalizerTests.cls-meta.xml
+++ b/extra-tests/classes/RollupFinalizerTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupFlowBulkProcessorTests.cls
+++ b/extra-tests/classes/RollupFlowBulkProcessorTests.cls
@@ -167,7 +167,7 @@ private class RollupFlowBulkProcessorTests {
 
     acc = [SELECT AnnualRevenue FROM Account WHERE Id = :acc.Id];
     // reparenting should purely subtract from account ...
-    System.assertEquals(0, acc.AnnualRevenue);
+    System.assertEquals(null, acc.AnnualRevenue);
   }
 
   @IsTest

--- a/extra-tests/classes/RollupFlowBulkProcessorTests.cls-meta.xml
+++ b/extra-tests/classes/RollupFlowBulkProcessorTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupFlowFullRecalcDispatcherTests.cls-meta.xml
+++ b/extra-tests/classes/RollupFlowFullRecalcDispatcherTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -466,7 +466,7 @@ private class RollupFullRecalcTests {
     acc = [SELECT Id, AnnualRevenue FROM Account WHERE Id = :acc.Id];
     System.assertEquals(1500, acc.AnnualRevenue, 'SUM REFRESH from flow should fully recalc');
     reparentedAccount = [SELECT Id, AnnualRevenue FROM Account WHERE Id = :reparentedAccount.Id];
-    System.assertEquals(0, reparentedAccount.AnnualRevenue, 'Reparenting with REFRESH should run decrement logic on old parent');
+    System.assertEquals(null, reparentedAccount.AnnualRevenue, 'Reparenting with REFRESH should run decrement logic on old parent');
   }
 
   @IsTest

--- a/extra-tests/classes/RollupFullRecalcTests.cls-meta.xml
+++ b/extra-tests/classes/RollupFullRecalcTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -1761,7 +1761,7 @@ private class RollupIntegrationTests {
     }
 
     System.assertNotEquals(null, ex);
-    System.assertEquals('Field: BillingAddress of type: ADDRESS specified invalid for rollup operation', ex.getMessage());
+    System.assertEquals('Calculation not defined for parent field: BillingAddress and op: MAX', ex.getMessage());
   }
 
   /** Invocable integration tests */

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -1829,8 +1829,8 @@ private class RollupIntegrationTests {
     Test.stopTest();
 
     Account updatedAccount = [SELECT AnnualRevenue, NumberOfEmployees, Phone FROM Account];
-    System.assertEquals(0, updatedAccount.NumberOfEmployees, 'COUNT should be cleared now that calc item no longer matches');
-    System.assertEquals(0, updatedAccount.AnnualRevenue, 'SUM should be cleared now that calc item no longer matches');
+    System.assertEquals(null, updatedAccount.NumberOfEmployees, 'COUNT should be cleared now that calc item no longer matches');
+    System.assertEquals(null, updatedAccount.AnnualRevenue, 'SUM should be cleared now that calc item no longer matches');
     System.assertEquals(cons[0].Phone, updatedAccount.Phone, 'MAX should not be cleared since calc item matches');
   }
 

--- a/extra-tests/classes/RollupIntegrationTests.cls-meta.xml
+++ b/extra-tests/classes/RollupIntegrationTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupLoggerTests.cls-meta.xml
+++ b/extra-tests/classes/RollupLoggerTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupParentResetProcessorTests.cls
+++ b/extra-tests/classes/RollupParentResetProcessorTests.cls
@@ -88,4 +88,27 @@ private class RollupParentResetProcessorTests {
 
     System.assertEquals(null, ex, 'Should not fail when field is not filterable');
   }
+
+  @IsTest
+  static void doesNotBlowUpOnWhenMultipleMetadataPresentForDifferentParents() {
+    RollupParentResetProcessor processor = new RollupParentResetProcessor(
+      new List<Rollup__mdt>{
+        new Rollup__mdt(RollupFieldOnLookupObject__c = 'Description', LookupObject__c = 'Account'),
+        new Rollup__mdt(RollupFieldOnLookupObject__c = 'FirstName', LookupObject__c = 'Contact')
+      },
+      Account.SObjectType,
+      'SELECT Id\nFROM Account WHERE Id != null',
+      new Set<String>(),
+      null
+    );
+
+    Exception ex;
+    try {
+      processor.runCalc();
+    } catch (Exception e) {
+      ex = e;
+    }
+
+    System.assertEquals(null, ex, 'Should not fail when different parent fields present');
+  }
 }

--- a/extra-tests/classes/RollupParentResetProcessorTests.cls-meta.xml
+++ b/extra-tests/classes/RollupParentResetProcessorTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupQueryBuilderTests.cls-meta.xml
+++ b/extra-tests/classes/RollupQueryBuilderTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupRecursionItemTests.cls-meta.xml
+++ b/extra-tests/classes/RollupRecursionItemTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupRelationshipFieldFinderTests.cls-meta.xml
+++ b/extra-tests/classes/RollupRelationshipFieldFinderTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>54.0</apiVersion>
+  <apiVersion>55.0</apiVersion>
   <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupSObjectUpdaterTests.cls
+++ b/extra-tests/classes/RollupSObjectUpdaterTests.cls
@@ -74,6 +74,29 @@ public class RollupSObjectUpdaterTests {
     System.assertEquals(String.valueOf(blobValue), opp.Description);
   }
 
+  @SuppressWarnings('PMD.EmptyWhileStmt')
+  @IsTest
+  static void doesNotUpdateRecordsWhichOnlyContainId() {
+    Account acc = new Account(Name = 'Should Not Be Updated');
+    insert acc;
+
+    acc = [SELECT Id, LastModifiedDate FROM Account];
+    Datetime nowish = System.now();
+    while (System.now() < nowish.addSeconds(1)) {
+      // let's waste some time together!
+      // we could later compare the hashCode() of
+      // the SObjects to ensure no update was made, but
+      // I've legitimately seen instances where the update
+      // happened so quick that a change in seconds wasn't registered
+      // and the hashCode for SObjects is made up of all the selected fields
+    }
+
+    new RollupSObjectUpdater().doUpdate(new List<SObject>{ new Account(Id = acc.Id) });
+
+    Account updatedAccount = [SELECT Id, LastModifiedDate FROM Account];
+    System.assertEquals(acc, updatedAccount, 'Last modified date should not have updated if only Id was passed');
+  }
+
   public class DispatcherMock implements RollupSObjectUpdater.IDispatcher {
     public void dispatch(List<SObject> records) {
       dispatcherMockWasCalled = true;

--- a/extra-tests/classes/RollupSObjectUpdaterTests.cls-meta.xml
+++ b/extra-tests/classes/RollupSObjectUpdaterTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupTestUtils.cls-meta.xml
+++ b/extra-tests/classes/RollupTestUtils.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -1,11 +1,9 @@
 @IsTest
 private class RollupTests {
-  static Object testPriorVal;
   static Rollup.Op testOp;
   static SObjectField testOpFieldOnCalcItem;
   static SObjectField testOpFieldOnLookupObject;
   static Rollup__mdt testMetadata;
-  static String testLookupRecordKey;
   static SObjectField testLookupKeyField;
   static Rollup.Op rollupOp;
   static Boolean calcMockWasCalled = false;
@@ -24,29 +22,25 @@ private class RollupTests {
 
   private class FactoryMock extends RollupCalculator.Factory {
     public override RollupCalculator getCalculator(
-      Object priorVal,
       Rollup.Op op,
       SObjectfield opFieldOnCalcItem,
       SObjectField opFieldOnLookupObject,
       Rollup__mdt metadata,
-      String lookupRecordKey,
       SObjectField lookupKeyField
     ) {
-      testPriorVal = priorVal;
       testOp = op;
       testOpFieldOnCalcItem = opFieldOnCalcItem;
       testOpFieldOnLookupObject = opFieldOnLookupObject;
       testMetadata = metadata;
-      testLookupRecordKey = lookupRecordKey;
       testLookupKeyField = lookupKeyField;
       return new RollupCalcMock();
     }
   }
 
-  public class RollupCalcMock extends RollupCalculator {
+  private class RollupCalcMock extends RollupCalculator {
     // everything is a no-op
     public RollupCalcMock() {
-      super(0, rollupOp, null, null, null, new Rollup__mdt(), null, null);
+      super(rollupOp, null, Account.AnnualRevenue, null, new Rollup__mdt(), null);
       calcMockWasCalled = true;
     }
   }
@@ -344,7 +338,9 @@ private class RollupTests {
     Rollup.countFromApex(ContactPointAddress.PreferenceRank, ContactPointAddress.ParentId, Account.Id, Account.AnnualRevenue, Account.SObjectType).runCalc();
     Test.stopTest();
 
-    System.assertEquals(0, mock.Records.size(), 'Records should not have been populated when empty COUNT AFTER_INSERT');
+    System.assertEquals(1, mock.Records.size(), 'Records should have been populated COUNT AFTER_INSERT');
+    Account updatedAcc = (Account) mock.Records[0];
+    System.assertEquals(0, updatedAcc.AnnualRevenue);
   }
 
   @IsTest
@@ -435,7 +431,8 @@ private class RollupTests {
         RollupFieldOnLookupObject__c = 'Name',
         RollupOperation__c = 'MAX',
         CalcItem__c = 'ContactPointAddress',
-        FullRecalculationDefaultStringValue__c = 'Z'
+        FullRecalculationDefaultStringValue__c = 'Z',
+        IsFullRecordSet__c = true
       )
     };
 
@@ -3100,6 +3097,7 @@ private class RollupTests {
     flowInput.rollupSObjectName = 'Contract';
     flowInput.rollupOperation = 'MAX';
     flowInput.fullRecalculationDefaultNumberValue = nowish.getTime();
+    flowInput.isFullRecordSet = true;
 
     Test.startTest();
     List<Rollup.FlowOutput> flowOutputs = Rollup.performRollup(new List<Rollup.FlowInput>{ flowInput });
@@ -3122,6 +3120,7 @@ private class RollupTests {
     flowInputs[0].fullRecalculationDefaultStringValue = 'Z';
     flowInputs[0].rollupFieldOnOpObject = 'Name';
     flowInputs[0].rollupFieldOnCalcItem = 'Name';
+    flowInputs[0].isFullRecordSet = true;
 
     Test.startTest();
     List<Rollup.FlowOutput> flowOutputs = Rollup.performRollup(flowInputs);
@@ -3511,10 +3510,10 @@ private class RollupTests {
     Test.stopTest();
 
     System.assertEquals(2, mock.Records.size(), 'Records should have been populated SUM AFTER_UPDATE, ' + mock.Records);
-    Account updatedAcc = (Account) mock.Records[1];
+    Account updatedAcc = (Account) mock.Records[0];
     System.assertEquals(acc.Id, updatedAcc.Id);
     System.assertEquals(50, updatedAcc.AnnualRevenue, 'AVERAGE AFTER_UPDATE should take the diff between the current amount and the pre-existing one');
-    Account updatedOldAcc = (Account) mock.Records[0];
+    Account updatedOldAcc = (Account) mock.Records[1];
     System.assertEquals(oldAcc.Id, updatedOldAcc.Id);
     System.assertEquals(null, updatedOldAcc.AnnualRevenue, 'AVERAGE AFTER_UPDATE should take the diff between the current amount and the pre-existing one');
   }

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -288,7 +288,7 @@ private class RollupTests {
 
     System.assertEquals(1, mock.Records.size(), 'Records should have been populated COUNT AFTER_UPDATE');
     Account updatedAcc = (Account) mock.Records[0];
-    System.assertEquals(0, updatedAcc.AnnualRevenue, 'COUNT AFTER_UPDATE should decrement when field is removed');
+    System.assertEquals(null, updatedAcc.AnnualRevenue, 'COUNT AFTER_UPDATE should decrement when field is removed');
   }
 
   @IsTest
@@ -338,9 +338,7 @@ private class RollupTests {
     Rollup.countFromApex(ContactPointAddress.PreferenceRank, ContactPointAddress.ParentId, Account.Id, Account.AnnualRevenue, Account.SObjectType).runCalc();
     Test.stopTest();
 
-    System.assertEquals(1, mock.Records.size(), 'Records should have been populated COUNT AFTER_INSERT');
-    Account updatedAcc = (Account) mock.Records[0];
-    System.assertEquals(0, updatedAcc.AnnualRevenue);
+    System.assertEquals(0, mock.Records.size(), 'Records should not have been populated COUNT AFTER_INSERT');
   }
 
   @IsTest
@@ -813,7 +811,7 @@ private class RollupTests {
 
     System.assertEquals(1, mock.Records.size(), 'Records should have been populated MAX BEFORE_DELETE');
     Account updatedAcc = (Account) mock.Records[0];
-    System.assertEquals(0, updatedAcc.AnnualRevenue, 'MAX BEFORE_DELETE should take the maximum cpaortunity amount');
+    System.assertEquals(null, updatedAcc.AnnualRevenue, 'MAX BEFORE_DELETE should take the maximum cpaortunity amount');
   }
 
   @IsTest
@@ -3083,7 +3081,7 @@ private class RollupTests {
     Datetime nowish = System.now();
 
     // it only matters that the amount below is LESS than the above value, and that "nowish" is assigned to the fullRecalculationDefaultNumberValue flow input value
-    List<Event> events = new List<Event>{ new Event(ActivityDateTime = nowish.addDays(-2), WhatId = con.Id) };
+    List<Event> events = new List<Event>{ new Event(WhatId = con.Id) };
     RollupTestUtils.DMLMock mock = RollupTestUtils.loadMock(events);
     Rollup.records = null;
 
@@ -3304,7 +3302,7 @@ private class RollupTests {
     Account updatedAcc = (Account) mock.Records[0];
     System.assertEquals(325, updatedAcc.AnnualRevenue, 'SUM AFTER_UPDATE should take the diff between the current amount and the pre-existing one');
     Account updatedOldAcc = (Account) mock.Records[1];
-    System.assertEquals(0, updatedOldAcc.AnnualRevenue, 'SUM AFTER_UPDATE should take the diff between the current amount and the pre-existing one');
+    System.assertEquals(null, updatedOldAcc.AnnualRevenue, 'SUM AFTER_UPDATE should take the diff between the current amount and the pre-existing one');
   }
 
   @IsTest
@@ -3335,7 +3333,7 @@ private class RollupTests {
       'SUM AFTER_UPDATE should take the diff between the current amount and the pre-existing one'
     );
     Account updatedOldAcc = (Account) mock.Records[1];
-    System.assertEquals(0, updatedOldAcc.AnnualRevenue, 'SUM AFTER_UPDATE should take the diff between the current amount and the pre-existing one');
+    System.assertEquals(null, updatedOldAcc.AnnualRevenue, 'SUM AFTER_UPDATE should take the diff between the current amount and the pre-existing one');
   }
 
   @IsTest
@@ -3372,7 +3370,7 @@ private class RollupTests {
 
     System.assertNotEquals(0, mock.Records.size());
     Account updatedAcc = (Account) new Map<Id, SObject>(mock.Records).get(acc.Id);
-    System.assertEquals(0, updatedAcc.AnnualRevenue, 'Count should have been decremented');
+    System.assertEquals(null, updatedAcc.AnnualRevenue, 'Count should have been decremented');
   }
 
   @IsTest
@@ -3479,7 +3477,7 @@ private class RollupTests {
       if (updatedAcc.Id == acc.Id) {
         System.assertEquals(1, updatedAcc.AnnualRevenue, 'COUNT AFTER_UPDATE should only count updated entries reparented to it');
       } else if (updatedAcc.Id == oldAcc.Id) {
-        System.assertEquals(0, updatedAcc.AnnualRevenue, 'Old account should have had its annual revenue decremented');
+        System.assertEquals(null, updatedAcc.AnnualRevenue, 'Old account should have had its annual revenue decremented');
       }
     }
   }

--- a/extra-tests/classes/RollupTests.cls-meta.xml
+++ b/extra-tests/classes/RollupTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/flows/Rollup_Integration_Clear_Lookup_Fields.flow-meta.xml
+++ b/extra-tests/flows/Rollup_Integration_Clear_Lookup_Fields.flow-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
     <actionCalls>
         <name>ROLL_UP</name>
@@ -78,7 +78,7 @@
         </inputParameters>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </actionCalls>
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <assignments>
         <name>Add_Records_To_Collections</name>
         <label>Add Records To Collections</label>

--- a/extra-tests/flows/Rollup_Integration_Multiple_Deferred_Case_Rollups.flow-meta.xml
+++ b/extra-tests/flows/Rollup_Integration_Multiple_Deferred_Case_Rollups.flow-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
     <actionCalls>
         <name>Add_matching_description_to_Site</name>
@@ -501,7 +501,7 @@
         </inputParameters>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </actionCalls>
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <assignments>
         <name>Add_case_and_prior_case_to_collections</name>
         <label>Add case and prior case to collections</label>

--- a/extra-tests/flows/Rollup_Integration_Parent_Where_Clause_Filtering.flow-meta.xml
+++ b/extra-tests/flows/Rollup_Integration_Parent_Where_Clause_Filtering.flow-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
     <actionCalls>
         <description>Assigns the last phone number to the Account&apos;s BusinessPhone field</description>
@@ -85,7 +85,7 @@
         </inputParameters>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </actionCalls>
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <assignments>
         <name>Add_to_collections</name>
         <label>Add to collections</label>

--- a/extra-tests/triggers/AccountTrigger.trigger-meta.xml
+++ b/extra-tests/triggers/AccountTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.0' encoding='UTF-8' ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>54.0</apiVersion>
+  <apiVersion>55.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/extra-tests/triggers/ApplicationLogTrigger.trigger-meta.xml
+++ b/extra-tests/triggers/ApplicationLogTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.0' encoding='UTF-8' ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>54.0</apiVersion>
+  <apiVersion>55.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/extra-tests/triggers/ApplicationTrigger.trigger-meta.xml
+++ b/extra-tests/triggers/ApplicationTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.0' encoding='UTF-8' ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>54.0</apiVersion>
+  <apiVersion>55.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/extra-tests/triggers/ParentApplicationTrigger.trigger-meta.xml
+++ b/extra-tests/triggers/ParentApplicationTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.0' encoding='UTF-8' ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>54.0</apiVersion>
+  <apiVersion>55.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/extra-tests/triggers/RollupChildTrigger.trigger-meta.xml
+++ b/extra-tests/triggers/RollupChildTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.0' encoding='UTF-8' ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>54.0</apiVersion>
+  <apiVersion>55.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/plugins/CustomObjectRollupLogger/classes/RollupCustomObjectLogger.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/classes/RollupCustomObjectLogger.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/classes/RollupLogBatchPurger.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/classes/RollupLogBatchPurger.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/classes/RollupLogControl.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/classes/RollupLogControl.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/classes/RollupLogEventHandler.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/classes/RollupLogEventHandler.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/classes/RollupPurgerSchedulable.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/classes/RollupPurgerSchedulable.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/tests/RollupCustomObjectLoggerTests.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/tests/RollupCustomObjectLoggerTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/tests/RollupLogBatchPurgerTests.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/tests/RollupLogBatchPurgerTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/triggers/RollupLogEventTrigger.trigger-meta.xml
+++ b/plugins/CustomObjectRollupLogger/triggers/RollupLogEventTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.0' encoding='UTF-8' ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>54.0</apiVersion>
+  <apiVersion>55.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/plugins/ExtraCodeCoverage/README.md
+++ b/plugins/ExtraCodeCoverage/README.md
@@ -1,11 +1,11 @@
 # Extra Code Coverage
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkVAAA0">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkVZAA0">
   <img alt="Deploy to Salesforce"
        src="../../media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkVAAA0">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkVZAA0">
   <img alt="Deploy to Salesforce Sandbox"
        src="../../media/deploy-package-to-sandbox.png">
 </a>

--- a/plugins/NebulaLogger/classes/RollupNebulaLoggerAdapter.cls-meta.xml
+++ b/plugins/NebulaLogger/classes/RollupNebulaLoggerAdapter.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/NebulaLogger/tests/RollupNebulaLoggerAdapterTest.cls-meta.xml
+++ b/plugins/NebulaLogger/tests/RollupNebulaLoggerAdapterTest.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/RollupCallback/README.md
+++ b/plugins/RollupCallback/README.md
@@ -43,7 +43,7 @@ export default class RollupChangeNotifier extends LightningElement {
 <!-- in rollupChangeNotifier.js-meta.xml -->
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Rollup Change Notifier</masterLabel>
     <targets>

--- a/plugins/RollupCallback/classes/RollupDispatch.cls-meta.xml
+++ b/plugins/RollupCallback/classes/RollupDispatch.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/RollupCallback/tests/RollupDispatchTests.cls-meta.xml
+++ b/plugins/RollupCallback/tests/RollupDispatchTests.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/app/lwc/recalculateParentRollupFlexipage/recalculateParentRollupFlexipage.js-meta.xml
+++ b/rollup/app/lwc/recalculateParentRollupFlexipage/recalculateParentRollupFlexipage.js-meta.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Recalc Rollups Button</masterLabel>
     <targets>

--- a/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js-meta.xml
+++ b/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js-meta.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
       <target>lightning__AppPage</target>

--- a/rollup/app/lwc/rollupOrderBy/rollupOrderBy.js-meta.xml
+++ b/rollup/app/lwc/rollupOrderBy/rollupOrderBy.js-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/rollup/app/lwc/rollupUtils/rolupUtils.js-meta.xml
+++ b/rollup/app/lwc/rollupUtils/rolupUtils.js-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -360,9 +360,9 @@ global without sharing virtual class Rollup {
   protected virtual Map<String, String> customizeToStringEntries(Map<String, String> props) {
     this.addToMap(props, 'Rollup Metadata', this.metadata);
     this.addToMap(props, 'Rollup Control', this.rollupControl);
-    this.addToMap(props, 'Calc Items', this.calcItems?.size() > 10 ? (Object) '10 items or more ...' : (Object) this.calcItems);
+    this.addToMap(props, 'Calc Items', this.calcItems?.size() > 10 ? ((Object) this.calcItems.size() + ' items') : (Object) this.calcItems);
     if (this.oldCalcItems?.isEmpty() == false) {
-      this.addToMap(props, 'Old Calc Items', this.oldCalcItems.size() > 10 ? (Object) '10 items or more ...' : (Object) this.oldCalcItems);
+      this.addToMap(props, 'Old Calc Items', this.oldCalcItems?.size() > 10 ? ((Object) this.oldCalcItems.size() + ' items') : (Object) this.oldCalcItems);
     }
     this.addToMap(props, 'Query Count', this.queryCount);
     return props;

--- a/rollup/core/classes/Rollup.cls-meta.xml
+++ b/rollup/core/classes/Rollup.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -217,7 +217,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         this.rollups.remove(index);
         this.deferredRollups.add(roll);
       } else {
-        this.initializeRollupFieldDefaults(lookupItems, roll);
+        this.flagFullRecalcRollups(roll);
       }
     }
 
@@ -546,7 +546,11 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
       List<SObject> localLookupItems = this.getLookupItems(calcItemsByLookupField, updatedLookupRecords, roll);
       RollupLogger.Instance.log('starting rollup for:', roll, LoggingLevel.DEBUG);
-      updatedLookupRecords.putAll(this.getUpdatedLookupItemsByRollup(roll, calcItemsByLookupField, localLookupItems));
+      List<SObject> updatedLookupItems = this.getUpdatedLookupItemsByRollup(roll, calcItemsByLookupField, localLookupItems);
+      for (SObject updatedLookupItem : updatedLookupItems) {
+        updatedLookupRecords.put(updatedLookupItem.Id, updatedLookupItem);
+        this.storeParentResetField(roll, updatedLookupItem);
+      }
     }
 
     if (this.isTimingOut) {
@@ -659,12 +663,11 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         lookupItemKeys.remove(lookupId);
         // this way, the updated values are persisted for each field, and the default values are initialized
         SObject updatedLookupObject = updatedLookupRecords.get(lookupId);
-        this.resetLookupFieldsForNullOrFullRecalcs(updatedLookupObject, roll);
         localLookupItems.add(updatedLookupObject);
       }
     }
     localLookupItems.addAll(roll.getExistingLookupItems(lookupItemKeys, roll, this.lookupObjectToUniqueFieldNames.get(roll.lookupObj)));
-    this.initializeRollupFieldDefaults(localLookupItems, roll);
+    this.flagFullRecalcRollups(roll);
     return localLookupItems;
   }
 
@@ -850,21 +853,9 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     return lookupFieldToCalcItems;
   }
 
-  private void initializeRollupFieldDefaults(List<SObject> lookupItems, RollupAsyncProcessor rollup) {
+  private void flagFullRecalcRollups(RollupAsyncProcessor rollup) {
     if (this.isValidAdditionalCalcItemRetrieval(rollup) && rollup.isFullRecalc == false) {
       rollup.isFullRecalc = true;
-    }
-    // prior to returning, we need to ensure the default value for the rollup field is set
-    for (SObject lookupItem : lookupItems) {
-      this.resetLookupFieldsForNullOrFullRecalcs(lookupItem, rollup);
-    }
-  }
-
-  private void resetLookupFieldsForNullOrFullRecalcs(SObject lookupItem, RollupAsyncProcessor rollup) {
-    if (lookupItem.getSObjectType() == rollup.lookupObj) {
-      if (lookupItem.get(rollup.opFieldOnLookupObject) == null || this.isValidFullRecalcReset(rollup, lookupItem)) {
-        lookupItem.put(rollup.opFieldOnLookupObject, RollupFieldInitializer.Current.getDefaultValue(rollup.opFieldOnLookupObject));
-      }
     }
   }
 
@@ -1027,7 +1018,8 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         // has already been setup to adjust the lookup item's rollup field
         if (localCalcItems.isEmpty() == false || (localCalcItems.isEmpty() && oldLookupItems.isEmpty())) {
           Object priorVal = lookupRecord.get(roll.opFieldOnLookupObject);
-          calc = this.getCalculator(calc, roll, localCalcItems, lookupRecord, priorVal, key, roll.lookupFieldOnCalcItem);
+          Object priorValToUse = roll.isFullRecalc && this.parentRollupFieldHasBeenReset(roll, lookupRecord) == false ? null : priorVal;
+          calc = this.getCalculator(calc, roll, localCalcItems, lookupRecord, priorValToUse, key, roll.lookupFieldOnCalcItem);
           this.conditionallyPerformUpdate(priorVal, calc, lookupRecord, roll, recordsToUpdate, updater, 'lookup');
         }
       }
@@ -1105,19 +1097,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       rollupOp = Rollup.Op.valueOf(roll.op.name().substringAfter('_'));
     }
     if (rollupCalc == null) {
-      rollupCalc = RollupCalculator.Factory.getCalculator(
-        priorVal,
-        rollupOp,
-        roll.opFieldOnCalcItem,
-        roll.opFieldOnLookupObject,
-        roll.metadata,
-        lookupRecordKey,
-        lookupKeyField
-      );
-    } else {
-      rollupCalc.setDefaultValues(lookupRecordKey, priorVal);
+      rollupCalc = RollupCalculator.Factory.getCalculator(rollupOp, roll.opFieldOnCalcItem, roll.opFieldOnLookupObject, roll.metadata, lookupKeyField);
     }
     rollupCalc.setFullRecalc(roll.isFullRecalc);
+    rollupCalc.setDefaultValues(lookupRecordKey, priorVal);
     rollupCalc.setEvaluator(roll.eval);
     rollupCalc.setCDCUpdate(this.isCDCUpdate);
     rollupCalc.setMultiCurrencyInfo(lookupRecord);
@@ -1183,12 +1166,11 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   ) {
     RollupLogger.Instance.log(logKey + ' record prior to rolling up:', lookupRecord, LoggingLevel.DEBUG);
     Object newVal = calc.getReturnValue();
-    if (priorVal != newVal || this.isFullRecalc || roll.isFullRecalc) {
+    if (priorVal != newVal) {
       String key = (String) lookupRecord.get(roll.lookupFieldOnLookupObject);
       RollupLogger.Instance.log('updating record ...', LoggingLevel.FINE);
       updater.updateField(lookupRecord, newVal);
       recordsToUpdate.put(key, lookupRecord);
-      this.storeParentResetField(roll, lookupRecord);
     }
     RollupLogger.Instance.log(logKey + ' record after rolling up:', lookupRecord, LoggingLevel.DEBUG);
   }

--- a/rollup/core/classes/RollupAsyncProcessor.cls-meta.xml
+++ b/rollup/core/classes/RollupAsyncProcessor.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupCalcItemReplacer.cls
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls
@@ -105,11 +105,14 @@ public without sharing class RollupCalcItemReplacer {
       RollupLogger.Instance.log('replacing calc items with missing base fields using query string:', queryString, LoggingLevel.FINE);
       List<SObject> calcItemsWithReplacement = Database.query(queryString);
       Map<Id, SObject> idToCalcItem = new Map<Id, SObject>(calcItems);
+      Map<String, Schema.SObjectField> fieldNameToDescribe = firstItem.getSObjectType().getDescribe().fields.getMap();
       for (SObject calcItemWithReplacement : calcItemsWithReplacement) {
         if (idToCalcItem.containsKey(calcItemWithReplacement.Id)) {
           SObject calcItem = idToCalcItem.get(calcItemWithReplacement.Id);
           for (String baseField : baseFields) {
-            calcItem.put(baseField, calcItemWithReplacement.get(baseField));
+            if (fieldNameToDescribe.get(baseField)?.getDescribe().isCalculated() == false) {
+              calcItem.put(baseField, calcItemWithReplacement.get(baseField));
+            }
           }
         }
       }

--- a/rollup/core/classes/RollupCalcItemReplacer.cls-meta.xml
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupCalcItemSorter.cls-meta.xml
+++ b/rollup/core/classes/RollupCalcItemSorter.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -38,59 +38,51 @@ public without sharing abstract class RollupCalculator {
 
   public virtual class Factory {
     public virtual RollupCalculator getCalculator(
-      Object priorVal,
       Rollup.Op op,
       SObjectfield opFieldOnCalcItem,
       SObjectField opFieldOnLookupObject,
       Rollup__mdt metadata,
-      String lookupRecordKey,
       SObjectField lookupKeyField
     ) {
       RollupCalculator calc;
       switch on op {
         when COUNT_DISTINCT, UPDATE_COUNT_DISTINCT, DELETE_COUNT_DISTINCT {
-          calc = new CountDistinctRollupCalculator(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupRecordKey, lookupKeyField);
+          calc = new CountDistinctRollupCalculator(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField);
         }
         when COUNT, UPDATE_COUNT, DELETE_COUNT {
-          calc = new CountRollupCalculator(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupRecordKey, lookupKeyField);
+          calc = new CountRollupCalculator(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField);
         }
         when AVERAGE, UPDATE_AVERAGE, DELETE_AVERAGE {
-          calc = new AverageRollupCalculator(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupRecordKey, lookupKeyField);
+          calc = new AverageRollupCalculator(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField);
         }
         when FIRST, UPDATE_FIRST, DELETE_FIRST, LAST, UPDATE_LAST, DELETE_LAST {
-          calc = new FirstLastRollupCalculator(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupRecordKey, lookupKeyField);
+          calc = new FirstLastRollupCalculator(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField);
         }
         when MOST {
-          calc = new MostRollupCalculator(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupRecordKey, lookupKeyField);
+          calc = new MostRollupCalculator(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField);
         }
         when else {
-          if (priorVal instanceof Decimal) {
-            calc = new DecimalRollupCalculator(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupRecordKey, lookupKeyField);
-          } else if (priorVal instanceof String) {
-            calc = new PicklistRollupCalculator(
-              priorVal,
-              op,
-              opFieldOnCalcItem,
-              opFieldOnLookupObject,
-              metadata,
-              lookupRecordKey,
-              lookupKeyField,
-              metadata.ConcatDelimiter__c
-            );
-          } else if (priorVal instanceof Date) {
-            // not obvious: the order of these else if's is of supreme importance
-            // Date has to go before Datetime; in the same way that all numbers test true as an instanceof Decimal
-            // all Dates test true as Datetimes ...
-            calc = new DateRollupCalculator(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupRecordKey, lookupKeyField);
-          } else if (priorVal instanceof Time) {
-            calc = new TimeRollupCalculator(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupRecordKey, lookupKeyField);
-          } else if (priorval instanceof Datetime) {
-            calc = new DatetimeRollupCalculator(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupRecordKey, lookupKeyField);
+          switch on opFieldOnLookupObject.getDescribe().getType() {
+            when Currency, Double, Integer, Long, Percent {
+              calc = new DecimalRollupCalculator(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField);
+            }
+            when Combobox, Email, EncryptedString, Id, MultiPicklist, Phone, Reference, String, TextArea, URL {
+              calc = new PicklistRollupCalculator(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField, metadata.ConcatDelimiter__c);
+            }
+            when Date {
+              calc = new DateRollupCalculator(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField);
+            }
+            when Time {
+              calc = new TimeRollupCalculator(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField);
+            }
+            when Datetime {
+              calc = new DatetimeRollupCalculator(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField);
+            }
           }
         }
       }
       if (calc == null) {
-        throw new IllegalArgumentException('Calculation not defined for prior value: ' + JSON.serialize(priorVal) + ' and op: ' + op);
+        throw new IllegalArgumentException('Calculation not defined for parent field: ' + String.valueOf(opFieldOnLookupObject) + ' and op: ' + op);
       }
 
       return calc;
@@ -98,13 +90,11 @@ public without sharing abstract class RollupCalculator {
   }
 
   protected RollupCalculator(
-    Object priorVal,
     Rollup.Op op,
     SObjectField opFieldOnCalcItem,
     SObjectField opFieldOnLookupObject,
     Object defaultVal,
     Rollup__mdt metadata,
-    String lookupRecordKey,
     SObjectField lookupKeyField
   ) {
     this.opFieldOnLookupObject = opFieldOnLookupObject;
@@ -113,7 +103,6 @@ public without sharing abstract class RollupCalculator {
     this.metadata = metadata;
     this.lookupKeyField = lookupKeyField;
     this.defaultVal = defaultVal;
-    this.setDefaultValues(lookupRecordKey, priorVal);
     if (this.isMultiCurrencyRollup == null) {
       this.isMultiCurrencyRollup =
         UserInfo.isMultiCurrencyOrganization() &&
@@ -128,10 +117,10 @@ public without sharing abstract class RollupCalculator {
 
   public virtual void setDefaultValues(String lookupRecordKey, Object priorVal) {
     this.lookupRecordKey = lookupRecordKey;
-    if (this.defaultVal != null) {
-      this.returnVal = this.defaultVal;
+    if (priorVal == null) {
+      this.returnVal = this.defaultVal != null ? this.defaultVal : RollupFieldInitializer.Current.getDefaultValue(this.opFieldOnLookupObject);
     } else {
-      this.returnVal = priorVal == null ? RollupFieldInitializer.Current.getDefaultValue(this.opFieldOnLookupObject) : priorVal;
+      this.returnVal = priorVal;
     }
     this.lookupKeyQuery =
       this.lookupKeyField +
@@ -370,15 +359,8 @@ public without sharing abstract class RollupCalculator {
         this.returnVal = null;
       } else {
         Rollup.Op baseOp = Rollup.Op.valueOf(Rollup.getBaseOperationName(op.name()));
-        RollupCalculator calc = Factory.getCalculator(
-          this.returnVal,
-          baseOp,
-          this.opFieldOnCalcItem,
-          this.opFieldOnLookupObject,
-          this.metadata,
-          this.lookupRecordKey,
-          this.lookupKeyField
-        );
+        RollupCalculator calc = Factory.getCalculator(baseOp, this.opFieldOnCalcItem, this.opFieldOnLookupObject, this.metadata, this.lookupKeyField);
+        calc.setDefaultValues(this.lookupRecordKey, this.returnVal);
         calc.parentIsoCode = this.parentIsoCode;
         calc.performRollup(allOtherItems, new Map<Id, SObject>());
         this.returnVal = calc.getReturnValue();
@@ -420,15 +402,13 @@ public without sharing abstract class RollupCalculator {
     private final Set<Object> distinctValues = new Set<Object>();
     private Boolean isIdCount;
     public CountDistinctRollupCalculator(
-      Object priorVal,
       Rollup.Op op,
       SObjectfield opFieldOnCalcItem,
       SObjectField opFieldOnLookupObject,
       Rollup__mdt metadata,
-      String lookupRecordKey,
       SObjectField lookupKeyField
     ) {
-      super(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata.FullRecalculationDefaultNumberValue__c, metadata, lookupRecordKey, lookupKeyField);
+      super(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata.FullRecalculationDefaultNumberValue__c, metadata, lookupKeyField);
     }
 
     public override void setDefaultValues(String lookupRecordKey, Object priorVal) {
@@ -505,15 +485,13 @@ public without sharing abstract class RollupCalculator {
   private without sharing virtual class DecimalRollupCalculator extends RollupCalculator {
     private Decimal returnDecimal;
     public DecimalRollupCalculator(
-      Object priorVal,
       Rollup.Op op,
       SObjectField opFieldOnCalcItem,
       SObjectField opFieldOnLookupObject,
       Rollup__mdt metadata,
-      String lookupRecordKey,
       SObjectField lookupKeyField
     ) {
-      super(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata.FullRecalculationDefaultNumberValue__c, metadata, lookupRecordKey, lookupKeyField);
+      super(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata.FullRecalculationDefaultNumberValue__c, metadata, lookupKeyField);
     }
 
     public virtual override void setDefaultValues(String lookupRecordKey, Object priorVal) {
@@ -652,15 +630,13 @@ public without sharing abstract class RollupCalculator {
 
   private without sharing virtual class DatetimeRollupCalculator extends DecimalRollupCalculator {
     public DatetimeRollupCalculator(
-      Object priorVal,
       Rollup.Op op,
       SObjectfield opFieldOnCalcItem,
       SObjectField opFieldOnLookupObject,
       Rollup__mdt metadata,
-      String lookupRecordKey,
       SObjectField lookupKeyField
     ) {
-      super(((Datetime) priorVal).getTime(), op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupRecordKey, lookupKeyField);
+      super(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField);
     }
 
     public virtual override Object getReturnValue() {
@@ -672,6 +648,9 @@ public without sharing abstract class RollupCalculator {
     }
 
     public virtual override void setDefaultValues(String lookupRecordKey, Object priorVal) {
+      if (priorVal == null) {
+        priorVal = RollupFieldInitializer.Current.defaultDateTime;
+      }
       if (priorVal instanceof Datetime) {
         priorVal = ((Datetime) priorVal).getTime();
       }
@@ -700,23 +679,13 @@ public without sharing abstract class RollupCalculator {
 
   private without sharing class DateRollupCalculator extends DatetimeRollupCalculator {
     public DateRollupCalculator(
-      Object priorVal,
       Rollup.Op op,
       SObjectField opFieldOnCalcItem,
       SObjectField opFieldOnLookupObject,
       Rollup__mdt metadata,
-      String lookupRecordKey,
       SObjectField lookupKeyField
     ) {
-      super(
-        Datetime.newInstanceGmt((Date) priorVal, Time.newInstance(0, 0, 0, 0)),
-        op,
-        opFieldOnCalcItem,
-        opFieldOnLookupObject,
-        metadata,
-        lookupRecordKey,
-        lookupKeyField
-      );
+      super(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField);
     }
 
     public override void setDefaultValues(String lookupRecordKey, Object priorVal) {
@@ -734,23 +703,13 @@ public without sharing abstract class RollupCalculator {
 
   private without sharing class TimeRollupCalculator extends DatetimeRollupCalculator {
     public TimeRollupCalculator(
-      Object priorVal,
       Rollup.Op op,
       SObjectField opFieldOnCalcItem,
       SObjectField opFieldOnLookupObject,
       Rollup__mdt metadata,
-      String lookupRecordKey,
       SObjectField lookupKeyField
     ) {
-      super(
-        Datetime.newInstanceGmt(RollupFieldInitializer.Current.defaultDateTime.dateGmt(), (Time) priorVal),
-        op,
-        opFieldOnCalcItem,
-        opFieldOnLookupObject,
-        metadata,
-        lookupRecordKey,
-        lookupKeyField
-      );
+      super(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField);
     }
 
     public override void setDefaultValues(String lookupRecordKey, Object priorVal) {
@@ -783,15 +742,13 @@ public without sharing abstract class RollupCalculator {
 
   private without sharing class CountRollupCalculator extends DecimalRollupCalculator {
     public CountRollupCalculator(
-      Object priorVal,
       Rollup.Op op,
       SObjectfield opFieldOnCalcItem,
       SObjectField opFieldOnLookupObject,
       Rollup__mdt metadata,
-      String lookupRecordKey,
       SObjectField lookupKeyField
     ) {
-      super(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupRecordKey, lookupKeyField);
+      super(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField);
     }
 
     public override Object getReturnValue() {
@@ -845,25 +802,14 @@ public without sharing abstract class RollupCalculator {
     private final Set<Id> concatDistinctIds = new Set<Id>();
 
     public StringRollupCalculator(
-      Object priorVal,
       Rollup.Op op,
       SObjectField opFieldOnCalcItem,
       SObjectField opFieldOnLookupObject,
       Rollup__mdt metadata,
-      String lookupRecordKey,
-      SObjectField lookupKeyField,
+      Schema.SObjectField lookupKeyField,
       String customConcatDelimiter
     ) {
-      super(
-        isConcatDistinct(op) ? '' : priorVal,
-        op,
-        opFieldOnCalcItem,
-        opFieldOnLookupObject,
-        metadata.FullRecalculationDefaultStringValue__c,
-        metadata,
-        lookupRecordKey,
-        lookupKeyField
-      );
+      super(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata.FullRecalculationDefaultStringValue__c, metadata, lookupKeyField);
       if (String.isNotBlank(customConcatDelimiter)) {
         this.concatDelimiter = customConcatDelimiter + ' ';
       }
@@ -871,7 +817,7 @@ public without sharing abstract class RollupCalculator {
     }
 
     public virtual override void setDefaultValues(String lookupRecordKey, Object priorVal) {
-      super.setDefaultValues(lookupRecordKey, priorVal);
+      super.setDefaultValues(lookupRecordKey, isConcatDistinct(op) ? '' : priorVal);
       this.stringVal = (String) this.returnVal;
     }
 
@@ -1068,16 +1014,14 @@ public without sharing abstract class RollupCalculator {
       set;
     }
     public PicklistRollupCalculator(
-      Object priorVal,
       Rollup.Op op,
       SObjectfield opFieldOnCalcItem,
       SObjectField opFieldOnLookupObject,
       Rollup__mdt metadata,
-      String lookupRecordKey,
-      SObjectField lookupKeyField,
+      Schema.SObjectField lookupKeyField,
       String customConcatDelimiter
     ) {
-      super(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupRecordKey, lookupKeyField, customConcatDelimiter);
+      super(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField, customConcatDelimiter);
       this.rollupFieldController = new RollupFieldInitializer.PicklistController(opFieldOnLookupObject.getDescribe());
       if (this.rollupFieldController.isMultiSelectPicklist()) {
         this.concatDelimiter = ';';
@@ -1124,15 +1068,13 @@ public without sharing abstract class RollupCalculator {
 
   private without sharing class AverageRollupCalculator extends RollupCalculator {
     public AverageRollupCalculator(
-      Object priorVal,
       Rollup.Op op,
       SObjectField opFieldOnCalcItem,
       SObjectField opFieldOnLookupObject,
       Rollup__mdt metadata,
-      String lookupRecordKey,
       SObjectField lookupKeyField
     ) {
-      super(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, metadata.FullRecalculationDefaultNumberValue__c, metadata, lookupRecordKey, lookupKeyField);
+      super(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata.FullRecalculationDefaultNumberValue__c, metadata, lookupKeyField);
     }
     @SuppressWarnings('PMD.UnusedLocalVariable')
     public override void performRollup(List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
@@ -1169,16 +1111,13 @@ public without sharing abstract class RollupCalculator {
 
   private without sharing class FirstLastRollupCalculator extends RollupCalculator {
     public FirstLastRollupCalculator(
-      Object priorVal,
       Rollup.Op op,
       SObjectField opFieldOnCalcItem,
       SObjectField opFieldOnLookupObject,
       Rollup__mdt metadata,
-      String lookupRecordKey,
       SObjectField lookupKeyField
     ) {
       super(
-        priorVal,
         op,
         opFieldOnCalcItem,
         opFieldOnLookupObject,
@@ -1189,7 +1128,6 @@ public without sharing abstract class RollupCalculator {
           ? (Object) metadata.FullRecalculationDefaultNumberValue__c
           : (Object) metadata.FullRecalculationDefaultStringValue__c),
         metadata,
-        lookupRecordKey,
         lookupKeyField
       );
       Map<String, SObjectField> fieldMap = this.calcItemSObjectType.getDescribe().fields.getMap();
@@ -1237,15 +1175,13 @@ public without sharing abstract class RollupCalculator {
     private final Map<Object, Integer> occurrenceToCount = new Map<Object, Integer>();
     private Integer largestCountPointer;
     public MostRollupCalculator(
-      Object priorVal,
       Rollup.Op op,
       SObjectField opFieldOnCalcItem,
       SObjectField opFieldOnLookupObject,
       Rollup__mdt metadata,
-      String lookupRecordKey,
       SObjectField lookupKeyField
     ) {
-      super(priorVal, op, opFieldOnCalcItem, opFieldOnLookupObject, null, metadata, lookupRecordKey, lookupKeyField);
+      super(op, opFieldOnCalcItem, opFieldOnLookupObject, null, metadata, lookupKeyField);
     }
 
     public override void performRollup(List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -536,6 +536,9 @@ public without sharing abstract class RollupCalculator {
       if (this.returnVal == RollupFieldInitializer.Current.maximumLongValue || this.returnVal == RollupFieldInitializer.Current.minimumLongValue) {
         this.returnVal = 0.00;
       }
+      if (this.returnVal == 0) {
+        this.returnVal = this.metadata.FullRecalculationDefaultNumberValue__c != null ? this.metadata.FullRecalculationDefaultNumberValue__c : null;
+      }
       return this.returnVal;
     }
 
@@ -641,7 +644,7 @@ public without sharing abstract class RollupCalculator {
 
     public virtual override Object getReturnValue() {
       Object superReturnVal = super.getReturnValue();
-      if (superReturnVal instanceof Decimal && superReturnVal != 0) {
+      if (superReturnVal instanceof Decimal) {
         superReturnVal = Datetime.newInstance(((Decimal) superReturnVal).longValue());
       }
       return superReturnVal;
@@ -755,7 +758,7 @@ public without sharing abstract class RollupCalculator {
       this.setReturnValue();
       // we shouldn't encourage negative counts. it's totally possible as a rollup is implemented and updates happen before
       // inserts or deletes, but it doesn't really make sense in the context of tracking
-      Integer potentialReturnVal = ((Decimal) super.getReturnValue()).intValue();
+      Integer potentialReturnVal = ((Decimal) super.getReturnValue())?.intValue();
       return potentialReturnVal < 0 ? 0.00 : potentialReturnVal;
     }
 

--- a/rollup/core/classes/RollupCalculator.cls-meta.xml
+++ b/rollup/core/classes/RollupCalculator.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupComparer.cls-meta.xml
+++ b/rollup/core/classes/RollupComparer.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>54.0</apiVersion>
+	<apiVersion>55.0</apiVersion>
 	<status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupCurrencyInfo.cls-meta.xml
+++ b/rollup/core/classes/RollupCurrencyInfo.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>54.0</apiVersion>
+	<apiVersion>55.0</apiVersion>
 	<status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupDateLiteral.cls-meta.xml
+++ b/rollup/core/classes/RollupDateLiteral.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>54.0</apiVersion>
+	<apiVersion>55.0</apiVersion>
 	<status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupDeferredFullRecalcProcessor.cls-meta.xml
+++ b/rollup/core/classes/RollupDeferredFullRecalcProcessor.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>54.0</apiVersion>
+	<apiVersion>55.0</apiVersion>
 	<status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupEvaluator.cls-meta.xml
+++ b/rollup/core/classes/RollupEvaluator.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>54.0</apiVersion>
+	<apiVersion>55.0</apiVersion>
 	<status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFieldInitializer.cls-meta.xml
+++ b/rollup/core/classes/RollupFieldInitializer.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFinalizer.cls-meta.xml
+++ b/rollup/core/classes/RollupFinalizer.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFlowBulkProcessor.cls-meta.xml
+++ b/rollup/core/classes/RollupFlowBulkProcessor.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFlowBulkSaver.cls-meta.xml
+++ b/rollup/core/classes/RollupFlowBulkSaver.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFlowFullRecalcDispatcher.cls-meta.xml
+++ b/rollup/core/classes/RollupFlowFullRecalcDispatcher.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls-meta.xml
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFullRecalcProcessor.cls-meta.xml
+++ b/rollup/core/classes/RollupFullRecalcProcessor.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger extends Rollup implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.9';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.10';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
   private static Boolean disabledMessageHasBeenLogged = false;

--- a/rollup/core/classes/RollupLogger.cls-meta.xml
+++ b/rollup/core/classes/RollupLogger.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupMetaPicklists.cls-meta.xml
+++ b/rollup/core/classes/RollupMetaPicklists.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>54.0</apiVersion>
+  <apiVersion>55.0</apiVersion>
   <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupParentResetProcessor.cls
+++ b/rollup/core/classes/RollupParentResetProcessor.cls
@@ -68,7 +68,7 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
       return;
     }
     RollupLogger.Instance.log('resetting parent fields for: ' + parentItems.size() + ' items', LoggingLevel.DEBUG);
-    Map<String, Schema.SObjectField> parentFields = calcItems.get(0).getSObjectType().getDescribe().fields.getMap();
+    Map<String, Schema.SObjectField> parentFields = parentItems.get(0).getSObjectType().getDescribe().fields.getMap();
     for (SObject parentItem : parentItems) {
       for (Rollup__mdt rollupMeta : this.rollupInfo) {
         if (this.parentRollupFieldHasBeenReset(rollupMeta, parentItem) == false && parentFields.containsKey(rollupMeta.RollupFieldOnLookupObject__c)) {

--- a/rollup/core/classes/RollupParentResetProcessor.cls
+++ b/rollup/core/classes/RollupParentResetProcessor.cls
@@ -63,19 +63,20 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
     return processId;
   }
 
-  public override void execute(Database.BatchableContext bc, List<SObject> calcItems) {
-    if (calcItems.isEmpty()) {
+  public override void execute(Database.BatchableContext bc, List<SObject> parentItems) {
+    if (parentItems.isEmpty()) {
       return;
     }
-    RollupLogger.Instance.log('resetting parent fields for: ' + calcItems.size() + ' items', LoggingLevel.DEBUG);
-    for (SObject parentItem : calcItems) {
+    RollupLogger.Instance.log('resetting parent fields for: ' + parentItems.size() + ' items', LoggingLevel.DEBUG);
+    Map<String, Schema.SObjectField> parentFields = calcItems.get(0).getSObjectType().getDescribe().fields.getMap();
+    for (SObject parentItem : parentItems) {
       for (Rollup__mdt rollupMeta : this.rollupInfo) {
-        if (this.parentRollupFieldHasBeenReset(rollupMeta, parentItem) == false) {
+        if (this.parentRollupFieldHasBeenReset(rollupMeta, parentItem) == false && parentFields.containsKey(rollupMeta.RollupFieldOnLookupObject__c)) {
           parentItem.put(rollupMeta.RollupFieldOnLookupObject__c, null);
         }
       }
     }
-    this.getDML().doUpdate(calcItems);
+    this.getDML().doUpdate(parentItems);
   }
 
   protected override String getTypeName() {
@@ -106,7 +107,7 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
         .fields.getMap();
       for (Rollup__mdt meta : matchingMeta) {
         SObjectField token = RollupFieldInitializer.Current.getSObjectFieldByName(fieldTokens, meta.RollupFieldOnLookupObject__c);
-        if (token.getDescribe().isFilterable()) {
+        if (token?.getDescribe().isFilterable() == true) {
           isValidRun = isValidRun || true;
           additionalFilters += meta.RollupFieldOnLookupObject__c + (' != null' + orClause);
         }

--- a/rollup/core/classes/RollupParentResetProcessor.cls-meta.xml
+++ b/rollup/core/classes/RollupParentResetProcessor.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupPlugin.cls-meta.xml
+++ b/rollup/core/classes/RollupPlugin.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupQueryBuilder.cls-meta.xml
+++ b/rollup/core/classes/RollupQueryBuilder.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupRecursionItem.cls-meta.xml
+++ b/rollup/core/classes/RollupRecursionItem.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupRelationshipFieldFinder.cls-meta.xml
+++ b/rollup/core/classes/RollupRelationshipFieldFinder.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>54.0</apiVersion>
+  <apiVersion>55.0</apiVersion>
   <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupSObjectUpdater.cls
+++ b/rollup/core/classes/RollupSObjectUpdater.cls
@@ -52,6 +52,7 @@ public without sharing virtual class RollupSObjectUpdater {
       if (this.rollupControl.ShouldDuplicateRulesBeIgnored__c != false) {
         dmlOptions.DuplicateRuleHeader.AllowSave = true;
       }
+      this.winnowRecords(recordsToUpdate);
       this.updateRecords(recordsToUpdate, dmlOptions);
       this.dispatch(recordsToUpdate);
     }
@@ -139,6 +140,15 @@ public without sharing virtual class RollupSObjectUpdater {
   private void performAsyncUpdate(List<SObject> recordsToUpdate) {
     if (Limits.getLimitQueueableJobs() > Limits.getQueueableJobs() && recordsToUpdate.isEmpty() == false) {
       System.enqueueJob(new RollupAsyncSaver(recordsToUpdate, this.rollupControl));
+    }
+  }
+
+  private void winnowRecords(List<SObject> records) {
+    for (Integer index = records.size() - 1; index >= 0; index--) {
+      SObject record = records.get(index);
+      if (record.getPopulatedFieldsAsMap().size() == 1 && record.get('Id') != null) {
+        records.remove(index);
+      }
     }
   }
 

--- a/rollup/core/classes/RollupSObjectUpdater.cls-meta.xml
+++ b/rollup/core/classes/RollupSObjectUpdater.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupSchedulable.cls-meta.xml
+++ b/rollup/core/classes/RollupSchedulable.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>54.0</apiVersion>
+  <apiVersion>55.0</apiVersion>
   <status>Active</status>
 </ApexClass>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -102,6 +102,6 @@
         "apex-rollup@1.5.7-0": "04t6g000008SkNkAAK",
         "apex-rollup@1.5.8-0": "04t6g000008SkRSAA0",
         "apex-rollup@1.5.9-0": "04t6g000008SkVFAA0",
-        "apex-rollup@1.5.10-0": "04t6g000008SkVUAA0"
+        "apex-rollup@1.5.10-0": "04t6g000008SkVeAAK"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -75,25 +75,21 @@
             "default": false,
             "dependencies": [
                 {
-                    "package": "apex-rollup@1.5.9-0"
+                    "package": "apex-rollup@1.5.10-0"
                 }
             ]
         }
     ],
     "namespace": "",
     "sfdcLoginUrl": "https://login.salesforce.com",
-    "sourceApiVersion": "54.0",
+    "sourceApiVersion": "55.0",
     "packageAliases": {
         "Apex Rollup - Custom Logger": "0Ho6g000000Gn8ZCAS",
-        "Apex Rollup - Custom Logger@0.0.10-0": "04t6g000008SijqAAC",
         "Apex Rollup - Custom Logger@0.0.11-0": "04t6g000008SirvAAC",
         "Apex Rollup - Custom Logger@0.0.12-0": "04t6g000008SjqIAAS",
         "Apex Rollup - Extra Code Coverage": "0Ho6g000000GnCWCA0",
-        "Apex Rollup - Extra Code Coverage@0.0.8-0": "04t6g000008SjuzAAC",
-        "Apex Rollup - Extra Code Coverage@0.0.9-0": "04t6g000008Sk13AAC",
-        "Apex Rollup - Extra Code Coverage@0.0.10-0": "04t6g000008Sk7gAAC",
         "Apex Rollup - Extra Code Coverage@0.0.11-0": "04t6g000008SkNaAAK",
-        "Apex Rollup - Extra Code Coverage@0.0.12-0": "04t6g000008SkVAAA0",
+        "Apex Rollup - Extra Code Coverage@0.0.12-0": "04t6g000008SkVZAA0",
         "Apex Rollup - Nebula Logger": "0Ho6g000000Gn8PCAS",
         "Apex Rollup - Nebula Logger@0.0.5-0": "04t6g000008Si1BAAS",
         "Apex Rollup - Nebula Logger@0.0.6-0": "04t6g000008SiisAAC",
@@ -102,15 +98,10 @@
         "Apex Rollup - Rollup Callback@0.0.3-0": "04t6g000008Sis0AAC",
         "Nebula Logger - Unlocked Package@4.5.2-0-plugin-framework-enhancements": "04t5Y0000027FNaQAM",
         "apex-rollup": "0Ho6g000000TNcOCAW",
-        "apex-rollup@1.5.0-0": "04t6g000008Sk8FAAS",
-        "apex-rollup@1.5.1-0": "04t6g000008Sk8KAAS",
-        "apex-rollup@1.5.2-0": "04t6g000008Sk93AAC",
-        "apex-rollup@1.5.3-0": "04t6g000008SkBEAA0",
-        "apex-rollup@1.5.4-0": "04t6g000008SkJdAAK",
-        "apex-rollup@1.5.5-0": "04t6g000008SkKqAAK",
         "apex-rollup@1.5.6-0": "04t6g000008SkMhAAK",
         "apex-rollup@1.5.7-0": "04t6g000008SkNkAAK",
         "apex-rollup@1.5.8-0": "04t6g000008SkRSAA0",
-        "apex-rollup@1.5.9-0": "04t6g000008SkVFAA0"
+        "apex-rollup@1.5.9-0": "04t6g000008SkVFAA0",
+        "apex-rollup@1.5.10-0": "04t6g000008SkVUAA0"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Fixes an issue reported by solo-1234 where parent reset processors could fail during a full recalc when multiple parents were present in a single reset operation",
+            "versionName": "Fixes an issue reported by solo-1234 where parent reset processors could fail during a full recalc when multiple parents were present in a single reset operation. Apex Rollup now omits parent records from being updated unless at least one rollup field has changed.",
             "versionNumber": "1.5.10.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Bugfixes for date literals associated with QUARTER/FISCAL_QUARTER, deferred rollup fixes, added the ability to opt Flow-driven rollups out of running in different flow contexts. Added the ability to write any type of field to text/text area parent fields.",
-            "versionNumber": "1.5.9.0",
+            "versionName": "Fixes an issue reported by solo-1234 where parent reset processors could fail during a full recalc when multiple parents were present in a single reset operation",
+            "versionNumber": "1.5.10.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
# V1.5.10
* Fixed an "issue" where unnecessary updates could be performed on parent records when their rollup values hadn't changed. This was requested by a few people over the past few months, and I finally had the chance to re-architect how rollups were processed in order to implement this. This is an especially nice feature if you have external integrations performing callouts based on some rolling timestamp where newly updated records qualify; previously, this would have caused extra API calls to be consumed for integrations like that due to the parent records _always_ being updated. Now, they'll only be updated if an actual field change on at least one of their rollups has occurred
* Fixes two issues for @solo-1234:
  * Fixes #331 for real this time by ensuring parent reset processors don't fail when multiple parent fields from different SObjects are included in the same reset operation
  * Fixes a problem in `RollupParentResetProcessor` where a full recalc with more than one parent type being updated could throw errors on the full reset part
  ---
## Breaking Changes
  **Special note for people using the [Extra Code Coverage plugin](https://github.com/jamessimone/apex-rollup/tree/main/plugins/ExtraCodeCoverage)** - this version comes with a new version of the package _and_ a breaking change that will force you to uninstall the old Extra Code Coverage plugin you have prior to installing [the new version of the plugin](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkVZAA0). Thank you for your attention and understanding!