### PR TITLE
v1.5.11 - Full Recalc Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkVeAAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkWhAAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkVeAAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkWhAAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupFlowBulkProcessorTests.cls
+++ b/extra-tests/classes/RollupFlowBulkProcessorTests.cls
@@ -324,4 +324,47 @@ private class RollupFlowBulkProcessorTests {
     System.assertEquals(10, acc.AnnualRevenue, 'Account annual revenue should have summed properly');
     System.assertEquals(2, acc.NumberOfEmployees, 'Account number of employees should have counted properly');
   }
+
+  @IsTest
+  static void handlesRollupsStartedFromParent() {
+    Rollup.onlyUseMockMetadata = true;
+    List<Account> accs = [SELECT Id, AnnualRevenue FROM Account];
+    insert new List<SObject>{
+      new Opportunity(Amount = 5, AccountId = accs[0].Id, StageName = 'A', CloseDate = System.today(), Name = 'Amount 1'),
+      new Opportunity(Amount = 5, AccountId = accs[0].Id, StageName = 'A', CloseDate = System.today(), Name = 'Amount 2')
+    };
+
+    RollupFlowBulkProcessor.FlowInput input = new RollupFlowBulkProcessor.FlowInput();
+    input.recordsToRollup = accs;
+    input.rollupContext = 'UPSERT';
+    input.oldRecordsToRollup = new List<SObject>{ null, null };
+    input.deferProcessing = false;
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupOperation__c = 'SUM',
+        CalcItem__c = 'Opportunity',
+        LookupObject__c = 'Account',
+        RollupFieldOnCalcItem__c = 'Amount',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        IsRollupStartedFromParent__c = true,
+        CalcItemWhereClause__c = 'Amount > 0' // validate where clause only runs for children
+      )
+    };
+
+    Exception ex;
+    Test.startTest();
+    try {
+      RollupFlowBulkProcessor.addRollup(new List<RollupFlowBulkProcessor.FlowInput>{ input });
+    } catch (Exception e) {
+      ex = e;
+    }
+    Test.stopTest();
+
+    System.assertEquals(null, ex, 'Exception should not be thrown when calc item info can be inferred from CMDT');
+    Account acc = [SELECT AnnualRevenue, NumberOfEmployees FROM Account];
+    System.assertEquals(10, acc.AnnualRevenue, 'Account annual revenue should have summed properly');
+  }
 }

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -491,7 +491,33 @@ private class RollupFullRecalcTests {
     System.assertEquals(true, flowOutputs[0].isSuccess);
 
     Account updatedAcc = [SELECT Id, AnnualRevenue FROM Account];
-    System.assertEquals(1500, updatedAcc.AnnualRevenue, 'SUM REFRESH from flow should fully recalc');
+    System.assertEquals(1500, updatedAcc.AnnualRevenue, 'SUM REFRESH from flow started from parent should fully recalc');
+  }
+
+  @IsTest
+  static void properlyPerformsFullRecalcsOnUpdateFromParent() {
+    List<Account> accs = [SELECT Id, AnnualRevenue FROM Account];
+
+    insert new List<ContactPointAddress>{
+      new ContactPointAddress(PreferenceRank = 500, ParentId = accs[0].Id, Name = 'One'),
+      new ContactPointAddress(PreferenceRank = 1000, ParentId = accs[0].Id, Name = 'Two')
+    };
+
+    List<Rollup.FlowInput> flowInputs = RollupTestUtils.prepareFlowTest(accs, 'UPDATE', 'COUNT');
+    flowInputs[0].isRollupStartedFromParent = true;
+    flowInputs[0].calcItemTypeWhenRollupStartedFromParent = 'ContactPointAddress';
+    flowInputs[0].oldRecordsToRollup = accs;
+
+    Test.startTest();
+    List<Rollup.FlowOutput> flowOutputs = Rollup.performRollup(flowInputs);
+    Test.stopTest();
+
+    System.assertEquals(1, flowOutputs.size(), 'Flow outputs were not provided');
+    System.assertEquals('SUCCESS', flowOutputs[0].message);
+    System.assertEquals(true, flowOutputs[0].isSuccess);
+
+    Account updatedAcc = [SELECT Id, AnnualRevenue FROM Account];
+    System.assertEquals(2, updatedAcc.AnnualRevenue, 'COUNT UPDATE from flow started from parent should fully recalc');
   }
 
   @IsTest
@@ -1494,6 +1520,8 @@ private class RollupFullRecalcTests {
     acc.AccountNumber = 'someString';
     acc.AnnualRevenue = 5;
     update acc;
+    Account accDoesNotGetReset = new Account(Name = 'Should Not Get Reset Annual Revenue', AnnualRevenue = 4);
+    insert accDoesNotGetReset;
 
     insert new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 0, Name = 'Should not match');
 
@@ -1520,10 +1548,12 @@ private class RollupFullRecalcTests {
     };
 
     Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_SINGULAR_PARENT_RECALC_LWC.name());
-    acc = [SELECT AccountNumber, AnnualRevenue FROM Account];
+    acc = [SELECT AccountNumber, AnnualRevenue FROM Account WHERE Id = :acc.Id];
     System.assertEquals(null, acc.AnnualRevenue, 'AnnualRevenue should have been reset');
     // seems like some standard fields default to null when you save an empty string to them, even if they have no default value 🙄
     System.assertEquals(null, acc.AccountNumber, 'AccountNumber should have been reset');
+    accDoesNotGetReset = [SELECT AnnualRevenue FROM Account WHERE Id = :accDoesNotGetReset.Id];
+    System.assertNotEquals(null, accDoesNotGetReset.AnnualRevenue);
   }
 
   @IsTest

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -495,6 +495,51 @@ private class RollupFullRecalcTests {
   }
 
   @IsTest
+  static void clearsParentValuesWhenNoRefreshMatches() {
+    List<Account> accs = [SELECT Id, AnnualRevenue FROM Account];
+    accs[0].AnnualRevenue = 1500;
+    update accs;
+
+    List<Rollup.FlowInput> flowInputs = RollupTestUtils.prepareFlowTest(accs, 'REFRESH', 'SUM');
+    flowInputs[0].isRollupStartedFromParent = true;
+    flowInputs[0].calcItemTypeWhenRollupStartedFromParent = 'ContactPointAddress';
+
+    Test.startTest();
+    List<Rollup.FlowOutput> flowOutputs = Rollup.performRollup(flowInputs);
+    Test.stopTest();
+
+    System.assertEquals(1, flowOutputs.size(), 'Flow outputs were not provided');
+    System.assertEquals('SUCCESS', flowOutputs[0].message);
+    System.assertEquals(true, flowOutputs[0].isSuccess);
+
+    Account updatedAcc = [SELECT Id, AnnualRevenue FROM Account];
+    System.assertEquals(null, updatedAcc.AnnualRevenue, 'SUM REFRESH from flow started from parent should fully clear');
+  }
+
+  @IsTest
+  static void clearsParentValuesWhenNoUpdateMatches() {
+    List<Account> accs = [SELECT Id, AnnualRevenue FROM Account];
+    accs[0].AnnualRevenue = 1500;
+    update accs;
+
+    List<Rollup.FlowInput> flowInputs = RollupTestUtils.prepareFlowTest(accs, 'UPSERT', 'SUM');
+    flowInputs[0].isRollupStartedFromParent = true;
+    flowInputs[0].calcItemTypeWhenRollupStartedFromParent = 'ContactPointAddress';
+    flowInputs[0].oldRecordsToRollup = new List<SObject>{ null };
+
+    Test.startTest();
+    List<Rollup.FlowOutput> flowOutputs = Rollup.performRollup(flowInputs);
+    Test.stopTest();
+
+    System.assertEquals(1, flowOutputs.size(), 'Flow outputs were not provided');
+    System.assertEquals('SUCCESS', flowOutputs[0].message);
+    System.assertEquals(true, flowOutputs[0].isSuccess);
+
+    Account updatedAcc = [SELECT Id, AnnualRevenue FROM Account];
+    System.assertEquals(null, updatedAcc.AnnualRevenue, 'SUM REFRESH from flow started from parent should fully clear');
+  }
+
+  @IsTest
   static void properlyPerformsFullRecalcsOnUpdateFromParent() {
     List<Account> accs = [SELECT Id, AnnualRevenue FROM Account];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -181,6 +181,7 @@ global without sharing virtual class Rollup {
     public final Set<String> recordIds = new Set<String>();
     public final Set<String> queryFields = new Set<String>();
     public final List<Rollup__mdt> metadata = new List<Rollup__mdt>();
+    public final List<SObject> parentRecordsToReset = new List<SObject>();
     public String whereClause = '';
     public Integer recordCount = RollupQueryBuilder.SENTINEL_COUNT_VALUE;
   }
@@ -1864,15 +1865,7 @@ global without sharing virtual class Rollup {
         // meta.IsRollupStartedFromParent__c, so that check can't come first
         queryWrapper = getFullRecalcQueryWrapper(meta, calcItems, oldCalcItems);
       } else if (meta.IsRollupStartedFromParent__c) {
-        queryWrapper = getParentWhereClause(
-          calcItems,
-          oldCalcItems,
-          meta.LookupFieldOnLookupObject__c,
-          meta.LookupObject__c,
-          meta.LookupFieldOnCalcItem__c,
-          meta.GrandparentRelationshipFieldPath__c,
-          meta.CalcItemWhereClause__c
-        );
+        queryWrapper = getParentQueryWrapper(calcItems, oldCalcItems, meta);
       } else if (isIntermediateRollupForGrandparent) {
         queryWrapper = getIntermediateGrandparentQueryWrapper(meta, calcItems, oldCalcItems);
       }
@@ -1936,15 +1929,7 @@ global without sharing virtual class Rollup {
         fillWrapper(wrapper, meta.LookupFieldOnCalcItem__c, calcItem, oldCalcItems);
       }
     } else {
-      wrapper = getParentWhereClause(
-        calcItems,
-        oldCalcItems,
-        meta.LookupFieldOnLookupObject__c,
-        meta.LookupObject__c,
-        meta.LookupFieldOnCalcItem__c,
-        meta.GrandparentRelationshipFieldPath__c,
-        meta.CalcItemWhereClause__c
-      );
+      wrapper = getParentQueryWrapper(calcItems, oldCalcItems, meta);
     }
 
     return wrapper;
@@ -2119,14 +2104,7 @@ global without sharing virtual class Rollup {
         wrappedMeta.recordCount = RollupQueryBuilder.SENTINEL_COUNT_VALUE;
       }
       String queryString = RollupQueryBuilder.Current.getQuery(calcType, new List<String>(wrappedMeta.queryFields), 'Id', '!=', wrappedMeta.whereClause);
-      RollupFullRecalcProcessor fullRecalc = buildFullRecalcRollup(
-        wrappedMeta.metadata,
-        wrappedMeta.recordCount,
-        queryString,
-        wrappedMeta.recordIds,
-        calcType,
-        localInvokePoint
-      );
+      RollupFullRecalcProcessor fullRecalc = buildFullRecalcRollup(wrappedMeta, queryString, calcType, localInvokePoint);
       setControlToSyncForSingularParentRecalcs(fullRecalc.rollupControl, localInvokePoint);
       if (fullRecalc.isNoOp) {
         fullRecalc.isNoOp = wrappedMeta.recordCount == 0;
@@ -2152,46 +2130,64 @@ global without sharing virtual class Rollup {
       String additionalClause = (String.isNotBlank(wrappedMeta.whereClause) ? ' AND ' : '') + fullRecalcMeta.meta.LookupFieldOnCalcItem__c + ' = :recordIds';
       wrappedMeta.whereClause += additionalClause;
     }
+    wrappedMeta.parentRecordsToReset.addAll(fullRecalcMeta.wrapper.parentRecordsToReset);
   }
 
   private static RollupFullRecalcProcessor buildFullRecalcRollup(
-    List<Rollup__mdt> matchingMeta,
-    Integer amountOfCalcItems,
+    RollupMetadata wrappedMeta,
     String queryString,
-    Set<String> recordIds,
     SObjectType calcItemType,
     InvocationPoint invokePoint
   ) {
-    for (Rollup__mdt meta : matchingMeta) {
+    for (Rollup__mdt meta : wrappedMeta.metadata) {
       meta.IsFullRecordSet__c = true;
       meta.RollupOperation__c = getBaseOperationName(meta.RollupOperation__c);
     }
-    RollupFullRecalcProcessor parentResetProcessor;
-    SObjectType parentType = RollupFieldInitializer.Current.getSObjectFromName(matchingMeta[0].LookupObject__c).getSObjectType();
+    SObjectType parentType = RollupFieldInitializer.Current.getSObjectFromName(wrappedMeta.metadata[0].LookupObject__c).getSObjectType();
     String equality = invokePoint == InvocationPoint.FROM_SINGULAR_PARENT_RECALC_LWC ? '=' : '!=';
     String parentQuery = RollupQueryBuilder.Current.getQuery(parentType, new List<String>{ 'Id' }, 'Id', equality);
-    parentResetProcessor = new RollupParentResetProcessor(matchingMeta, parentType, parentQuery, recordIds, invokePoint);
+    RollupFullRecalcProcessor parentResetProcessor = new RollupParentResetProcessor(
+      wrappedMeta.metadata,
+      parentType,
+      parentQuery,
+      wrappedMeta.recordIds,
+      invokePoint
+    );
     Boolean shouldQueue =
-      amountOfCalcItems != RollupQueryBuilder.SENTINEL_COUNT_VALUE &&
-      amountOfCalcItems < parentResetProcessor.rollupControl.MaxLookupRowsBeforeBatching__c;
-    if (amountOfCalcItems == 0 && matchingMeta.isEmpty() == false && isFullRecalcApp) {
+      wrappedMeta.recordCount != RollupQueryBuilder.SENTINEL_COUNT_VALUE &&
+      wrappedMeta.recordCount < parentResetProcessor.rollupControl.MaxLookupRowsBeforeBatching__c;
+    if (wrappedMeta.recordCount == 0 && wrappedMeta.metadata.isEmpty() == false && isFullRecalcApp) {
       return parentResetProcessor;
-    } else if (invokePoint != InvocationPoint.FROM_FULL_RECALC_LWC) {
+    } else if (invokePoint != InvocationPoint.FROM_FULL_RECALC_LWC && invokePoint != InvocationPoint.FROM_FULL_RECALC_FLOW) {
       parentResetProcessor = null;
     }
 
+    RollupFullRecalcProcessor fullRecalc;
     if (shouldQueue) {
-      return new RollupDeferredFullRecalcProcessor(matchingMeta, calcItemType, queryString, recordIds, invokePoint, parentResetProcessor);
-    } else {
-      return new RollupFullBatchRecalculator(
-        (queryString + getFullRecalcQueryString(matchingMeta)),
-        invokePoint,
-        matchingMeta,
+      fullRecalc = new RollupDeferredFullRecalcProcessor(
+        wrappedMeta.metadata,
         calcItemType,
-        recordIds,
+        queryString,
+        wrappedMeta.recordIds,
+        invokePoint,
+        parentResetProcessor
+      );
+    } else {
+      fullRecalc = new RollupFullBatchRecalculator(
+        (queryString + getFullRecalcQueryString(wrappedMeta.metadata)),
+        invokePoint,
+        wrappedMeta.metadata,
+        calcItemType,
+        wrappedMeta.recordIds,
         parentResetProcessor
       );
     }
+
+    if (wrappedMeta.parentRecordsToReset.isEmpty() == false) {
+      fullRecalc.storeParentFieldsToClear(wrappedMeta.parentRecordsToReset);
+      fullRecalc.isNoOp = false;
+    }
+    return fullRecalc;
   }
 
   private static List<SObject> replaceFlowInputCalcItemsIfNecessary(
@@ -2343,10 +2339,13 @@ global without sharing virtual class Rollup {
   private class QueryWrapper {
     private Boolean hasQuery = false;
     private String query;
-    public final Set<String> recordIds = new Set<String>();
-    private final List<String> stringifiedRecordIds = new List<String>();
+    private final List<SObject> parentRecordsToReset = new List<SObject>();
+    private final Set<String> recordIds = new Set<String>();
+    private final Set<String> stringifiedRecordIds = new Set<String>();
+
     private QueryWrapper() {
     }
+
     private QueryWrapper(String lookupObject, String lookupField) {
       String base = String.isBlank(lookupObject) ? '' : lookupObject.replace('__c', '__r') + '.';
       this.query = base + lookupField + ' = :recordIds';
@@ -2355,10 +2354,8 @@ global without sharing virtual class Rollup {
     public void addRecordId(String recordId) {
       if (String.isNotBlank(recordId)) {
         this.hasQuery = true;
-        if (this.recordIds.contains(recordId) == false) {
-          this.recordIds.add(recordId);
-          this.stringifiedRecordIds.add('\'' + recordId + '\'');
-        }
+        this.recordIds.add(recordId);
+        this.stringifiedRecordIds.add('\'' + recordId + '\'');
       }
     }
 
@@ -2374,34 +2371,28 @@ global without sharing virtual class Rollup {
     }
 
     public override String toString() {
-      return this.hasQuery ? this.query.replace('= :recordIds', 'IN (' + String.join(this.stringifiedRecordIds, ',') + ')') : '';
+      return this.hasQuery ? this.query.replace('= :recordIds', 'IN (' + String.join(new List<String>(this.stringifiedRecordIds), ',') + ')') : '';
     }
   }
 
-  private static QueryWrapper getParentWhereClause(
-    List<SObject> calcItems,
-    Map<Id, SObject> oldCalcItems,
-    String lookupFieldOnLookupObject,
-    String lookupObjectName,
-    String lookupFieldOnCalcItem,
-    String grandparentFieldPath,
-    String potentialWhereClause
-  ) {
-    String fieldName = lookupFieldOnLookupObject;
-    if (String.isNotBlank(grandparentFieldPath)) {
+  private static QueryWrapper getParentQueryWrapper(List<SObject> calcItems, Map<Id, SObject> oldCalcItems, Rollup__mdt meta) {
+    String fieldName = meta.LookupFieldOnLookupObject__c;
+    String lookupObjectName = meta.LookupObject__c;
+    if (String.isNotBlank(meta.GrandparentRelationshipFieldPath__c)) {
       lookupObjectName = '';
-      fieldName = grandparentFieldPath.substringBeforeLast('.') + '.Id';
-    } else if (lookupFieldOnCalcItem.endsWith('Id') || lookupFieldOnCalcItem.endsWith('__c')) {
+      fieldName = meta.GrandparentRelationshipFieldPath__c.substringBeforeLast('.') + '.Id';
+    } else if (meta.LookupFieldOnCalcItem__c.endsWith('Id') || meta.LookupFieldOnCalcItem__c.endsWith('__c')) {
       lookupObjectName = '';
-      fieldName = lookupFieldOnCalcItem;
+      fieldName = meta.LookupFieldOnCalcItem__c;
     }
 
     QueryWrapper wrapper = new QueryWrapper(lookupObjectName, fieldName);
+    wrapper.parentRecordsToReset.addAll(calcItems);
     for (SObject calcItem : calcItems) {
-      fillWrapper(wrapper, lookupFieldOnLookupObject, calcItem, oldCalcItems);
+      fillWrapper(wrapper, meta.LookupFieldOnLookupObject__c, calcItem, oldCalcItems);
     }
-    if (String.isNotBlank(potentialWhereClause)) {
-      String whereClause = '(' + potentialWhereClause + ') AND ';
+    if (String.isNotBlank(meta.CalcItemWhereClause__c)) {
+      String whereClause = '(' + meta.CalcItemWhereClause__c + ') AND ';
       wrapper.setQuery(whereClause + wrapper.getQuery());
     }
     return wrapper;

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -410,20 +410,22 @@ global without sharing virtual class Rollup {
 
   @AuraEnabled
   global static String performSerializedBulkFullRecalc(String serializedMetadata, String invokePointName) {
-    isFullRecalcApp = true;
+    InvocationPoint localInvokePoint = InvocationPoint.valueOf(invokePointName);
+    switch on localInvokePoint {
+      when FROM_FULL_RECALC_LWC, FROM_SINGULAR_PARENT_RECALC_LWC, FROM_FULL_RECALC_FLOW {
+        isFullRecalcApp = true;
+      }
+    }
     List<Rollup__mdt> matchingMetadata = (List<Rollup__mdt>) JSON.deserialize(serializedMetadata, List<Rollup__mdt>.class);
     RollupLogger.Instance.log('bulk full recalc called with data:', matchingMetadata, LoggingLevel.DEBUG);
-    InvocationPoint localInvokePoint = InvocationPoint.valueOf(invokePointName);
 
-    Integer amountOfCalcItems = 0;
-    Set<String> objIds = new Set<String>(); // will always be present as a bind var, below
-    Set<String> recordIds = new Set<String>(); // always empty, here, but necessary for the "getCountFromDb" call
-    Map<SObjectType, RollupMetadata> childToMetaWrapper = new Map<SObjectType, RollupMetadata>();
     String potentialWhereClause = '';
     String delimiter = ' ||| ';
     String lookupFieldName;
     Integer delimiterIndex = -1;
+    String possibleParentId;
 
+    Map<SObjectType, RollupMetadata> childToMetaWrapper = new Map<SObjectType, RollupMetadata>();
     for (Rollup__mdt matchingMeta : matchingMetadata) {
       FlowInput validationRuleWrapper = new FlowInput();
       validationRuleWrapper.rollupOperation = matchingMeta.RollupOperation__c.toUpperCase();
@@ -435,6 +437,7 @@ global without sharing virtual class Rollup {
       if (localInvokePoint == InvocationPoint.FROM_SINGULAR_PARENT_RECALC_LWC && String.isBlank(potentialWhereClause)) {
         delimiterIndex = matchingMeta.CalcItemWhereClause__c.indexOf(delimiter);
         potentialWhereClause = matchingMeta.CalcItemWhereClause__c.substring(delimiterIndex + delimiter.length(), matchingMeta.CalcItemWhereClause__c.length());
+        possibleParentId = potentialWhereClause.substringAfter(' = ').remove('\'');
         lookupFieldName = matchingMeta.LookupFieldOnCalcItem__c;
       } else if (String.isNotBlank(potentialWhereClause)) {
         potentialWhereClause = potentialWhereClause.replace(lookupFieldName, matchingMeta.LookupFieldOnCalcItem__c);
@@ -449,38 +452,7 @@ global without sharing virtual class Rollup {
         }
       }
 
-      SObjectType childType = RollupFieldInitializer.Current.getSObjectFromName(matchingMeta.CalcItem__c).getSObjectType();
-      RollupEvaluator.WhereFieldEvaluator eval = String.isBlank(matchingMeta.CalcItemWhereClause__c)
-        ? null
-        : RollupEvaluator.getWhereEval(matchingMeta.CalcItemWhereClause__c, childType);
-      Set<String> whereFields = getQueryFieldsFromMetadata(matchingMeta, eval);
-      RollupMetadata metaWrapper;
-      if (childToMetaWrapper.containsKey(childType)) {
-        metaWrapper = childToMetaWrapper.get(childType);
-      } else {
-        metaWrapper = new RollupMetadata();
-        metaWrapper.whereClause = matchingMeta.CalcItemWhereClause__c;
-        childToMetaWrapper.put(childType, metaWrapper);
-      }
-      metaWrapper.queryFields.addAll(wherefields);
-      metaWrapper.metadata.add(matchingMeta);
-
-      if (amountOfCalcItems != RollupQueryBuilder.SENTINEL_COUNT_VALUE) {
-        String countQuery = RollupQueryBuilder.Current.getQuery(
-          childType,
-          new List<String>{ 'Count()' },
-          matchingMeta.LookupFieldOnLookupObject__c,
-          '!=',
-          matchingMeta.CalcItemWhereClause__c
-        );
-        Integer currentCount = getCountFromDb(countQuery, objIds, recordIds);
-        if (currentCount == RollupQueryBuilder.SENTINEL_COUNT_VALUE) {
-          amountOfCalcItems = currentCount;
-        } else {
-          metaWrapper.recordCount = currentCount;
-          amountOfCalcItems += currentCount;
-        }
-      }
+      populateFullRecalcMetasByType(childToMetaWrapper, matchingMeta, possibleParentId);
     }
 
     List<Rollup> processors = transformWrappedMetadataToFullRecalcRollups(childToMetaWrapper, localInvokePoint);
@@ -691,10 +663,10 @@ global without sharing virtual class Rollup {
     Map<SObjectType, RollupMetadata> typeToWrappedMeta = new Map<SObjectType, RollupMetadata>();
     for (Rollup__mdt key : metaToInputWrapper.keySet()) {
       FlowInputWrapper wrapper = metaToInputWrapper.get(key);
-      // here we clone the list because it can get winnowed in "processCustomMetadata"
       if (wrapper == null) {
         continue;
       }
+      // here we clone the list because it can get winnowed in "processCustomMetadata"
       List<Rollup__mdt> metas = new List<Rollup__mdt>(wrapper.rollupMetadata);
       wrapper.flowInput.recordsToRollup = replaceFlowInputCalcItemsIfNecessary(hashCodeToCalcItems, wrapper.flowInput.recordsToRollup, metas);
       wrapper.flowInput.oldRecordsToRollup = replaceFlowInputCalcItemsIfNecessary(hashCodeToCalcItems, wrapper.flowInput.oldRecordsToRollup, metas);
@@ -1978,6 +1950,46 @@ global without sharing virtual class Rollup {
     return wrapper;
   }
 
+  private static void populateFullRecalcMetasByType(Map<SObjectType, RollupMetadata> childToMetaWrapper, Rollup__mdt matchingMeta, String possibleParentId) {
+    SObjectType childType = RollupFieldInitializer.Current.getSObjectFromName(matchingMeta.CalcItem__c).getSObjectType();
+    RollupEvaluator.WhereFieldEvaluator eval = String.isBlank(matchingMeta.CalcItemWhereClause__c)
+      ? null
+      : RollupEvaluator.getWhereEval(matchingMeta.CalcItemWhereClause__c, childType);
+    Set<String> whereFields = getQueryFieldsFromMetadata(matchingMeta, eval);
+    RollupMetadata metaWrapper;
+    if (childToMetaWrapper.containsKey(childType)) {
+      metaWrapper = childToMetaWrapper.get(childType);
+    } else {
+      metaWrapper = new RollupMetadata();
+      metaWrapper.whereClause = matchingMeta.CalcItemWhereClause__c;
+      childToMetaWrapper.put(childType, metaWrapper);
+    }
+    if (possibleParentId != null) {
+      metaWrapper.recordIds.add(possibleParentId);
+    }
+    metaWrapper.queryFields.addAll(wherefields);
+    metaWrapper.metadata.add(matchingMeta);
+
+    Integer amountOfCalcItems = 0;
+    if (amountOfCalcItems != RollupQueryBuilder.SENTINEL_COUNT_VALUE) {
+      String countQuery = RollupQueryBuilder.Current.getQuery(
+        childType,
+        new List<String>{ 'Count()' },
+        matchingMeta.LookupFieldOnLookupObject__c,
+        '!=',
+        matchingMeta.CalcItemWhereClause__c
+      );
+      Set<String> emptyCollection = new Set<String>();
+      Integer currentCount = getCountFromDb(countQuery, emptyCollection, emptyCollection);
+      if (currentCount == RollupQueryBuilder.SENTINEL_COUNT_VALUE) {
+        amountOfCalcItems = currentCount;
+      } else {
+        metaWrapper.recordCount = currentCount;
+        amountOfCalcItems += currentCount;
+      }
+    }
+  }
+
   private class DeleteReparentOperation {
     public List<SObject> reparentedRecords;
     public final List<Rollup__mdt> rollupMetas = new List<Rollup__mdt>();
@@ -1989,7 +2001,7 @@ global without sharing virtual class Rollup {
     Map<Id, SObject> oldCalcItems,
     Map<String, DeleteReparentOperation> deleteKeyToOps
   ) {
-    if (oldCalcItems?.isEmpty() != false || calcItems?.isEmpty() != false) {
+    if (oldCalcItems?.isEmpty() != false || calcItems?.isEmpty() != false || meta.IsRollupStartedFromParent__c) {
       return;
     }
     List<SObject> typedCalcItems = calcItems.clone();
@@ -2152,10 +2164,12 @@ global without sharing virtual class Rollup {
   ) {
     for (Rollup__mdt meta : matchingMeta) {
       meta.IsFullRecordSet__c = true;
+      meta.RollupOperation__c = getBaseOperationName(meta.RollupOperation__c);
     }
     RollupFullRecalcProcessor parentResetProcessor;
     SObjectType parentType = RollupFieldInitializer.Current.getSObjectFromName(matchingMeta[0].LookupObject__c).getSObjectType();
-    String parentQuery = RollupQueryBuilder.Current.getQuery(parentType, new List<String>{ 'Id' }, 'Id', '!=');
+    String equality = invokePoint == InvocationPoint.FROM_SINGULAR_PARENT_RECALC_LWC ? '=' : '!=';
+    String parentQuery = RollupQueryBuilder.Current.getQuery(parentType, new List<String>{ 'Id' }, 'Id', equality);
     parentResetProcessor = new RollupParentResetProcessor(matchingMeta, parentType, parentQuery, recordIds, invokePoint);
     Boolean shouldQueue =
       amountOfCalcItems != RollupQueryBuilder.SENTINEL_COUNT_VALUE &&

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -216,8 +216,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       if (lookupItems.getSObjectType() != roll.lookupObj) {
         this.rollups.remove(index);
         this.deferredRollups.add(roll);
-      } else {
-        this.flagFullRecalcRollups(roll);
       }
     }
 
@@ -376,6 +374,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
           localLookupItems.remove(index);
         }
       }
+      this.fullRecalcProcessor?.processParentFieldsToReset(localLookupItems);
       return localLookupItems;
     }
 
@@ -415,6 +414,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
   protected virtual List<SObject> getExistingLookupItems(Set<String> objIds, RollupAsyncProcessor rollup, Set<String> uniqueQueryFieldNames) {
     // for Rollups that are Batchable, the lookup items are retrieved en masse in the "start" method and cached in the "execute method"
+    this.fullRecalcProcessor?.processParentFieldsToReset(this.lookupItems);
     return this.lookupItems;
   }
 
@@ -660,13 +660,12 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     for (String lookupId : calcItemsByLookupField.keySet()) {
       if (updatedLookupRecords.containsKey(lookupId)) {
         lookupItemKeys.remove(lookupId);
-        // this way, the updated values are persisted for each field, and the default values are initialized
+        // this way, the updated values are persisted for each field
         SObject updatedLookupObject = updatedLookupRecords.get(lookupId);
         localLookupItems.add(updatedLookupObject);
       }
     }
     localLookupItems.addAll(roll.getExistingLookupItems(lookupItemKeys, roll, this.lookupObjectToUniqueFieldNames.get(roll.lookupObj)));
-    this.flagFullRecalcRollups(roll);
     return localLookupItems;
   }
 
@@ -852,17 +851,11 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     return lookupFieldToCalcItems;
   }
 
-  private void flagFullRecalcRollups(RollupAsyncProcessor rollup) {
-    if (this.isValidAdditionalCalcItemRetrieval(rollup) && rollup.isFullRecalc == false) {
-      rollup.isFullRecalc = true;
-    }
-  }
-
   private void ingestRollupControlData(List<RollupAsyncProcessor> syncRollups) {
     Boolean isRunningAsnyc = this.getIsRunningAsync();
     for (Integer index = this.rollups.size() - 1; index >= 0; index--) {
       RollupAsyncProcessor rollup = this.rollups[index];
-      rollup.isFullRecalc = rollup.isFullRecalc || this.isFullRecalc;
+      this.flagFullRecalcRollups(rollup);
 
       Boolean shouldRunSyncDeferred = this.getShouldRunSyncDeferred(rollup);
       Boolean couldRunSync =
@@ -882,6 +875,14 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       }
 
       this.overrideParentRollupControlValues(rollup.rollupControl);
+    }
+  }
+
+  private void flagFullRecalcRollups(RollupAsyncProcessor rollup) {
+    if (this.isValidAdditionalCalcItemRetrieval(rollup) && rollup.isFullRecalc == false) {
+      rollup.isFullRecalc = true;
+    } else {
+      rollup.isFullRecalc = rollup.isFullRecalc || this.isFullRecalc;
     }
   }
 

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -444,7 +444,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     if (this.isValidAdditionalCalcItemRetrieval(rollup) == false) {
       return;
     }
-    rollup.isFullRecalc = true;
 
     String key = rollup.calcItemType.getDescribe().getName() + String.valueOf(rollup.lookupFieldOnCalcItem);
     Boolean hasPreviouslyCachedItems = localCachedFullRecalcs.containsKey(key);
@@ -857,14 +856,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     if (this.isValidAdditionalCalcItemRetrieval(rollup) && rollup.isFullRecalc == false) {
       rollup.isFullRecalc = true;
     }
-  }
-
-  private Boolean isValidFullRecalcReset(RollupAsyncProcessor rollup, SObject lookupItem) {
-    Boolean isValid = false;
-    if (rollup.isFullRecalc) {
-      isValid = this.parentRollupFieldHasBeenReset(rollup, lookupItem) == false;
-    }
-    return isValid;
   }
 
   private void ingestRollupControlData(List<RollupAsyncProcessor> syncRollups) {

--- a/rollup/core/classes/RollupCalcItemReplacer.cls
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls
@@ -64,6 +64,9 @@ public without sharing class RollupCalcItemReplacer {
     Set<String> baseQueryFieldSet = this.baseQueryFields.containsKey(calcType) ? this.baseQueryFields.get(calcType) : new Set<String>();
     for (Rollup__mdt meta : metadata) {
       Boolean isPresentInMapAlready = this.metaToEval.containsKey(meta);
+      if (meta.IsRollupStartedFromParent__c && meta.LookupObject__c == calcType.getDescribe().getName()) {
+        return false;
+      }
       Boolean mightNeedReplacement = String.isNotBlank(meta.CalcItemWhereClause__c) || meta.RollupOrderBys__r.isEmpty() == false;
       if (mightNeedReplacement && isPresentInMapAlready == false) {
         localNeedsReplacement = true;

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -577,7 +577,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
             val = TRUE_VAL;
           } else if (val.equalsIgnoreCase(FALSE_VAL)) {
             val = FALSE_VAL;
-          } else if (val == 'null') {
+          } else if (val.equalsIgnoreCase('null')) {
             val = null;
           }
           this.values.add(val?.trim()?.replace('%', ''));

--- a/rollup/core/classes/RollupFlowBulkProcessor.cls
+++ b/rollup/core/classes/RollupFlowBulkProcessor.cls
@@ -78,14 +78,16 @@ global without sharing class RollupFlowBulkProcessor {
         String sObjectName = flowInput.recordsToRollup == null ? '' : flowInput.recordsToRollup[0].getSObjectType().getDescribe().getName();
         List<Rollup.FlowInput> rollupFlowInputs = new List<Rollup.FlowInput>();
         for (Rollup__mdt meta : rollupMetadata) {
-          if (
-            flowInput.recordsToRollup == null ||
-            meta.CalcItem__c == sObjectName ||
-            String.isNotBlank(flowInput.calcItemTypeWhenRollupStartedFromParent) && flowInput.calcItemTypeWhenRollupStartedFromParent == meta.CalcItem__c
-          ) {
+          if (meta.IsRollupStartedFromParent__c) {
+            flowInput.calcItemTypeWhenRollupStartedFromParent = flowInput.calcItemTypeWhenRollupStartedFromParent != null
+              ? flowInput.calcItemTypeWhenRollupStartedFromParent
+              : meta.CalcItem__c;
+          }
+          if (flowInput.recordsToRollup == null || meta.CalcItem__c == sObjectName || flowInput.calcItemTypeWhenRollupStartedFromParent == meta.CalcItem__c) {
             Rollup.FlowInput input = new Rollup.FlowInput();
             // pertinent fields from CMDT (can be overridden by optional flow properties)
             input.calcItemChangedFields = flowInput.calcItemChangedFields != null ? flowInput.calcItemChangedFields : meta.ChangedFieldsOnCalcItem__c;
+            input.calcItemTypeWhenRollupStartedFromParent = flowInput.calcItemTypeWhenRollupStartedFromParent;
             input.calcItemWhereClause = flowInput.calcItemWhereClause != null ? flowInput.calcItemWhereClause : meta.CalcItemWhereClause__c;
             input.concatDelimiter = flowInput.concatDelimiter != null ? flowInput.concatDelimiter : meta.ConcatDelimiter__c;
             input.fullRecalculationDefaultNumberValue = flowInput.fullRecalculationDefaultNumberValue != null
@@ -122,7 +124,6 @@ global without sharing class RollupFlowBulkProcessor {
             input.rollupSObjectName = meta.LookupObject__c;
             input.rollupControlId = meta.RollupControl__c;
             // everything else is supplied from the invocable
-            input.calcItemTypeWhenRollupStartedFromParent = flowInput.calcItemTypeWhenRollupStartedFromParent;
             input.deferProcessing = flowInput.deferProcessing != null ? flowInput.deferProcessing : true;
             input.oldRecordsToRollup = flowInput.oldRecordsToRollup;
             input.recordsToRollup = flowInput.recordsToRollup;

--- a/rollup/core/classes/RollupFullRecalcProcessor.cls
+++ b/rollup/core/classes/RollupFullRecalcProcessor.cls
@@ -7,6 +7,9 @@ public abstract without sharing class RollupFullRecalcProcessor extends RollupAs
   protected final Set<String> objIds = new Set<String>(); // necessary; there's a bind variable in the query string
 
   private final RollupFullRecalcProcessor postProcessor;
+  private final Map<Id, SObject> parentRecordsToClear = new Map<Id, SObject>();
+
+  private Boolean hasProcessedParentRecords = false;
 
   private static final Map<String, List<SObject>> QUERY_TO_CALC_ITEMS {
     get {
@@ -56,14 +59,63 @@ public abstract without sharing class RollupFullRecalcProcessor extends RollupAs
     return this;
   }
 
+  public void finish() {
+    if (this.postProcessor != null) {
+      RollupLogger.Instance.log('Starting post-full recalc processor', this.postProcessor, LoggingLevel.DEBUG);
+      // chain jobs together so that if recalc job is being tracked within the Recalc Rollups app,
+      // job continuity is established between the full recalc and then any downstream job that runs
+      // (as the postProcessor)
+      this.setCurrentJobId(this.postProcessor.runCalc());
+    }
+    if (this.hasProcessedParentRecords == false) {
+      List<SObject> parentRecords = new List<SObject>();
+      this.processParentFieldsToReset(parentRecords);
+      this.getDML().doUpdate(parentRecords);
+    }
+  }
+
+  public override void storeParentResetField(RollupAsyncProcessor processor, SObject parent) {
+    super.storeParentResetField(processor, parent);
+    this.postProcessor?.recordIds.add(parent.Id);
+    this.postProcessor?.storeParentResetField(processor, parent);
+  }
+
+  public void storeParentFieldsToClear(List<SObject> parentRecordsToClear) {
+    this.parentRecordsToClear.putAll(parentRecordsToClear);
+  }
+
+  public void processParentFieldsToReset(List<SObject> relatedParentRecords) {
+    if (this.hasProcessedParentRecords) {
+      return;
+    }
+    this.hasProcessedParentRecords = true;
+    Map<Id, SObject> relatedParentRecordsMap = new Map<Id, SObject>(relatedParentRecords);
+    for (SObject parentRecordToReset : this.parentRecordsToClear.values()) {
+      SObject relatedParentRecord = relatedParentRecordsMap.containsKey(parentRecordToReset.Id)
+        ? relatedParentRecordsMap.get(parentRecordToReset.Id)
+        : parentRecordToReset;
+
+      for (Rollup__mdt meta : this.rollupInfo) {
+        if (relatedParentRecord.getSobjectType().getDescribe().getName() == meta.LookupObject__c) {
+          relatedParentRecord.put(meta.RollupFieldOnLookupObject__c, null);
+        }
+      }
+
+      relatedParentRecordsMap.put(relatedParentRecord.Id, relatedParentRecord);
+    }
+    relatedParentRecords.clear();
+    relatedParentRecords.addAll(relatedParentRecordsMap.values());
+    this.parentRecordsToClear.clear();
+  }
+
   protected List<SObject> getCalcItemsByQuery() {
     if (QUERY_TO_CALC_ITEMS.containsKey(this.queryString)) {
       RollupLogger.Instance.log('returning pre-queried records from cache', LoggingLevel.FINE);
       return QUERY_TO_CALC_ITEMS.get(this.queryString);
     }
-    List<SObject> calcItems = Database.query(this.queryString);
-    QUERY_TO_CALC_ITEMS.put(this.queryString, calcItems);
-    return calcItems;
+    List<SObject> localCalcItems = Database.query(this.queryString);
+    QUERY_TO_CALC_ITEMS.put(this.queryString, localCalcItems);
+    return localCalcItems;
   }
 
   protected override Map<String, String> customizeToStringEntries(Map<String, String> props) {
@@ -75,22 +127,6 @@ public abstract without sharing class RollupFullRecalcProcessor extends RollupAs
 
   protected override String getHashedContents() {
     return String.valueOf(this.rollupInfo);
-  }
-
-  public void finish() {
-    if (this.postProcessor != null) {
-      RollupLogger.Instance.log('Starting post-full recalc processor', this.postProcessor, LoggingLevel.DEBUG);
-      // chain jobs together so that if recalc job is being tracked within the Recalc Rollups app,
-      // job continuity is established between the full recalc and then any downstream job that runs
-      // (as the postProcessor)
-      this.setCurrentJobId(this.postProcessor.runCalc());
-    }
-  }
-
-  public override void storeParentResetField(RollupAsyncProcessor processor, SObject parent) {
-    super.storeParentResetField(processor, parent);
-    this.postProcessor?.recordIds.add(parent.Id);
-    this.postProcessor?.storeParentResetField(processor, parent);
   }
 
   private void overrideRollupControl() {

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger extends Rollup implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.10';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.11';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
   private static Boolean disabledMessageHasBeenLogged = false;

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Fixes an issue reported by solo-1234 where parent reset processors could fail during a full recalc when multiple parents were present in a single reset operation. Apex Rollup now omits parent records from being updated unless at least one rollup field has changed.",
-            "versionNumber": "1.5.10.0",
+            "versionName": "Fixed a few issues with the singular parent recalc button. Fixed an issue where full recalcs called from flow with UPSERT/UPDATE contexts wouldn't always run correctly",
+            "versionNumber": "1.5.11.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -102,6 +102,7 @@
         "apex-rollup@1.5.7-0": "04t6g000008SkNkAAK",
         "apex-rollup@1.5.8-0": "04t6g000008SkRSAA0",
         "apex-rollup@1.5.9-0": "04t6g000008SkVFAA0",
-        "apex-rollup@1.5.10-0": "04t6g000008SkVeAAK"
+        "apex-rollup@1.5.10-0": "04t6g000008SkVeAAK",
+        "apex-rollup@1.5.11-0": "04t6g000008SkWhAAK"
     }
 }


### PR DESCRIPTION
* Did a little cleanup in Rollup.cls to break up the now quite large `performSerializedBulkFullRecalc` method while fixing a bug where invocations of that method internally (as opposed to from LWC) were sometimes resetting too many parent fields
* Fixed a bug reported by @rodgersjosh where full recalcs started through Flow when records were updated wouldn't properly perform the full recalculation for a Rollup Operation not already listed as a full recalc (bonus points if you made it through that sentence without your eyes crossing)
* Removed a now-unused method in RollupAsyncProcessor