### PR TITLE
V1.5.12 - Parent-based Rollups Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkWhAAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkXfAAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkWhAAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkXfAAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -496,9 +496,12 @@ private class RollupFullRecalcTests {
 
   @IsTest
   static void clearsParentValuesWhenNoRefreshMatches() {
-    List<Account> accs = [SELECT Id, AnnualRevenue FROM Account];
+    List<Account> accs = [SELECT Id, AnnualRevenue, Description FROM Account];
     accs[0].AnnualRevenue = 1500;
+    accs[0].Description = 'This is the value that should be persisted';
     update accs;
+    // simulate un-related, in-flight update
+    accs[0].Description = 'Something else';
 
     List<Rollup.FlowInput> flowInputs = RollupTestUtils.prepareFlowTest(accs, 'REFRESH', 'SUM');
     flowInputs[0].isRollupStartedFromParent = true;
@@ -512,8 +515,9 @@ private class RollupFullRecalcTests {
     System.assertEquals('SUCCESS', flowOutputs[0].message);
     System.assertEquals(true, flowOutputs[0].isSuccess);
 
-    Account updatedAcc = [SELECT Id, AnnualRevenue FROM Account];
+    Account updatedAcc = [SELECT Id, AnnualRevenue, Description FROM Account];
     System.assertEquals(null, updatedAcc.AnnualRevenue, 'SUM REFRESH from flow started from parent should fully clear');
+    System.assertEquals('This is the value that should be persisted', updatedAcc.Description, 'Unrelated field should not be cleared');
   }
 
   @IsTest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -225,8 +225,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   public virtual void finish(Database.BatchableContext context) {
+    if (this.isTimingOut == false) {
+      this.fullRecalcProcessor?.finish();
+    }
     this.logFinish();
-    this.fullRecalcProcessor?.finish();
   }
 
   public virtual override String runCalc() {
@@ -381,10 +383,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     public void execute(System.QueueableContext qc) {
       System.attachFinalizer(new RollupFinalizer());
       this.process(this.rollups);
-      if (this.isTimingOut == false) {
-        this.fullRecalcProcessor?.finish();
-      }
-      this.logFinish();
+      this.finish(null);
     }
   }
 
@@ -413,7 +412,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   protected virtual List<SObject> getExistingLookupItems(Set<String> objIds, RollupAsyncProcessor rollup, Set<String> uniqueQueryFieldNames) {
-    // for Rollups that are Batchable, the lookup items are retrieved en masse in the "start" method and cached in the "execute method"
+    // for Rollups that are Batchable, the lookup items are retrieved en masse in the "start" method and cached in the "execute" method
     this.fullRecalcProcessor?.processParentFieldsToReset(this.lookupItems);
     return this.lookupItems;
   }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -184,12 +184,12 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   public virtual Database.QueryLocator start(Database.BatchableContext context) {
     /**
      * for batch, we know 100% for sure there's only 1 SObjectType / Set<String> in the map.
-     * NB: we have to call "getFieldNamesForRollups" in both the "start" and "execute" methods because
+     * NB: we have to call "populateObjectFields" in both the "start" and "execute" methods because
      * trying to use Database.Stateful on the top-level class ** in addition to Batchable ** results in the dreaded:
      * "System.AsyncException: Queueable cannot be implemented with other system interfaces" exception
      */
     this.winnowRollups(this.rollups);
-    this.getFieldNamesForRollups(this.rollups);
+    this.populateObjectFields(this.rollups);
     String lookupFieldForLookupObject;
     SObjectType sObjectType;
     String query;
@@ -510,9 +510,9 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   protected void process(List<RollupAsyncProcessor> rollups) {
-    this.transformRollups(rollups);
+    this.preProcessRollups(rollups);
     this.handleMultipleDMLRollupsEnqueuedInTheSameTransaction(rollups);
-    this.getFieldNamesForRollups(rollups); // populates this.lookupObjectToUniqueFieldNames
+    this.populateObjectFields(rollups);
 
     Map<String, SObject> updatedLookupRecords = new Map<String, SObject>();
     Map<SObjectType, RollupRelationshipFieldFinder.Traversal> grandparentRollups = new Map<SObjectType, RollupRelationshipFieldFinder.Traversal>();
@@ -624,7 +624,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     return this.isTimingOut;
   }
 
-  private void transformRollups(List<RollupAsyncProcessor> rollupsToProcess) {
+  private void preProcessRollups(List<RollupAsyncProcessor> rollupsToProcess) {
     for (Integer index = rollupsToProcess.size() - 1; index >= 0; index--) {
       RollupAsyncProcessor rollup = rollupsToProcess[index];
       List<RollupAsyncProcessor> additionalRollups = rollup.transformFullRecalcRollups();
@@ -721,7 +721,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
   }
 
-  private void getFieldNamesForRollups(List<RollupAsyncProcessor> rollups) {
+  private void populateObjectFields(List<RollupAsyncProcessor> rollups) {
+    if (this.lookupObjectToUniqueFieldNames != null) {
+      return;
+    }
     this.lookupObjectToUniqueFieldNames = new Map<SObjectType, Set<String>>();
     this.calcObjectToUniqueFieldNames = new Map<SObjectType, Set<String>>();
     List<Rollup__mdt> combinedMeta = new List<Rollup__mdt>();
@@ -739,17 +742,17 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         this.lookupObjectToUniqueFieldNames.put(roll.lookupObj, rollupFieldNames);
       }
 
-      List<String> whereFields = String.isBlank(roll.metadata.CalcItemWhereClause__c)
-        ? new List<String>()
-        : RollupEvaluator.getWhereEval(roll.metadata.CalcItemWhereClause__c, roll.calcItemType).getQueryFields();
-      whereFields.addAll(new List<String>{ roll.opFieldOnCalcItem.getDescribe().getName(), roll.lookupFieldOnCalcItem.getDescribe().getName() });
+      Set<String> whereFields = new Set<String>{ roll.opFieldOnCalcItem.getDescribe().getName(), roll.lookupFieldOnCalcItem.getDescribe().getName() };
+      if (String.isNotBlank(roll.metadata.CalcItemWhereClause__c)) {
+        whereFields.addAll(RollupEvaluator.getWhereEval(roll.metadata.CalcItemWhereClause__c, roll.calcItemType).getQueryFields());
+      }
       for (RollupOrderBy__mdt orderBy : roll.metadata.RollupOrderBys__r) {
         whereFields.add(orderBy.FieldName__c);
       }
       if (this.calcObjectToUniqueFieldNames.containsKey(roll.calcItemType)) {
         this.calcObjectToUniqueFieldNames.get(roll.calcItemType).addAll(whereFields);
       } else {
-        this.calcObjectToUniqueFieldNames.put(roll.calcItemType, new Set<String>(whereFields));
+        this.calcObjectToUniqueFieldNames.put(roll.calcItemType, whereFields);
       }
       if (this.calcItemReplacer?.hasProcessedMetadata(combinedMeta, roll.calcItems) == false) {
         Integer oldHashCode = roll.calcItems?.hashCode();
@@ -785,7 +788,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   private void winnowRollups(List<RollupAsyncProcessor> potentialRollups) {
-    this.transformRollups(potentialRollups);
+    this.preProcessRollups(potentialRollups);
     for (Integer index = potentialRollups.size() - 1; index >= 0; index--) {
       RollupAsyncProcessor processor = potentialRollups[index];
       Map<String, SObjectField> fieldMap = processor.lookupObj?.getDescribe().fields.getMap();

--- a/rollup/core/classes/RollupFullRecalcProcessor.cls
+++ b/rollup/core/classes/RollupFullRecalcProcessor.cls
@@ -93,7 +93,7 @@ public abstract without sharing class RollupFullRecalcProcessor extends RollupAs
     for (SObject parentRecordToReset : this.parentRecordsToClear.values()) {
       SObject relatedParentRecord = relatedParentRecordsMap.containsKey(parentRecordToReset.Id)
         ? relatedParentRecordsMap.get(parentRecordToReset.Id)
-        : parentRecordToReset;
+        : parentRecordToReset.getSObjectType().newSObject(parentRecordToReset.Id);
 
       for (Rollup__mdt meta : this.rollupInfo) {
         if (relatedParentRecord.getSobjectType().getDescribe().getName() == meta.LookupObject__c) {

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger extends Rollup implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.11';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.12';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
   private static Boolean disabledMessageHasBeenLogged = false;

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -104,6 +104,6 @@
         "apex-rollup@1.5.9-0": "04t6g000008SkVFAA0",
         "apex-rollup@1.5.10-0": "04t6g000008SkVeAAK",
         "apex-rollup@1.5.11-0": "04t6g000008SkWhAAK",
-        "apex-rollup@1.5.12-0": "04t6g000008SkX1AAK"
+        "apex-rollup@1.5.12-0": "04t6g000008SkXfAAK"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Fixed a few issues with the singular parent recalc button. Fixed an issue where full recalcs called from flow with UPSERT/UPDATE contexts wouldn't always run correctly",
-            "versionNumber": "1.5.11.0",
+            "versionName": "Process improvements, fixed an issue where rollups started from parents could have old fields persisted.",
+            "versionNumber": "1.5.12.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -103,6 +103,7 @@
         "apex-rollup@1.5.8-0": "04t6g000008SkRSAA0",
         "apex-rollup@1.5.9-0": "04t6g000008SkVFAA0",
         "apex-rollup@1.5.10-0": "04t6g000008SkVeAAK",
-        "apex-rollup@1.5.11-0": "04t6g000008SkWhAAK"
+        "apex-rollup@1.5.11-0": "04t6g000008SkWhAAK",
+        "apex-rollup@1.5.12-0": "04t6g000008SkX1AAK"
     }
 }


### PR DESCRIPTION
* Rollups started from parent don't reset in-flight changed fields in the event that a parent record needs to have its values cleared. Previously, the version of the parent record used included all of the values from Flow/Apex when clearing a field which no longer had rollup values, but this meant that there was the possibility for changes made to the parent record while the rollup was processing to get those updates rolled back.
* Updated a few internal rollup method names to better account for what they were doing, and slightly optimized the batch job version of Apex Rollup