### PR TITLE
V1.5.16 - Avoid resetting parents when their fields are already blank

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Skg4AAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SklPAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Skg4AAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SklPAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupFlowBulkProcessorTests.cls
+++ b/extra-tests/classes/RollupFlowBulkProcessorTests.cls
@@ -14,6 +14,12 @@ private class RollupFlowBulkProcessorTests {
     System.assertEquals('No records', outputs[0].message);
   }
 
+  private class CachedRollup extends Rollup {
+    public List<Rollup> getCurrentlyCachedRollups() {
+      return this.getCachedRollups();
+    }
+  }
+
   @IsTest
   static void shouldAddToRollupsIfCMDTPresent() {
     RollupFlowBulkProcessor.FlowInput input = new RollupFlowBulkProcessor.FlowInput();
@@ -38,7 +44,7 @@ private class RollupFlowBulkProcessorTests {
     for (Rollup.FlowOutput output : outputs) {
       System.assertEquals(true, outputs[0].isSuccess, 'Should not error when adding deferred flow rollup');
     }
-    System.assertNotEquals(true, Rollup.CACHED_ROLLUPS.isEmpty(), 'Deferred rollup should be kept in buffer');
+    System.assertNotEquals(true, new CachedRollup().getCurrentlyCachedRollups().isEmpty(), 'Deferred rollup should be kept in buffer');
   }
 
   @IsTest
@@ -70,7 +76,7 @@ private class RollupFlowBulkProcessorTests {
 
     acc = [SELECT AnnualRevenue FROM Account WHERE Id = :acc.Id];
     System.assertEquals(5, acc.AnnualRevenue);
-    System.assertEquals(0, Rollup.CACHED_ROLLUPS.size(), 'Flow rollup buffer should have been flushed!');
+    System.assertEquals(0, new CachedRollup().getCurrentlyCachedRollups().size(), 'Flow rollup buffer should have been flushed!');
   }
 
   @IsTest

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -349,6 +349,54 @@ private class RollupFullRecalcTests {
   }
 
   @IsTest
+  static void doesNotUpdateParentRecordsWhereRollupValueHasNotChangedInFullRecalc() {
+    RollupTestUtils.DMLMock mock = new RollupTestUtils.DMLMock();
+    Rollup.DML = mock;
+
+    Account acc = [SELECT Id FROM Account];
+    Account secondParent = new Account(Name = 'Second');
+    insert secondParent;
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
+      // ensure another matching item exists outside of the passed in list
+      new ContactPointAddress(PreferenceRank = 500, ParentId = acc.Id, Name = 'One'),
+      // ensure that the PreferenceRank associated with the second parent DOES match
+      // the second parent's existing annual revenue; here we are looking to ensure only the parent records needing an update are saved
+      new ContactPointAddress(ParentId = secondParent.Id, Name = 'Two')
+    };
+    insert cpas;
+
+    List<Rollup__mdt> metadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        RollupOperation__c = 'SUM',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupFieldOnCalcItem__c = 'PreferenceRank',
+        LookupFieldOnLookupObject__c = 'Id',
+        CalcItemWhereClause__c = 'Name != \'Two\''
+      ),
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        RollupOperation__c = 'COUNT',
+        RollupFieldOnLookupObject__c = 'NumberOfEmployees',
+        RollupFieldOnCalcItem__c = 'Id',
+        LookupFieldOnLookupObject__c = 'Id'
+      )
+    };
+
+    Test.startTest();
+    Rollup.performBulkFullRecalc(metadata, Rollup.InvocationPoint.FROM_FULL_RECALC_LWC.name());
+    Test.stopTest();
+
+    Map<Id, SObject> updatedRecordMap = new Map<Id, SObject>(mock.Records);
+    System.assertEquals(1, updatedRecordMap.size());
+    System.assertEquals(true, updatedRecordMap.containsKey(acc.Id));
+  }
+
+  @IsTest
   static void shouldPerformFullRecalcWithGrandparentHierarchyFlow() {
     Rollup.onlyUseMockMetadata = true;
     Account acc = [SELECT Id FROM Account];

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -8,7 +8,6 @@ private class RollupTests {
   static Rollup.Op rollupOp;
   static Boolean calcMockWasCalled = false;
 
-  @SuppressWarnings('apex-assist')
   @TestSetup
   static void setup() {
     // in the event that rollups are running in the org, we want to avoid triggering any operations while performing setup DML

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/plugins/NebulaLogger/classes/RollupNebulaLoggerAdapter.cls
+++ b/plugins/NebulaLogger/classes/RollupNebulaLoggerAdapter.cls
@@ -1,4 +1,3 @@
-@SuppressWarnings('apex-assist')
 public class RollupNebulaLoggerAdapter extends RollupLogger {
   public override void save() {
     Logger.saveLog();

--- a/plugins/NebulaLogger/tests/RollupNebulaLoggerAdapterTest.cls
+++ b/plugins/NebulaLogger/tests/RollupNebulaLoggerAdapterTest.cls
@@ -1,6 +1,5 @@
 @IsTest
 private class RollupNebulaLoggerAdapterTest {
-  @SuppressWarnings('apex-assist')
   @IsTest
   static void shouldLogToNebula() {
     Rollup.defaultControl = new RollupControl__mdt(IsRollupLoggingEnabled__c = true);

--- a/plugins/RollupCallback/classes/RollupDispatch.cls
+++ b/plugins/RollupCallback/classes/RollupDispatch.cls
@@ -4,7 +4,6 @@ public class RollupDispatch implements RollupSObjectUpdater.IDispatcher {
   @TestVisible
   private static String platformEventOverride;
 
-  @SuppressWarnings('apex-assist')
   private static String PLATFORM_EVENT_BOOLEAN_STRING {
     get {
       if (PLATFORM_EVENT_BOOLEAN_STRING == null && platformEventOverride != null) {

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -2062,7 +2062,7 @@ global without sharing virtual class Rollup {
           '!=',
           wrappedMeta.whereClause
         );
-        Integer localCount = getCountFromDb(countQuery, new Set<String>(), fullRecalcMeta.wrapper.recordIds);
+        Integer localCount = getCountFromDb(countQuery, new Set<String>(), wrappedMeta.recordIds);
         wrappedMeta.recordCount = localCount == RollupQueryBuilder.SENTINEL_COUNT_VALUE ? localCount : wrappedMeta.recordCount + localCount;
       }
       typeToWrappedMeta.put(fullRecalcMeta.calcItemType, wrappedMeta);
@@ -2118,7 +2118,7 @@ global without sharing virtual class Rollup {
     FullRecalculationMetadata fullRecalcMeta = fullRecalcMetas[index];
     wrappedMeta.metadata.add(fullRecalcMeta.meta);
     wrappedMeta.recordIds.addAll(fullRecalcMeta.wrapper.recordIds);
-    wrappedMeta.whereClause = fullRecalcMeta.wrapper.getQuery();
+    wrappedMeta.whereClause = wrappedMeta.recordIds.isEmpty() ? null : fullRecalcMeta.wrapper.getQuery();
     if (String.isNotBlank(fullRecalcMeta.meta.CalcItemWhereClause__c)) {
       wrappedMeta.queryFields.addAll(RollupEvaluator.getWhereEval(fullRecalcMeta.meta.CalcItemWhereClause__c, fullRecalcMeta.calcItemType).getQueryFields());
     }
@@ -2401,14 +2401,16 @@ global without sharing virtual class Rollup {
       countQuery = countQuery.replace(RollupQueryBuilder.ALL_ROWS, '');
     }
 
+    Integer countAmount;
     try {
-      return Database.countQuery(countQuery);
+      countAmount = Database.countQuery(countQuery);
     } catch (Exception ex) {
       RollupLogger.Instance.log('an error occurred while trying to get count query:\n' + countQuery, ex, LoggingLevel.WARN);
       // not all queries are valid, particularly those with polymorphic fields referencing parent fields
       // return a sentinel value instead, to be checked for downstream
-      return RollupQueryBuilder.SENTINEL_COUNT_VALUE;
+      countAmount = RollupQueryBuilder.SENTINEL_COUNT_VALUE;
     }
+    return countAmount;
   }
 
   private static void fillWrapper(QueryWrapper wrapper, String fieldName, SObject calcItem, Map<Id, SObject> oldCalcItems) {

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -64,7 +64,6 @@ global without sharing virtual class Rollup {
     set;
   }
 
-  @TestVisible
   private static final List<Rollup> CACHED_ROLLUPS {
     get {
       if (CACHED_ROLLUPS == null) {
@@ -134,7 +133,6 @@ global without sharing virtual class Rollup {
     set;
   }
 
-  @SuppressWarnings('apex-assist')
   public enum Op {
     SUM,
     UPDATE_SUM,

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger extends Rollup implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.15';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.16';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
   private static Boolean disabledMessageHasBeenLogged = false;

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -107,6 +107,7 @@
         "apex-rollup@1.5.12-0": "04t6g000008SkXfAAK",
         "apex-rollup@1.5.13-0": "04t6g000008SkaAAAS",
         "apex-rollup@1.5.14-0-do-not-use": "04t6g000008SkfkAAC",
-        "apex-rollup@1.5.15-0": "04t6g000008Skg4AAC"
+        "apex-rollup@1.5.15-0": "04t6g000008Skg4AAC",
+        "apex-rollup@1.5.16-0": "04t6g000008SklPAAS"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Fixed an issue with 1.5.14 where not all queries produced by REFRESH rollups were valid due to paranthetical nesting",
-            "versionNumber": "1.5.15.0",
+            "versionName": "Only reset parent-level rollup fields in full recalcs from the app",
+            "versionNumber": "1.5.16.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
* some slight cleanup of `@TestVisible` annotated variables
* full recalcs (kicked off via `REFRESH` context from flow, by rollups starting from the parent, or from the app) now should only update parent records if at least one rollup field had changed. Previously there was an edge case where parents whose rollup values were already null could also be included in full recalc updates, which had the downside of increasing the number of records being DML'ed - possibly leading to downstream CPU timeouts if there's a lot of other automation going on for the parent records. This should help alleviate that (to some extent, safe harbor 🚢)