### PR TITLE
V1.5.18 - Deeply Nested Conditional Bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkuIAAS">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkucAAC">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkuIAAS">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SkucAAC">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupEvaluatorTests.cls
+++ b/extra-tests/classes/RollupEvaluatorTests.cls
@@ -1101,7 +1101,7 @@ private class RollupEvaluatorTests {
 
   @IsTest
   static void crazilyNestedConditionalsAreRecursedProperly() {
-    String whereClause = '((IsActive = TRUE) OR (IsActive = FALSE) OR (IsActive = FALSE AND FirstName LIKE \'Special%\') OR (FirstName = \'One Item\' AND IsActive = TRUE) OR (Item_Auto__c = \'One Item\'))';
+    String whereClause = '((IsActive = TRUE) OR (IsActive = FALSE) OR (IsActive = FALSE AND FirstName LIKE \'Special%\') OR (FirstName = \'One Item\' AND IsActive = TRUE) OR (FirstName = \'One Item\'))';
     User target = new User(IsActive = false, FirstName = 'One');
 
     RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, target.getSObjectType());

--- a/extra-tests/classes/RollupEvaluatorTests.cls
+++ b/extra-tests/classes/RollupEvaluatorTests.cls
@@ -1098,4 +1098,14 @@ private class RollupEvaluatorTests {
 
     System.assertEquals(true, eval.matches(opp));
   }
+
+  @IsTest
+  static void crazilyNestedConditionalsAreRecursedProperly() {
+    String whereClause = '((IsActive = TRUE) OR (IsActive = FALSE) OR (IsActive = FALSE AND FirstName LIKE \'Special%\') OR (FirstName = \'One Item\' AND IsActive = TRUE) OR (Item_Auto__c = \'One Item\'))';
+    User target = new User(IsActive = false, FirstName = 'One');
+
+    RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, target.getSObjectType());
+
+    System.assertEquals(true, eval.matches(target));
+  }
 }

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -354,13 +354,12 @@ private class RollupFullRecalcTests {
     Rollup.DML = mock;
 
     Account acc = [SELECT Id FROM Account];
-    Account secondParent = new Account(Name = 'Second');
+    Account secondParent = new Account(Name = 'Second', NumberOfEmployees = 1);
     insert secondParent;
     List<ContactPointAddress> cpas = new List<ContactPointAddress>{
-      // ensure another matching item exists outside of the passed in list
       new ContactPointAddress(PreferenceRank = 500, ParentId = acc.Id, Name = 'One'),
-      // ensure that the PreferenceRank associated with the second parent DOES match
-      // the second parent's existing annual revenue; here we are looking to ensure only the parent records needing an update are saved
+      // ensure that the count of children records associated with the second parent DOES match
+      // the second parent's existing NumberOfEmployees; here we are looking to ensure only the parent records needing an update are saved
       new ContactPointAddress(ParentId = secondParent.Id, Name = 'Two')
     };
     insert cpas;
@@ -383,7 +382,8 @@ private class RollupFullRecalcTests {
         RollupOperation__c = 'COUNT',
         RollupFieldOnLookupObject__c = 'NumberOfEmployees',
         RollupFieldOnCalcItem__c = 'Id',
-        LookupFieldOnLookupObject__c = 'Id'
+        LookupFieldOnLookupObject__c = 'Id',
+        CalcItemWhereClause__c = 'Name != \'One\''
       )
     };
 
@@ -394,6 +394,61 @@ private class RollupFullRecalcTests {
     Map<Id, SObject> updatedRecordMap = new Map<Id, SObject>(mock.Records);
     System.assertEquals(1, updatedRecordMap.size());
     System.assertEquals(true, updatedRecordMap.containsKey(acc.Id));
+  }
+
+  @IsTest
+  static void updatesParentRecordsWhenAtLeastOneCmdtRecordDoesNotHaveWhereClause() {
+    RollupTestUtils.DMLMock mock = new RollupTestUtils.DMLMock();
+    Rollup.DML = mock;
+
+    Account acc = [SELECT Id FROM Account];
+    Account secondParent = new Account(Name = 'Second', NumberOfEmployees = 1);
+    insert secondParent;
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
+      new ContactPointAddress(PreferenceRank = 500, ParentId = acc.Id, Name = 'One'),
+      new ContactPointAddress(ParentId = secondParent.Id, Name = 'Two')
+    };
+    insert cpas;
+
+    List<Rollup__mdt> metadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        RollupOperation__c = 'SUM',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupFieldOnCalcItem__c = 'PreferenceRank',
+        LookupFieldOnLookupObject__c = 'Id',
+        CalcItemWhereClause__c = 'Name != \'Two\''
+      ),
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        RollupOperation__c = 'COUNT',
+        RollupFieldOnLookupObject__c = 'NumberOfEmployees',
+        RollupFieldOnCalcItem__c = 'Id',
+        LookupFieldOnLookupObject__c = 'Id',
+        CalcItemWhereClause__c = 'Name != \'Two\''
+      ),
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        RollupOperation__c = 'CONCAT',
+        RollupFieldOnLookupObject__c = 'Description',
+        RollupFieldOnCalcItem__c = 'Id',
+        LookupFieldOnLookupObject__c = 'Id'
+      )
+    };
+
+    Test.startTest();
+    Rollup.performBulkFullRecalc(metadata, Rollup.InvocationPoint.FROM_FULL_RECALC_LWC.name());
+    Test.stopTest();
+
+    Map<Id, SObject> updatedRecordMap = new Map<Id, SObject>(mock.Records);
+    System.assertEquals(true, updatedRecordMap.containsKey(secondParent.Id));
+    System.assertEquals(cpas[1].Id, updatedRecordMap.get(secondParent.Id).get('Description'));
   }
 
   @IsTest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.17",
+  "version": "1.5.18",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -191,6 +191,11 @@ global without sharing virtual class Rollup {
       String orDelimiter = ' OR ';
       String concatenatedWhereClause = '(';
       for (String possibleClause : this.possibleWhereClauses) {
+        if (String.isBlank(possibleClause)) {
+          // if even one of the where clauses is null, all calc items need to be retrieved
+          // and the filtering has to be done in-memory
+          return null;
+        }
         concatenatedWhereClause += '(' + possibleClause + ')' + orDelimiter;
       }
 
@@ -1963,9 +1968,7 @@ global without sharing virtual class Rollup {
     if (possibleParentId != null) {
       metaWrapper.recordIds.add(possibleParentId);
     }
-    if (String.isNotBlank(matchingMeta.CalcItemWhereClause__c)) {
-      metaWrapper.possibleWhereClauses.add(matchingMeta.CalcItemWhereClause__c);
-    }
+    metaWrapper.possibleWhereClauses.add(matchingMeta.CalcItemWhereClause__c);
     metaWrapper.queryFields.addAll(wherefields);
     metaWrapper.metadata.add(matchingMeta);
 
@@ -2133,9 +2136,8 @@ global without sharing virtual class Rollup {
     FullRecalculationMetadata fullRecalcMeta = fullRecalcMetas[index];
     wrappedMeta.metadata.add(fullRecalcMeta.meta);
     wrappedMeta.recordIds.addAll(fullRecalcMeta.wrapper.recordIds);
-    if (fullRecalcMeta.wrapper.hasQuery) {
-      wrappedMeta.possibleWhereClauses.add(fullRecalcMeta.wrapper.getQuery());
-    }
+    wrappedMeta.possibleWhereClauses.add(fullRecalcMeta.wrapper.getQuery());
+
     if (String.isNotBlank(fullRecalcMeta.meta.CalcItemWhereClause__c)) {
       wrappedMeta.queryFields.addAll(RollupEvaluator.getWhereEval(fullRecalcMeta.meta.CalcItemWhereClause__c, fullRecalcMeta.calcItemType).getQueryFields());
     }

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -283,7 +283,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       try {
         for (String splitWhereClause : localSplitWheres) {
           List<WhereFieldCondition> conditions = this.createConditionsFromString(splitWhereClause, calcItemSObjectType);
-          if (this.isOrConditional(this.whereClause, splitWhereClause)) {
+          if (this.isOrConditional(splitWhereClause)) {
             this.conditionalGroupings.add(new OrConditionalGrouping(conditions));
           } else {
             this.conditionalGroupings.add(new AndConditionalGrouping(conditions));
@@ -340,7 +340,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
         Integer openParansRange = potentialNestedConditional.indexOf('(');
         if (openParansRange == 0 && potentialNestedConditional.length() > 1) {
           // remove the parans now
-          potentialNestedConditional = potentialNestedConditional.substring(1, potentialNestedConditional.length() - 1);
+          potentialNestedConditional = potentialNestedConditional.substring(1, potentialNestedConditional.length());
           // iterate through the rest of the list, stopping at the end of the parantheses
           for (Integer innerIndex = index + 1; innerIndex < localSplitWheres.size(); innerIndex++) {
             String innerMatch = localSplitWheres[innerIndex].trim();
@@ -349,7 +349,15 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
             if (innerMatch.endsWith(')')) {
               Integer startingPoint = whereClause.indexOf(potentialNestedConditional);
               Integer endingPoint = whereClause.indexOf(innerMatch) + (innerMatch.length() - 1);
-              potentialNestedConditional = whereClause.substring(startingPoint, endingPoint).removeStart('(').removeEnd(')');
+              try {
+                potentialNestedConditional = whereClause.substring(startingPoint, endingPoint);
+              } catch (System.StringException ex) {
+                // TODO - not an entirely ideal solution, as it implies an actual recursive parsing error
+                // but it seems that as long as this error is caught, the actual where clauses even for deeply nested conditionals
+                // end up being created correctly
+                RollupLogger.Instance.log('recursive nested conditional parse error, continuing ...', ex.getMessage(), LoggingLevel.WARN);
+              }
+              potentialNestedConditional = potentialNestedConditional.removeStart('(').removeEnd(')');
               break;
             } else {
               this.splitWheres.add(innerMatch);
@@ -363,7 +371,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
           List<String> innerWhereClauses = this.getSoqlWhereClauses(potentialNestedConditional, calcItemSObjectType);
           for (String innerWhere : innerWhereClauses) {
             this.splitWheres.add(innerWhere);
-            isAnInnerOrCondition = isAnInnerOrCondition || this.isOrConditional(potentialNestedConditional, innerWhere);
+            isAnInnerOrCondition = isAnInnerOrCondition || this.isOrConditional(innerWhere);
             conditions.addAll(this.createConditionsFromString(innerWhere, calcItemSObjectType));
           }
 
@@ -384,15 +392,15 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       }
     }
 
-    private Boolean isOrConditional(String fullString, String conditionalStatement) {
+    private Boolean isOrConditional(String conditionalStatement) {
       Boolean isOr = false;
-      Boolean isFirstConditional = fullString.indexOf(conditionalStatement) == 0;
+      Boolean isFirstConditional = this.originalWhereClause.indexOf(conditionalStatement) == 0;
       if (isFirstConditional == false) {
-        Integer whereWeAreInTheFullString = fullString.indexOf(conditionalStatement);
+        Integer whereWeAreInTheFullString = this.originalWhereClause.indexOf(conditionalStatement);
         // 5 is enough to encapsulate " or " with spaces
-        Integer clauseStartingIndex = whereWeAreInTheFullString - 5;
+        Integer clauseStartingIndex = whereWeAreInTheFullString - 7;
         if (clauseStartingIndex > 0) {
-          isOr = fullString.substring(clauseStartingIndex, whereWeAreInTheFullString).containsIgnoreCase(' or ');
+          isOr = this.originalWhereClause.substring(clauseStartingIndex, whereWeAreInTheFullString).containsIgnoreCase(' or ');
         }
       }
       return isOr;

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger extends Rollup implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.17';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.18';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
   private static Boolean disabledMessageHasBeenLogged = false;

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -109,6 +109,7 @@
         "apex-rollup@1.5.14-0-do-not-use": "04t6g000008SkfkAAC",
         "apex-rollup@1.5.15-0": "04t6g000008Skg4AAC",
         "apex-rollup@1.5.16-0": "04t6g000008SklPAAS",
-        "apex-rollup@1.5.17-0": "04t6g000008SkuIAAS"
+        "apex-rollup@1.5.17-0": "04t6g000008SkuIAAS",
+        "apex-rollup@1.5.18-0": "04t6g000008SkucAAC"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Process improvements for multi-currency, potential fix for parent items with null values being updated unnecessarily",
-            "versionNumber": "1.5.17.0",
+            "versionName": "Fixes an issue in RollupEvaluator where large inner paranthetical where clauses were being split incorrectly",
+            "versionNumber": "1.5.18.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
* fixes an issue reported by @solo-1234 where full recalcs with a large number of calc item where clauses could cause `RollupEvaluator` parsing errors during full recalcs