### PR TITLE
V1.5.24 - The Solo Admin Special

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0YSAAY">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0Z6AAI">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0YSAAY">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0Z6AAI">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupCalcItemReplacerTests.cls
+++ b/extra-tests/classes/RollupCalcItemReplacerTests.cls
@@ -129,4 +129,19 @@ private class RollupCalcItemReplacerTests {
 
     System.assertEquals(ACC_ANNUAL_REVENUE, acc.AnnualRevenue);
   }
+
+  @IsTest
+  static void skipsNonUpdateableFields() {
+    Account acc = [SELECT Id, CreatedDate FROM Account];
+
+    RollupCalcItemReplacer replacer = new RollupCalcItemReplacer(
+      new RollupControl__mdt(IsRollupLoggingEnabled__c = true, ReplaceCalcItemsAsyncWhenOverCount__c = 1)
+    );
+    Account updatedAccount = (Account) replacer.replace(
+      new List<Account>{ new Account(Id = acc.Id) },
+      new List<Rollup__mdt>{ new Rollup__mdt(CalcItemWhereClause__c = 'CreatedDate != null') }
+    )[0];
+
+    System.assertEquals(acc.CreatedDate, updatedAccount.CreatedDate);
+  }
 }

--- a/extra-tests/customMetadata/Rollup.RollupIntegrationChildRollupText.md-meta.xml
+++ b/extra-tests/customMetadata/Rollup.RollupIntegrationChildRollupText.md-meta.xml
@@ -1,10 +1,14 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomMetadata
+  xmlns="http://soap.sforce.com/2006/04/metadata"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+>
     <label>RollupIntegrationChildRollupText</label>
     <protected>false</protected>
     <values>
         <field>CalcItemWhereClause__c</field>
-        <value xsi:nil="true"/>
+        <value xsi:nil="true" />
     </values>
     <values>
         <field>CalcItem__c</field>
@@ -12,23 +16,23 @@
     </values>
     <values>
         <field>ChangedFieldsOnCalcItem__c</field>
-        <value xsi:nil="true"/>
+        <value xsi:nil="true" />
     </values>
     <values>
         <field>ConcatDelimiter__c</field>
-        <value xsi:nil="true"/>
+        <value xsi:nil="true" />
     </values>
     <values>
         <field>FullRecalculationDefaultNumberValue__c</field>
-        <value xsi:nil="true"/>
+        <value xsi:nil="true" />
     </values>
     <values>
         <field>FullRecalculationDefaultStringValue__c</field>
-        <value xsi:nil="true"/>
+        <value xsi:nil="true" />
     </values>
     <values>
         <field>GrandparentRelationshipFieldPath__c</field>
-        <value xsi:nil="true"/>
+        <value xsi:nil="true" />
     </values>
     <values>
         <field>IsFullRecordSet__c</field>
@@ -49,10 +53,6 @@
     <values>
         <field>LookupObject__c</field>
         <value xsi:type="xsd:string">RollupParent__c</value>
-    </values>
-    <values>
-        <field>OrderByFirstLast__c</field>
-        <value xsi:type="xsd:string">TextField__c</value>
     </values>
     <values>
         <field>RollupControl__c</field>
@@ -76,6 +76,6 @@
     </values>
     <values>
         <field>UltimateParentLookup__c</field>
-        <value xsi:nil="true"/>
+        <value xsi:nil="true" />
     </values>
 </CustomMetadata>

--- a/extra-tests/customMetadata/RollupOrderBy.Integration_TextValue_FIRST.md-meta.xml
+++ b/extra-tests/customMetadata/RollupOrderBy.Integration_TextValue_FIRST.md-meta.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomMetadata
+  xmlns="http://soap.sforce.com/2006/04/metadata"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+>
+    <label>Integration TextValue FIRST</label>
+    <protected>false</protected>
+    <values>
+        <field>FieldName__c</field>
+        <value xsi:type="xsd:string">TextField__c</value>
+    </values>
+    <values>
+        <field>NullSortOrder__c</field>
+        <value xsi:type="xsd:string">NULLS FIRST</value>
+    </values>
+    <values>
+        <field>Ranking__c</field>
+        <value xsi:type="xsd:double">0.0</value>
+    </values>
+    <values>
+        <field>Rollup__c</field>
+        <value xsi:type="xsd:string">RollupIntegrationChildRollupText</value>
+    </values>
+    <values>
+        <field>SortOrder__c</field>
+        <value xsi:type="xsd:string">Ascending</value>
+    </values>
+</CustomMetadata>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.23",
+  "version": "1.5.24",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/app/lwc/rollupForceRecalculation/__tests__/rollupForceRecalculation.test.js
+++ b/rollup/app/lwc/rollupForceRecalculation/__tests__/rollupForceRecalculation.test.js
@@ -312,14 +312,16 @@ describe('Rollup force recalc tests', () => {
 
   it('only sets up rollup order by children once', async () => {
     getRollupMetadataByCalcItem.mockClear();
-    mockMetadata.Contact[0].RollupOrderBys__r.push({
-      Rollup__c: 'someId',
-      Id: 'someOtherId',
-      FieldName__c: 'CreatedDate',
-      NullSortOrder__c: 'NULLS FIRST',
-      Ranking__c: 0,
-      SortOrder__c: 'Ascending'
-    });
+    mockMetadata.Contact[0].RollupOrderBys__r = [
+      {
+        Rollup__c: 'someId',
+        Id: 'someOtherId',
+        FieldName__c: 'CreatedDate',
+        NullSortOrder__c: 'NULLS FIRST',
+        Ranking__c: 0,
+        SortOrder__c: 'Ascending'
+      }
+    ];
     getRollupMetadataByCalcItem.mockResolvedValue(mockMetadata);
     const fullRecalc = createElement('c-rollup-force-recalculation', {
       is: RollupForceRecalculation

--- a/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js
+++ b/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js
@@ -193,7 +193,7 @@ export default class RollupForceRecalculation extends LightningElement {
           children = possibleOrderByComponent.orderBys;
         }
       }
-      if (children) {
+      if (children && !children.totalSize) {
         metadata.RollupOrderBys__r = { totalSize: children?.length, done: true, records: children };
       }
     }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -238,17 +238,6 @@ global without sharing virtual class Rollup {
     }
   }
 
-  private class FullRecalculationMetadata {
-    private final Rollup__mdt meta;
-    private final QueryWrapper wrapper;
-    private final SObjectType calcItemType;
-    public FullRecalculationMetadata(Rollup__mdt meta, QueryWrapper wrapper, SObjectType calcItemType) {
-      this.meta = meta;
-      this.wrapper = wrapper;
-      this.calcItemType = calcItemType;
-    }
-  }
-
   public class CalcItemBag {
     private final Map<Id, SObject> idToCalcItem = new Map<Id, SObject>();
     private Boolean hasBeenCleared = false;
@@ -506,7 +495,13 @@ global without sharing virtual class Rollup {
         }
       }
 
-      populateFullRecalcMetasByType(childToMetaWrapper, matchingMeta, possibleParentId);
+      SObjectType childType = RollupFieldInitializer.Current.getDescribeFromName(matchingMeta.CalcItem__c).getSObjectType();
+      RollupMetadata wrappedMeta = getWrappedMeta(childType, childToMetaWrapper, matchingMeta, matchingMeta.CalcItemWhereClause__c);
+      if (possibleParentId != null) {
+        wrappedMeta.recordIds.add(possibleParentId);
+      }
+      wrappedMeta.possibleWhereClauses.add(matchingMeta.CalcItemWhereClause__c);
+      appendQueryCount(wrappedMeta, matchingMeta, matchingMeta.CalcItemWhereClause__c, childType);
     }
 
     List<Rollup> processors = transformWrappedMetadataToFullRecalcRollups(childToMetaWrapper, localInvokePoint);
@@ -1934,7 +1929,6 @@ global without sharing virtual class Rollup {
     InvocationPoint invokePoint,
     Map<SObjectType, RollupMetadata> typeToWrappedMeta
   ) {
-    List<FullRecalculationMetadata> fullRecalcMetas = new List<FullRecalculationMetadata>();
     Map<String, DeleteReparentOperation> deleteKeyToReparentOp = new Map<String, DeleteReparentOperation>();
     for (Integer index = metas.size() - 1; index >= 0; index--) {
       Rollup__mdt meta = metas[index];
@@ -1976,7 +1970,21 @@ global without sharing virtual class Rollup {
 
       if (queryWrapper != null) {
         metas.remove(index);
-        fullRecalcMetas.add(new FullRecalculationMetadata(meta, queryWrapper, calcItemSObjectType));
+        RollupMetadata wrappedMeta = getWrappedMeta(
+          calcItemSObjectType,
+          typeToWrappedMeta,
+          meta,
+          queryWrapper.getQuery() + (String.isNotBlank(meta.CalcItemWhereClause__c) ? ' AND ' + meta.CalcItemWhereClause__c : '')
+        );
+        if (rollups.containsKey(calcItemSObjectType)) {
+          rollups.get(calcItemSObjectType).clear();
+        }
+        wrappedMeta.recordIds.addAll(queryWrapper.recordIds);
+        if (wrappedMeta.recordIds.isEmpty() == false) {
+          wrappedMeta.possibleWhereClauses.add(queryWrapper.getQuery());
+        }
+        wrappedMeta.parentRecordsToReset.addAll(queryWrapper.parentRecordsToReset);
+        appendQueryCount(wrappedMeta, meta, wrappedMeta.whereClause, calcItemSObjectType);
         if (isRefresh) {
           prepareReparentDeletionOps(meta, calcItems, oldCalcItems, deleteKeyToReparentOp);
         }
@@ -2008,7 +2016,10 @@ global without sharing virtual class Rollup {
       );
       populateRollupByType(rollups, deleteSObjectType, deleteProcessor);
     }
-    fillFullRecalcRollups(fullRecalcMetas, invokePoint, typeToWrappedMeta, rollups);
+    List<RollupFullRecalcProcessor> fullRecalcs = transformWrappedMetadataToFullRecalcRollups(typeToWrappedMeta, invokePoint);
+    for (RollupFullRecalcProcessor fullRecalc : fullRecalcs) {
+      populateRollupByType(rollups, fullRecalc.getCalcItemType(), fullRecalc);
+    }
   }
 
   private static QueryWrapper getFullRecalcQueryWrapper(Rollup__mdt meta, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
@@ -2039,37 +2050,6 @@ global without sharing virtual class Rollup {
     }
 
     return wrapper;
-  }
-
-  private static void populateFullRecalcMetasByType(Map<SObjectType, RollupMetadata> childToMetaWrapper, Rollup__mdt matchingMeta, String possibleParentId) {
-    SObjectType childType = RollupFieldInitializer.Current.getDescribeFromName(matchingMeta.CalcItem__c).getSObjectType();
-    RollupEvaluator.WhereFieldEvaluator eval = String.isBlank(matchingMeta.CalcItemWhereClause__c)
-      ? null
-      : RollupEvaluator.getWhereEval(matchingMeta.CalcItemWhereClause__c, childType);
-    Set<String> whereFields = getQueryFieldsFromMetadata(matchingMeta, eval);
-    RollupMetadata metaWrapper;
-    if (childToMetaWrapper.containsKey(childType)) {
-      metaWrapper = childToMetaWrapper.get(childType);
-    } else {
-      metaWrapper = new RollupMetadata();
-      childToMetaWrapper.put(childType, metaWrapper);
-    }
-    if (possibleParentId != null) {
-      metaWrapper.recordIds.add(possibleParentId);
-    }
-    metaWrapper.possibleWhereClauses.add(matchingMeta.CalcItemWhereClause__c);
-    metaWrapper.queryFields.addAll(wherefields);
-    metaWrapper.metadata.add(matchingMeta);
-    appendQueryCount(metaWrapper, matchingMeta, matchingMeta.CalcItemWhereClause__c, childType);
-  }
-
-  private static void appendQueryCount(RollupMetadata metaWrapper, Rollup__mdt meta, String whereClause, Schema.SObjectType childType) {
-    if (metaWrapper.recordCount != RollupQueryBuilder.SENTINEL_COUNT_VALUE) {
-      String countQuery = RollupQueryBuilder.Current.getQuery(childType, new List<String>{ 'Count()' }, meta.LookupFieldOnLookupObject__c, '!=', whereClause);
-      Set<String> emptyCollection = new Set<String>();
-      Integer currentCount = getCountFromDb(countQuery, emptyCollection, emptyCollection);
-      metaWrapper.recordCount = currentCount == RollupQueryBuilder.SENTINEL_COUNT_VALUE ? currentCount : metaWrapper.recordCount + currentCount;
-    }
   }
 
   private class DeleteReparentOperation {
@@ -2132,31 +2112,23 @@ global without sharing virtual class Rollup {
     return '\nORDER BY ' + String.join(new List<String>(orderByFields), ',');
   }
 
-  private static void fillFullRecalcRollups(
-    List<FullRecalculationMetadata> fullRecalcMetas,
-    InvocationPoint invokePoint,
-    Map<SObjectType, RollupMetadata> typeToWrappedMeta,
-    Map<SObjectType, List<Rollup>> rollups
+  private static RollupMetadata getWrappedMeta(
+    Schema.SObjectType childType,
+    Map<Schema.SObjectType, RollupMetadata> typeToWrappedMeta,
+    Rollup__mdt innerMeta,
+    String whereClause
   ) {
-    for (FullRecalculationMetadata fullRecalcMeta : fullRecalcMetas) {
-      RollupMetadata wrappedMeta;
-      if (typeToWrappedMeta.containsKey(fullRecalcMeta.calcItemType) == false) {
-        wrappedMeta = new RollupMetadata();
-      } else {
-        wrappedMeta = typeToWrappedMeta.get(fullRecalcMeta.calcItemType);
-        if (rollups.containsKey(fullRecalcMeta.calcItemType)) {
-          rollups.get(fullRecalcMeta.calcItemType).clear();
-        }
-      }
-      transformFullRecalcMetadataToRollupMetadata(fullRecalcMeta, wrappedMeta);
-      appendQueryCount(wrappedMeta, fullRecalcMeta.meta, wrappedMeta.whereClause, fullRecalcMeta.calcItemType);
-      typeToWrappedMeta.put(fullRecalcMeta.calcItemType, wrappedMeta);
+    RollupMetadata wrappedMeta;
+    if (typeToWrappedMeta.containsKey(childType) == false) {
+      wrappedMeta = new RollupMetadata();
+      typeToWrappedMeta.put(childType, wrappedMeta);
+    } else {
+      wrappedMeta = typeToWrappedMeta.get(childType);
     }
-
-    List<RollupFullRecalcProcessor> fullRecalcs = transformWrappedMetadataToFullRecalcRollups(typeToWrappedMeta, invokePoint);
-    for (RollupFullRecalcProcessor fullRecalc : fullRecalcs) {
-      populateRollupByType(rollups, fullRecalc.getCalcItemType(), fullRecalc);
-    }
+    wrappedMeta.metadata.add(innerMeta);
+    RollupEvaluator.WhereFieldEvaluator eval = String.isBlank(whereClause) ? null : RollupEvaluator.getWhereEval(whereClause, childType);
+    wrappedMeta.queryFields.addAll(getQueryFieldsFromMetadata(innerMeta, eval));
+    return wrappedMeta;
   }
 
   private static List<RollupFullRecalcProcessor> transformWrappedMetadataToFullRecalcRollups(
@@ -2200,20 +2172,13 @@ global without sharing virtual class Rollup {
     return fullRecalcRollups;
   }
 
-  private static void transformFullRecalcMetadataToRollupMetadata(FullRecalculationMetadata fullRecalcMeta, RollupMetadata wrappedMeta) {
-    wrappedMeta.metadata.add(fullRecalcMeta.meta);
-    wrappedMeta.recordIds.addAll(fullRecalcMeta.wrapper.recordIds);
-    if (wrappedMeta.recordIds.isEmpty() == false) {
-      wrappedMeta.possibleWhereClauses.add(fullRecalcMeta.wrapper.getQuery());
+  private static void appendQueryCount(RollupMetadata metaWrapper, Rollup__mdt meta, String whereClause, Schema.SObjectType childType) {
+    if (metaWrapper.recordCount != RollupQueryBuilder.SENTINEL_COUNT_VALUE) {
+      String countQuery = RollupQueryBuilder.Current.getQuery(childType, new List<String>{ 'Count()' }, meta.LookupFieldOnLookupObject__c, '!=', whereClause);
+      Set<String> emptyCollection = new Set<String>();
+      Integer currentCount = getCountFromDb(countQuery, emptyCollection, emptyCollection);
+      metaWrapper.recordCount = currentCount == RollupQueryBuilder.SENTINEL_COUNT_VALUE ? currentCount : metaWrapper.recordCount + currentCount;
     }
-    wrappedMeta.parentRecordsToReset.addAll(fullRecalcMeta.wrapper.parentRecordsToReset);
-
-    RollupEvaluator.WhereFieldEvaluator whereEval = RollupEvaluator.getWhereEval(
-      fullRecalcMeta.wrapper.getQuery() +
-      (String.isNotBlank(fullRecalcMeta.meta.CalcItemWhereClause__c) ? ' AND ' + fullRecalcMeta.meta.CalcItemWhereClause__c : ''),
-      fullRecalcMeta.calcItemType
-    );
-    wrappedMeta.queryFields.addAll(getQueryFieldsFromMetadata(fullRecalcMeta.meta, whereEval));
   }
 
   private static RollupFullRecalcProcessor buildFullRecalcRollup(

--- a/rollup/core/classes/RollupCalcItemReplacer.cls
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls
@@ -50,7 +50,7 @@ public without sharing class RollupCalcItemReplacer {
     } else if (mightNeedReplacement && calcItems?.isEmpty() == false) {
       this.calcItemHashCodes.add(calcItems.hashCode());
       this.processedMetadata.addAll(metadata);
-      this.potentiallyReplaceMissingBaseFields(calcItems);
+      calcItems = this.potentiallyReplaceMissingBaseFields(calcItems);
       calcItems = this.potentiallyReplacePolymorphicWhereClauses(calcItems);
       this.replaceCalcItemsWithParentWhereClauses(calcItems);
     } else if (mightNeedReplacement == false) {
@@ -103,6 +103,7 @@ public without sharing class RollupCalcItemReplacer {
 
   @SuppressWarnings('PMD.UnusedLocalVariable')
   private List<SObject> potentiallyReplaceMissingBaseFields(List<SObject> calcItems) {
+    Map<Id, SObject> idToCalcItem = new Map<Id, SObject>(calcItems);
     if (this.baseQueryFields.containsKey(calcItems[0].getSObjectType())) {
       SObject firstItem = calcItems[0];
       Set<String> baseFields = this.baseQueryFields.get(firstItem.getSObjectType());
@@ -111,22 +112,27 @@ public without sharing class RollupCalcItemReplacer {
       }
       String queryString = RollupQueryBuilder.Current.getQuery(firstItem.getSObjectType(), new List<String>(baseFields), 'Id', '=');
       List<SObject> objIds = calcItems; // for bind variable
-      RollupLogger.Instance.log('replacing calc items with missing base fields using query string:', queryString, LoggingLevel.FINE);
+      RollupLogger.Instance.log('replacing calc items with missing base fields using query string:', queryString, LoggingLevel.DEBUG);
       List<SObject> calcItemsWithReplacement = Database.query(queryString);
-      Map<Id, SObject> idToCalcItem = new Map<Id, SObject>(calcItems);
       Map<String, Schema.SObjectField> fieldNameToDescribe = firstItem.getSObjectType().getDescribe().fields.getMap();
       for (SObject calcItemWithReplacement : calcItemsWithReplacement) {
         if (idToCalcItem.containsKey(calcItemWithReplacement.Id)) {
           SObject calcItem = idToCalcItem.get(calcItemWithReplacement.Id);
           for (String baseField : baseFields) {
-            if (fieldNameToDescribe.get(baseField)?.getDescribe().isCalculated() == false) {
-              calcItem.put(baseField, calcItemWithReplacement.get(baseField));
+            Schema.SObjectfield baseFieldToken = fieldNameToDescribe.get(baseField);
+            if (baseFieldToken?.getDescribe().isCalculated() == false) {
+              if (baseFieldToken?.getDescribe().isUpdateable()) {
+                calcItem.put(baseField, calcItemWithReplacement.get(baseField));
+              } else {
+                calcItem = serializeReplace(calcItem, baseField, calcItemWithReplacement.get(baseField));
+                idToCalcItem.put(calcItem.Id, calcItem);
+              }
             }
           }
         }
       }
     }
-    return calcItems;
+    return idToCalcItem.values();
   }
 
   private List<SObject> potentiallyReplacePolymorphicWhereClauses(List<SObject> calcItems) {

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.23';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.24';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
   private static Boolean disabledMessageHasBeenLogged = false;

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Fixes full recalc issue reported by solo-1234 where sometimes RollupParentResetProcessor was returned instead of an actual full recalc rollup",
-            "versionNumber": "1.5.23.0",
+            "versionName": "Further optimizations for full recalc rollup code paths by removing an intermediate inner class",
+            "versionNumber": "1.5.24.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Further optimizations for full recalc rollup code paths by removing an intermediate inner class",
+            "versionName": "Further optimizations for full recalc rollup code paths by removing an intermediate inner class. Fixed two issues reported by solo-1234 with full recalcs and Rollup Order Bys",
             "versionNumber": "1.5.24.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -106,6 +106,7 @@
         "apex-rollup@1.5.20-0": "04t6g000008b0ObAAI",
         "apex-rollup@1.5.21-0": "04t6g000008b0RpAAI",
         "apex-rollup@1.5.22-0": "04t6g000008b0XjAAI",
-        "apex-rollup@1.5.23-0": "04t6g000008b0YSAAY"
+        "apex-rollup@1.5.23-0": "04t6g000008b0YSAAY",
+        "apex-rollup@1.5.24-0": "04t6g000008b0Z6AAI"
     }
 }


### PR DESCRIPTION
* [Further optimizations for full recalc rollup code paths by removing an intermediate inner class](https://github.com/jamessimone/apex-rollup/commit/53096b837275c63c19f2b951018190880b797621)
* [Fixes issue](https://github.com/jamessimone/apex-rollup/commit/f629816d4558e46ad8c6f3095b20bff63daa57cc)  reported by @solo-1234 where re-submitting a full recalc job for CMDT would improperly format the Rollup Order By CMDT records
* [Fixes issue](https://github.com/jamessimone/apex-rollup/commit/04a1c73cbcf06c66a20db128c753f2be6250ff01) reported by @solo-1234 where audit fields were causing RollupCalcItemReplacer to error out