### PR TITLE
v1.5.26 - Is Full Record Set bugfix

### DIFF
--- a/extra-tests/classes/RollupCalculatorTests.cls
+++ b/extra-tests/classes/RollupCalculatorTests.cls
@@ -722,6 +722,27 @@ private class RollupCalculatorTests {
     System.assertEquals(null, calc.getReturnValue());
   }
 
+  @IsTest
+  static void sumForFullRecalcIgnoresDiffForUpdates() {
+    Opportunity opp = new Opportunity(Id = RollupTestUtils.createId(Opportunity.SObjectType), Amount = 5);
+
+    RollupCalculator calc = getCalculator(
+      0,
+      Rollup.Op.UPDATE_SUM,
+      Opportunity.Amount,
+      Account.AnnualRevenue,
+      new Rollup__mdt(CalcItem__c = 'Opportunity'),
+      '',
+      Opportunity.AccountId
+    );
+    calc.setFullRecalc(true);
+    Map<Id, Opportunity> oldOppMap = new Map<Id, Opportunity>{ opp.Id => new Opportunity(Amount = 2) };
+
+    calc.performRollup(new List<Opportunity>{ opp }, oldOppMap);
+
+    System.assertEquals(opp.Amount, calc.getReturnValue());
+  }
+
   // CONCAT tests
 
   @IsTest

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -528,6 +528,8 @@ public without sharing abstract class RollupCalculator {
         return newVal;
       } else if (matchesCurrent == false && matchesOld && this.isChangedFieldCalc == false) {
         return oldVal * Decimal.valueOf(-1).setScale(oldVal.scale());
+      } else if (this.isFullRecalc) {
+        return newVal;
       }
 
       // could be negative, could be positive ... could be 0!

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Logging infrastructure improvements, decrease in heap size for Invocable usage with large record collection sizes",
-            "versionNumber": "1.5.25.0",
+            "versionName": "Is Full Record Set bugfix for SUM",
+            "versionNumber": "1.5.26.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -64,10 +64,6 @@
             }
         },
         {
-            "path": "extra-tests",
-            "default": false
-        },
-        {
             "path": "plugins\\ExtraCodeCoverage",
             "package": "Apex Rollup - Extra Code Coverage",
             "versionName": "Updating code coverage",
@@ -78,6 +74,10 @@
                     "package": "apex-rollup@1.5.19-0"
                 }
             ]
+        },
+        {
+            "path": "extra-tests",
+            "default": false
         }
     ],
     "namespace": "",


### PR DESCRIPTION
* Fixes #370 by properly accounting for all records being present when `Is Full Record Set` flag is used for SUM/COUNT-based rollups