### PR TITLE
V1.5.28 - Parent Reset Processor bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0iTAAQ">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0inAAA">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0iTAAQ">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0inAAA">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/CustomMetadataDrivenTests.cls-meta.xml
+++ b/extra-tests/classes/CustomMetadataDrivenTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/InvocableDrivenTests.cls-meta.xml
+++ b/extra-tests/classes/InvocableDrivenTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupCalcItemReplacerTests.cls-meta.xml
+++ b/extra-tests/classes/RollupCalcItemReplacerTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupCalcItemSorterTests.cls-meta.xml
+++ b/extra-tests/classes/RollupCalcItemSorterTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupCalculatorTests.cls-meta.xml
+++ b/extra-tests/classes/RollupCalculatorTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupCurrencyInfoTests.cls-meta.xml
+++ b/extra-tests/classes/RollupCurrencyInfoTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupDateLiteralTests.cls-meta.xml
+++ b/extra-tests/classes/RollupDateLiteralTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>55.0</apiVersion>
+	<apiVersion>56.0</apiVersion>
 	<status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupEvaluatorTests.cls-meta.xml
+++ b/extra-tests/classes/RollupEvaluatorTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>55.0</apiVersion>
+  <apiVersion>56.0</apiVersion>
   <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupFieldInitializerTests.cls-meta.xml
+++ b/extra-tests/classes/RollupFieldInitializerTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupFinalizerTests.cls-meta.xml
+++ b/extra-tests/classes/RollupFinalizerTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupFlowBulkProcessorTests.cls-meta.xml
+++ b/extra-tests/classes/RollupFlowBulkProcessorTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupFlowFullRecalcDispatcherTests.cls-meta.xml
+++ b/extra-tests/classes/RollupFlowFullRecalcDispatcherTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupFullRecalcTests.cls-meta.xml
+++ b/extra-tests/classes/RollupFullRecalcTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupIntegrationTests.cls-meta.xml
+++ b/extra-tests/classes/RollupIntegrationTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupLoggerTests.cls-meta.xml
+++ b/extra-tests/classes/RollupLoggerTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupParentResetProcessorTests.cls
+++ b/extra-tests/classes/RollupParentResetProcessorTests.cls
@@ -111,4 +111,25 @@ private class RollupParentResetProcessorTests {
 
     System.assertEquals(null, ex, 'Should not fail when different parent fields present');
   }
+
+  @IsTest
+  static void usesOverrideValueWhenApplicable() {
+    insert new List<SObject>{ new Account(Name = 'Account With Null'), new Contact(LastName = 'Contact With Null') };
+    RollupParentResetProcessor processor = new RollupParentResetProcessor(
+      new List<Rollup__mdt>{
+        new Rollup__mdt(RollupFieldOnLookupObject__c = 'AnnualRevenue', LookupObject__c = 'Account', FullRecalculationDefaultNumberValue__c = 0),
+        new Rollup__mdt(RollupFieldOnLookupObject__c = 'AccountNumber', LookupObject__c = 'Account', FullRecalculationDefaultStringValue__c = 'a')
+      },
+      Account.SObjectType,
+      'SELECT Id\nFROM Account WHERE Id != null',
+      new Set<String>(),
+      null
+    );
+
+    processor.runCalc();
+
+    Account resetAccount = [SELECT AnnualRevenue, AccountNumber FROM Account];
+    System.assertEquals(0, resetAccount.AnnualRevenue);
+    System.assertEquals('a', resetAccount.AccountNumber);
+  }
 }

--- a/extra-tests/classes/RollupParentResetProcessorTests.cls-meta.xml
+++ b/extra-tests/classes/RollupParentResetProcessorTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupQueryBuilderTests.cls-meta.xml
+++ b/extra-tests/classes/RollupQueryBuilderTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupRecursionItemTests.cls-meta.xml
+++ b/extra-tests/classes/RollupRecursionItemTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupRelationshipFieldFinderTests.cls-meta.xml
+++ b/extra-tests/classes/RollupRelationshipFieldFinderTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>55.0</apiVersion>
+  <apiVersion>56.0</apiVersion>
   <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupSObjectUpdaterTests.cls-meta.xml
+++ b/extra-tests/classes/RollupSObjectUpdaterTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupTestUtils.cls-meta.xml
+++ b/extra-tests/classes/RollupTestUtils.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/classes/RollupTests.cls-meta.xml
+++ b/extra-tests/classes/RollupTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/extra-tests/flows/Rollup_Integration_Clear_Lookup_Fields.flow-meta.xml
+++ b/extra-tests/flows/Rollup_Integration_Clear_Lookup_Fields.flow-meta.xml
@@ -78,7 +78,7 @@
         </inputParameters>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </actionCalls>
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <assignments>
         <name>Add_Records_To_Collections</name>
         <label>Add Records To Collections</label>

--- a/extra-tests/flows/Rollup_Integration_Multiple_Deferred_Case_Rollups.flow-meta.xml
+++ b/extra-tests/flows/Rollup_Integration_Multiple_Deferred_Case_Rollups.flow-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
     <actionCalls>
         <name>Add_matching_description_to_Site</name>
@@ -333,7 +333,7 @@
         </inputParameters>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </actionCalls>
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <assignments>
         <name>Add_case_and_prior_case_to_collections</name>
         <label>Add case and prior case to collections</label>

--- a/extra-tests/flows/Rollup_Integration_Parent_Where_Clause_Filtering.flow-meta.xml
+++ b/extra-tests/flows/Rollup_Integration_Parent_Where_Clause_Filtering.flow-meta.xml
@@ -85,7 +85,7 @@
         </inputParameters>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </actionCalls>
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <assignments>
         <name>Add_to_collections</name>
         <label>Add to collections</label>

--- a/extra-tests/triggers/AccountTrigger.trigger-meta.xml
+++ b/extra-tests/triggers/AccountTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>55.0</apiVersion>
+  <apiVersion>56.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/extra-tests/triggers/ApplicationLogTrigger.trigger-meta.xml
+++ b/extra-tests/triggers/ApplicationLogTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>55.0</apiVersion>
+  <apiVersion>56.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/extra-tests/triggers/ApplicationTrigger.trigger-meta.xml
+++ b/extra-tests/triggers/ApplicationTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>55.0</apiVersion>
+  <apiVersion>56.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/extra-tests/triggers/ParentApplicationTrigger.trigger-meta.xml
+++ b/extra-tests/triggers/ParentApplicationTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>55.0</apiVersion>
+  <apiVersion>56.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/extra-tests/triggers/RollupChildTrigger.trigger-meta.xml
+++ b/extra-tests/triggers/RollupChildTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>55.0</apiVersion>
+  <apiVersion>56.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.27",
+  "version": "1.5.28",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/plugins/CustomObjectRollupLogger/classes/RollupCustomObjectLogger.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/classes/RollupCustomObjectLogger.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/classes/RollupLogBatchPurger.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/classes/RollupLogBatchPurger.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/classes/RollupLogControl.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/classes/RollupLogControl.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/classes/RollupLogEventHandler.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/classes/RollupLogEventHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/classes/RollupPurgerSchedulable.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/classes/RollupPurgerSchedulable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/tests/RollupCustomObjectLoggerTests.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/tests/RollupCustomObjectLoggerTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/tests/RollupLogBatchPurgerTests.cls-meta.xml
+++ b/plugins/CustomObjectRollupLogger/tests/RollupLogBatchPurgerTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/CustomObjectRollupLogger/triggers/RollupLogEventTrigger.trigger-meta.xml
+++ b/plugins/CustomObjectRollupLogger/triggers/RollupLogEventTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>55.0</apiVersion>
+  <apiVersion>56.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/plugins/NebulaLogger/classes/RollupNebulaLoggerAdapter.cls-meta.xml
+++ b/plugins/NebulaLogger/classes/RollupNebulaLoggerAdapter.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/NebulaLogger/tests/RollupNebulaLoggerAdapterTest.cls-meta.xml
+++ b/plugins/NebulaLogger/tests/RollupNebulaLoggerAdapterTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/RollupCallback/README.md
+++ b/plugins/RollupCallback/README.md
@@ -43,7 +43,7 @@ export default class RollupChangeNotifier extends LightningElement {
 <!-- in rollupChangeNotifier.js-meta.xml -->
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Rollup Change Notifier</masterLabel>
     <targets>

--- a/plugins/RollupCallback/classes/RollupDispatch.cls-meta.xml
+++ b/plugins/RollupCallback/classes/RollupDispatch.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/plugins/RollupCallback/tests/RollupDispatchTests.cls-meta.xml
+++ b/plugins/RollupCallback/tests/RollupDispatchTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0iOAAQ">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0isAAA">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0iOAAQ">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0isAAA">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -18,7 +18,7 @@
     ],
     "namespace": "please",
     "sfdcLoginUrl": "https://login.salesforce.com",
-    "sourceApiVersion": "55.0",
+    "sourceApiVersion": "56.0",
     "packageAliases": {
         "apex-rollup-namespaced": "0Ho6g000000PBMjCAO",
         "apex-rollup-namespaced@1.0.0-0": "04t6g000008b0iOAAQ"

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "First finalized namespaced package version of Apex Rollup using the please__ namespace",
-            "versionNumber": "1.0.0.0",
+            "versionName": "Winter 23 API version upgrade",
+            "versionNumber": "1.0.1.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -21,6 +21,7 @@
     "sourceApiVersion": "56.0",
     "packageAliases": {
         "apex-rollup-namespaced": "0Ho6g000000PBMjCAO",
-        "apex-rollup-namespaced@1.0.0-0": "04t6g000008b0iOAAQ"
+        "apex-rollup-namespaced@1.0.0-0": "04t6g000008b0iOAAQ",
+        "apex-rollup-namespaced@1.0.1-0": "04t6g000008b0isAAA"
     }
 }

--- a/rollup/app/lwc/recalculateParentRollupFlexipage/recalculateParentRollupFlexipage.js-meta.xml
+++ b/rollup/app/lwc/recalculateParentRollupFlexipage/recalculateParentRollupFlexipage.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Recalc Rollups Button</masterLabel>
     <targets>

--- a/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js-meta.xml
+++ b/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
       <target>lightning__AppPage</target>

--- a/rollup/app/lwc/rollupOrderBy/rollupOrderBy.js-meta.xml
+++ b/rollup/app/lwc/rollupOrderBy/rollupOrderBy.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/rollup/app/lwc/rollupUtils/rolupUtils.js-meta.xml
+++ b/rollup/app/lwc/rollupUtils/rolupUtils.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/rollup/core/classes/Rollup.cls-meta.xml
+++ b/rollup/core/classes/Rollup.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupAsyncProcessor.cls-meta.xml
+++ b/rollup/core/classes/RollupAsyncProcessor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupCalcItemReplacer.cls-meta.xml
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupCalcItemSorter.cls-meta.xml
+++ b/rollup/core/classes/RollupCalcItemSorter.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupCalculator.cls-meta.xml
+++ b/rollup/core/classes/RollupCalculator.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupComparer.cls-meta.xml
+++ b/rollup/core/classes/RollupComparer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>55.0</apiVersion>
+	<apiVersion>56.0</apiVersion>
 	<status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupCurrencyInfo.cls-meta.xml
+++ b/rollup/core/classes/RollupCurrencyInfo.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>55.0</apiVersion>
+	<apiVersion>56.0</apiVersion>
 	<status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupDateLiteral.cls-meta.xml
+++ b/rollup/core/classes/RollupDateLiteral.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>55.0</apiVersion>
+	<apiVersion>56.0</apiVersion>
 	<status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupDeferredFullRecalcProcessor.cls-meta.xml
+++ b/rollup/core/classes/RollupDeferredFullRecalcProcessor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>55.0</apiVersion>
+	<apiVersion>56.0</apiVersion>
 	<status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupEvaluator.cls-meta.xml
+++ b/rollup/core/classes/RollupEvaluator.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>55.0</apiVersion>
+	<apiVersion>56.0</apiVersion>
 	<status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFieldInitializer.cls-meta.xml
+++ b/rollup/core/classes/RollupFieldInitializer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFinalizer.cls-meta.xml
+++ b/rollup/core/classes/RollupFinalizer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFlowBulkProcessor.cls-meta.xml
+++ b/rollup/core/classes/RollupFlowBulkProcessor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFlowBulkSaver.cls-meta.xml
+++ b/rollup/core/classes/RollupFlowBulkSaver.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFlowFullRecalcDispatcher.cls-meta.xml
+++ b/rollup/core/classes/RollupFlowFullRecalcDispatcher.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls-meta.xml
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupFullRecalcProcessor.cls-meta.xml
+++ b/rollup/core/classes/RollupFullRecalcProcessor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.27';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.28';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupLogger.cls-meta.xml
+++ b/rollup/core/classes/RollupLogger.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupMetaPicklists.cls-meta.xml
+++ b/rollup/core/classes/RollupMetaPicklists.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>55.0</apiVersion>
+  <apiVersion>56.0</apiVersion>
   <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupParentResetProcessor.cls
+++ b/rollup/core/classes/RollupParentResetProcessor.cls
@@ -69,7 +69,8 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
     for (SObject parentItem : parentItems) {
       for (Rollup__mdt rollupMeta : this.rollupMetas) {
         if (this.parentRollupFieldHasBeenReset(rollupMeta, parentItem) == false && parentFields.containsKey(rollupMeta.RollupFieldOnLookupObject__c)) {
-          parentItem.put(rollupMeta.RollupFieldOnLookupObject__c, null);
+          Object resetVal = getDefaultValue(rollupMeta);
+          parentItem.put(rollupMeta.RollupFieldOnLookupObject__c, resetVal);
         }
       }
     }
@@ -107,11 +108,27 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
         SObjectField token = RollupFieldInitializer.Current.getSObjectFieldByName(fieldTokens, meta.RollupFieldOnLookupObject__c);
         if (token?.getDescribe().isFilterable() == true) {
           isValidRun = isValidRun || true;
-          additionalFilters += meta.RollupFieldOnLookupObject__c + (' != null' + orClause);
+          Object searchObject = getDefaultValue(meta);
+          String searchValue = String.valueOf(searchObject);
+          if (searchObject instanceof String) {
+            searchValue = '\'' + searchValue + '\'';
+          }
+
+          additionalFilters += meta.RollupFieldOnLookupObject__c + (' != ' + searchValue + orClause);
         }
       }
     }
 
     return isValidRun ? localQueryString + '\nAND (' + additionalFilters.removeEnd(orClause) + ')' : localQueryString;
+  }
+
+  private static Object getDefaultValue(Rollup__mdt meta) {
+    Object resetVal = null;
+    if (meta.FullRecalculationDefaultNumberValue__c != null) {
+      resetVal = meta.FullRecalculationDefaultNumberValue__c;
+    } else if (meta.FullRecalculationDefaultStringValue__c != null) {
+      resetVal = meta.FullRecalculationDefaultStringValue__c;
+    }
+    return resetVal;
   }
 }

--- a/rollup/core/classes/RollupParentResetProcessor.cls-meta.xml
+++ b/rollup/core/classes/RollupParentResetProcessor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupPlugin.cls-meta.xml
+++ b/rollup/core/classes/RollupPlugin.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupQueryBuilder.cls-meta.xml
+++ b/rollup/core/classes/RollupQueryBuilder.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupRecursionItem.cls-meta.xml
+++ b/rollup/core/classes/RollupRecursionItem.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupRelationshipFieldFinder.cls-meta.xml
+++ b/rollup/core/classes/RollupRelationshipFieldFinder.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>55.0</apiVersion>
+  <apiVersion>56.0</apiVersion>
   <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupSObjectUpdater.cls-meta.xml
+++ b/rollup/core/classes/RollupSObjectUpdater.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupSchedulable.cls-meta.xml
+++ b/rollup/core/classes/RollupSchedulable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>55.0</apiVersion>
+  <apiVersion>56.0</apiVersion>
   <status>Active</status>
 </ApexClass>

--- a/scripts/generatePackage.ps1
+++ b/scripts/generatePackage.ps1
@@ -157,7 +157,7 @@ function Generate() {
   Update-Package-Install-Links $readmePath $currentPackageVersionId
 
   if ($shouldCreateNamespacedPackage -eq $true -and "apex-rollup" -eq $packageName) {
-    # New-Namespaced-Package
+    New-Namespaced-Package
   }
 
   Write-Host "Finished creating $packageName package version!" -ForegroundColor Green

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "TODO",
+            "versionName": "Winter 23 API version upgrade",
             "versionNumber": "1.5.28.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
@@ -83,7 +83,7 @@
     ],
     "namespace": "",
     "sfdcLoginUrl": "https://login.salesforce.com",
-    "sourceApiVersion": "55.0",
+    "sourceApiVersion": "56.0",
     "packageAliases": {
         "Apex Rollup - Custom Logger": "0Ho6g000000Gn8ZCAS",
         "Apex Rollup - Custom Logger@0.0.11-0": "04t6g000008SirvAAC",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -101,6 +101,7 @@
         "apex-rollup": "0Ho6g000000TNcOCAW",
         "apex-rollup@1.5.25-0": "04t6g000008b0a9AAA",
         "apex-rollup@1.5.26-0": "04t6g000008b0ceAAA",
-        "apex-rollup@1.5.27-0": "04t6g000008b0iTAAQ"
+        "apex-rollup@1.5.27-0": "04t6g000008b0iTAAQ",
+        "apex-rollup@1.5.28-0": "04t6g000008b0inAAA"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "First finalized namespaced package version of Apex Rollup using the please__ namespace",
-            "versionNumber": "1.5.27.0",
+            "versionName": "TODO",
+            "versionNumber": "1.5.28.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
* Winter 23 API version update
* Fixes a bug reported by Ellatan where the RollupParentResetProcessor would not use the full recalculation default values when supplied from flow/CMDT