### PR TITLE
V1.5.30 - Proper deferrals for parents with 50k+ children

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0nFAAQ">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLmvAAE">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0nFAAQ">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLmvAAE">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLmvAAE">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnAAAU">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLmvAAE">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnAAAU">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnKAAU">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnjAAE">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnKAAU">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnjAAE">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnAAAU">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnKAAU">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnAAAU">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnKAAU">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/InvocableDrivenTests.cls
+++ b/extra-tests/classes/InvocableDrivenTests.cls
@@ -11,7 +11,6 @@ private class InvocableDrivenTests {
   static void shouldWorkWithRefreshContext() {
     // Driven by extra-tests/flows/Rollup_Integration_Multiple_Deferred_Case_Rollups.flow-meta.xml
     Account acc = [SELECT Id FROM Account];
-
     // Description and Subject both are referenced in the Flow
     Case matchesFlow = new Case(Description = 'Name Match', AccountId = acc.Id, Subject = 'Refresh Test');
     Case nonMatch = new Case(Description = 'Non match', AccountId = acc.Id, Subject = 'Child Object Where Clause test');
@@ -47,7 +46,6 @@ private class InvocableDrivenTests {
     Rollup.defaultControl = new RollupControl__mdt(MaxLookupRowsBeforeBatching__c = 1, IsRollupLoggingEnabled__c = true, BatchChunkSize__c = 1000);
     // Driven by extra-tests/flows/Rollup_Integration_Multiple_Deferred_Case_Rollups.flow-meta.xml
     Account acc = [SELECT Id FROM Account];
-
     // Description and Subject both are referenced in the Flow
     Case matchesFlow = new Case(Description = 'Name Match', AccountId = acc.Id, Subject = 'Refresh Test');
 

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -2032,6 +2032,54 @@ private class RollupFullRecalcTests {
   }
 
   @IsTest
+  static void shouldCacheRetrievedCalcItemsBetweenFullRecalcRunsCount() {
+    // additionalCalcItemCount shortcuts a Database.countQuery() call in RollupAsyncProcessor
+    // which reduces the MaxNumberOfQueries__c needed below
+    RollupAsyncProcessor.additionalCalcItemCount = 1;
+    Rollup.defaultControl = new RollupControl__mdt(
+      BatchChunkSize__c = 1,
+      MaxNumberOfQueries__c = 6,
+      IsRollupLoggingEnabled__c = true,
+      ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.Synchronous
+    );
+    Account acc = [SELECT Id FROM Account];
+
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
+      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 1, Name = 'One'),
+      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 1, Name = 'Two')
+    };
+    insert cpas;
+
+    RollupFullBatchRecalculator fullRecalc = new RollupFullBatchRecalculator(
+      'SELECT Id, PreferenceRank FROM ContactPointAddress',
+      Rollup.InvocationPoint.FROM_APEX,
+      new List<Rollup__mdt>{
+        new Rollup__mdt(
+          CalcItem__c = 'ContactPointAddress',
+          RollupFieldOnCalcItem__c = 'PreferenceRank',
+          LookupFieldOnCalcItem__c = 'ParentId',
+          LookupObject__c = 'Account',
+          LookupFieldOnLookupObject__c = 'Id',
+          RollupFieldOnLookupObject__c = 'AnnualRevenue',
+          RollupOperation__c = 'Count'
+        )
+      },
+      ContactPointAddress.SObjectType,
+      new Set<String>(),
+      null
+    );
+    fullRecalc.addOrderBys(new List<RollupOrderBy__mdt>(), ContactPointAddress.PreferenceRank);
+    // since we can't have more than one batch chunk run in the tests, but we need to test logic in the execute method
+    // we'll call that method twice directly
+    fullRecalc.execute(null, new List<ContactPointAddress>{ cpas[0] });
+    fullRecalc.execute(null, new List<ContactPointAddress>{ cpas[1] });
+
+    acc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(2, acc.AnnualRevenue, 'Should have included all calc items in both runs without double-counting or incorrectly summing');
+    System.assertEquals(true, Rollup.CACHED_ROLLUPS.isEmpty(), 'second execute call should have run fully');
+  }
+
+  @IsTest
   static void limitsFullBatchRecalcCachedItemsProperly() {
     Rollup.defaultControl = new RollupControl__mdt(
       BatchChunkSize__c = 1,

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -2032,54 +2032,6 @@ private class RollupFullRecalcTests {
   }
 
   @IsTest
-  static void shouldCacheRetrievedCalcItemsBetweenFullRecalcRunsCount() {
-    // additionalCalcItemCount shortcuts a Database.countQuery() call in RollupAsyncProcessor
-    // which reduces the MaxNumberOfQueries__c needed below
-    RollupAsyncProcessor.additionalCalcItemCount = 1;
-    Rollup.defaultControl = new RollupControl__mdt(
-      BatchChunkSize__c = 1,
-      MaxNumberOfQueries__c = 6,
-      IsRollupLoggingEnabled__c = true,
-      ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.Synchronous
-    );
-    Account acc = [SELECT Id FROM Account];
-
-    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
-      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 1, Name = 'One'),
-      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 1, Name = 'Two')
-    };
-    insert cpas;
-
-    RollupFullBatchRecalculator fullRecalc = new RollupFullBatchRecalculator(
-      'SELECT Id, PreferenceRank FROM ContactPointAddress',
-      Rollup.InvocationPoint.FROM_APEX,
-      new List<Rollup__mdt>{
-        new Rollup__mdt(
-          CalcItem__c = 'ContactPointAddress',
-          RollupFieldOnCalcItem__c = 'PreferenceRank',
-          LookupFieldOnCalcItem__c = 'ParentId',
-          LookupObject__c = 'Account',
-          LookupFieldOnLookupObject__c = 'Id',
-          RollupFieldOnLookupObject__c = 'AnnualRevenue',
-          RollupOperation__c = 'Count'
-        )
-      },
-      ContactPointAddress.SObjectType,
-      new Set<String>(),
-      null
-    );
-    fullRecalc.addOrderBys(new List<RollupOrderBy__mdt>(), ContactPointAddress.PreferenceRank);
-    // since we can't have more than one batch chunk run in the tests, but we need to test logic in the execute method
-    // we'll call that method twice directly
-    fullRecalc.execute(null, new List<ContactPointAddress>{ cpas[0] });
-    fullRecalc.execute(null, new List<ContactPointAddress>{ cpas[1] });
-
-    acc = [SELECT AnnualRevenue FROM Account];
-    System.assertEquals(2, acc.AnnualRevenue, 'Should have included all calc items in both runs without double-counting or incorrectly summing');
-    System.assertEquals(true, Rollup.CACHED_ROLLUPS.isEmpty(), 'second execute call should have run fully');
-  }
-
-  @IsTest
   static void shouldFullRecalcWithInWhereClauses() {
     RollupParentResetProcessor.maxQueryRows = 0;
     RollupAsyncProcessor.shouldRunAsBatch = true;

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -2032,6 +2032,56 @@ private class RollupFullRecalcTests {
   }
 
   @IsTest
+  static void limitsFullBatchRecalcCachedItemsProperly() {
+    Rollup.defaultControl = new RollupControl__mdt(
+      BatchChunkSize__c = 1,
+      MaxNumberOfQueries__c = 100,
+      IsRollupLoggingEnabled__c = true,
+      ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.Synchronous,
+      MaxQueryRows__c = 2, // forced to pick up only one row at a time
+      MaxRollupRetries__c = 1
+    );
+    Account acc = [SELECT Id FROM Account];
+
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
+      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 1, Name = 'One'),
+      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 2, Name = 'Two'),
+      new ContactPointAddress(ParentId = acc.Id, PreferenceRank = 3, Name = 'Three')
+    };
+    insert cpas;
+
+    RollupFullBatchRecalculator fullRecalc = new RollupFullBatchRecalculator(
+      'SELECT Id, PreferenceRank FROM ContactPointAddress',
+      Rollup.InvocationPoint.FROM_APEX,
+      new List<Rollup__mdt>{
+        new Rollup__mdt(
+          CalcItem__c = 'ContactPointAddress',
+          RollupFieldOnCalcItem__c = 'PreferenceRank',
+          LookupFieldOnCalcItem__c = 'ParentId',
+          LookupObject__c = 'Account',
+          LookupFieldOnLookupObject__c = 'Id',
+          RollupFieldOnLookupObject__c = 'AnnualRevenue',
+          RollupOperation__c = 'SUM'
+        )
+      },
+      ContactPointAddress.SObjectType,
+      new Set<String>(),
+      null
+    );
+    RollupLimits.stubbedQueryRows = 1;
+
+    Test.startTest();
+    // first batch executes with cpas[0] and picks up cpas[1] in retrieveAdditionalCalcItems
+    // it should then get deferred and re-execute to pick up cpas[2]
+    fullRecalc.execute(null, new List<ContactPointAddress>{ cpas[0] });
+    Test.stopTest();
+
+    acc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(6, acc.AnnualRevenue, 'Should have included all calc items in both runs without double-counting or incorrectly summing');
+    System.assertEquals(true, Rollup.CACHED_ROLLUPS.isEmpty(), 'all deferrals should have been run');
+  }
+
+  @IsTest
   static void shouldFullRecalcWithInWhereClauses() {
     RollupParentResetProcessor.maxQueryRows = 0;
     RollupAsyncProcessor.shouldRunAsBatch = true;

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -3719,4 +3719,14 @@ private class RollupTests {
     System.assertEquals(acc.Id, updatedAccount.Id, 'Top-level parent should have been updated: ' + JSON.serialize(updatedAccount));
     System.assertEquals('One', updatedAccount.Name);
   }
+
+  @IsTest
+  static void encapsulatesNamespaceInfoProperly() {
+    Rollup.NamespaceInfo namespaceInfo = Rollup.getNamespaceInfo();
+
+    String rollupObjectName = Rollup__mdt.SObjectType.getDescribe().getName();
+    System.assertEquals(rollupObjectName + '.' + Rollup__mdt.RollupOperation__c.getDescribe().getName(), nameSpaceInfo.safeRollupOperationField);
+    System.assertEquals(rollupObjectName, nameSpaceInfo.safeObjectName);
+    System.assertEquals(RollupTests.class.getName().substringBefore('RollupTests'), nameSpaceInfo.namespace);
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.29",
+  "version": "1.5.30",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/plugins/RollupCallback/profiles/Admin.profile-meta.xml
+++ b/plugins/RollupCallback/profiles/Admin.profile-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <Profile xmlns="http://soap.sforce.com/2006/04/metadata">
     <fieldPermissions>
         <editable>true</editable>
@@ -11,7 +11,7 @@
         <allowEdit>true</allowEdit>
         <allowRead>true</allowRead>
         <modifyAllRecords>true</modifyAllRecords>
-        <object>RollupcallbackEvent__e</object>
+        <object>RollupCallbackEvent__e</object>
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>
     <userLicense>Salesforce</userLicense>

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnFAAU">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnPAAU">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnFAAU">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnPAAU">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLn0AAE">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnFAAU">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLn0AAE">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnFAAU">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnPAAU">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnoAAE">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnPAAU">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnoAAE">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0nKAAQ">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLn0AAE">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008b0nKAAQ">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLn0AAE">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -24,6 +24,6 @@
         "apex-rollup-namespaced@1.0.0-0": "04t6g000008b0iOAAQ",
         "apex-rollup-namespaced@1.0.1-0": "04t6g000008b0isAAA",
         "apex-rollup-namespaced@1.0.2-0": "04t6g000008b0nKAAQ",
-        "apex-rollup-namespaced@1.0.3-0": "04t6g000007zLn0AAE"
+        "apex-rollup-namespaced@1.0.3-0": "04t6g000007zLnFAAU"
     }
 }

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Fixes a bug with batch full recalcs that use a small Batch Chunk Size ",
-            "versionNumber": "1.0.2.0",
+            "versionName": "Fixes an issue where full batch recalculations could fail to pick up all calc items when the calc item amount for any given parent exceeded the Max Query Row limit",
+            "versionNumber": "1.0.3.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -23,6 +23,7 @@
         "apex-rollup-namespaced": "0Ho6g000000PBMjCAO",
         "apex-rollup-namespaced@1.0.0-0": "04t6g000008b0iOAAQ",
         "apex-rollup-namespaced@1.0.1-0": "04t6g000008b0isAAA",
-        "apex-rollup-namespaced@1.0.2-0": "04t6g000008b0nKAAQ"
+        "apex-rollup-namespaced@1.0.2-0": "04t6g000008b0nKAAQ",
+        "apex-rollup-namespaced@1.0.3-0": "04t6g000007zLn0AAE"
     }
 }

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -24,6 +24,6 @@
         "apex-rollup-namespaced@1.0.0-0": "04t6g000008b0iOAAQ",
         "apex-rollup-namespaced@1.0.1-0": "04t6g000008b0isAAA",
         "apex-rollup-namespaced@1.0.2-0": "04t6g000008b0nKAAQ",
-        "apex-rollup-namespaced@1.0.3-0": "04t6g000007zLnPAAU"
+        "apex-rollup-namespaced@1.0.3-0": "04t6g000007zLnoAAE"
     }
 }

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -24,6 +24,6 @@
         "apex-rollup-namespaced@1.0.0-0": "04t6g000008b0iOAAQ",
         "apex-rollup-namespaced@1.0.1-0": "04t6g000008b0isAAA",
         "apex-rollup-namespaced@1.0.2-0": "04t6g000008b0nKAAQ",
-        "apex-rollup-namespaced@1.0.3-0": "04t6g000007zLnFAAU"
+        "apex-rollup-namespaced@1.0.3-0": "04t6g000007zLnPAAU"
     }
 }

--- a/rollup/app/lwc/__mockData__/index.js
+++ b/rollup/app/lwc/__mockData__/index.js
@@ -19,4 +19,10 @@ const mockRollupMetadata = {
   ]
 };
 
+export const mockNamespaceInfo = {
+  namespace: '',
+  safeRollupOperationField: 'Rollup__mdt.RollupOperation__c',
+  safeObjectName: 'Rollup__mdt'
+};
+
 export const mockMetadata = mockRollupMetadata;

--- a/rollup/app/lwc/recalculateParentRollupFlexipage/__tests__/recalculateParentRollupFlexipage.test.js
+++ b/rollup/app/lwc/recalculateParentRollupFlexipage/__tests__/recalculateParentRollupFlexipage.test.js
@@ -177,4 +177,31 @@ describe('recalc parent rollup from flexipage tests', () => {
       invokePointName: 'FROM_SINGULAR_PARENT_RECALC_LWC'
     });
   });
+
+  it('detects namespace properly', async () => {
+    const parentRecalcEl = createElement('c-recalculate-parent-rollup-flexipage', {
+      is: RecalculateParentRollupFlexipage
+    });
+
+    const FAKE_RECORD_ID = '00100000000001';
+    const matchingMetadata = metadata[Object.keys(metadata)[0]];
+    delete matchingMetadata[0].CalcItem__r;
+    matchingMetadata[0].please__LookupObject__c = matchingMetadata[0].LookupObject__c;
+    delete matchingMetadata[0].LookupObject__c;
+    parentRecalcEl.objectApiName = matchingMetadata[0].please__LookupObject__c;
+    parentRecalcEl.recordId = FAKE_RECORD_ID;
+
+    document.body.appendChild(parentRecalcEl);
+    await flushPromises().then(() => {
+      parentRecalcEl.shadowRoot.querySelector('lightning-button').click();
+    });
+    await flushPromises();
+
+    matchingMetadata[0].CalcItemWhereClause__c = " ||| AccountId = '" + FAKE_RECORD_ID + "'";
+    expect(parentRecalcEl.shadowRoot.querySelector('lightning-spinner')).toBeFalsy();
+    expect(performSerializedBulkFullRecalc.mock.calls[0][0]).toEqual({
+      serializedMetadata: JSON.stringify(matchingMetadata),
+      invokePointName: 'FROM_SINGULAR_PARENT_RECALC_LWC'
+    });
+  });
 });

--- a/rollup/app/lwc/recalculateParentRollupFlexipage/recalculateParentRollupFlexipage.js
+++ b/rollup/app/lwc/recalculateParentRollupFlexipage/recalculateParentRollupFlexipage.js
@@ -1,5 +1,6 @@
 import { api, LightningElement } from 'lwc';
 import performSerializedBulkFullRecalc from '@salesforce/apex/Rollup.performSerializedBulkFullRecalc';
+import getNamespaceInfo from '@salesforce/apex/Rollup.getNamespaceInfo';
 
 import { getRollupMetadata } from 'c/rollupUtils';
 
@@ -13,9 +14,11 @@ export default class RecalculateParentRollupFlexipage extends LightningElement {
   isValid = false;
 
   _matchingMetas = [];
+  _namespaceInfo = {};
 
   async connectedCallback() {
     try {
+      this._namespaceInfo = await getNamespaceInfo();
       const metadata = await getRollupMetadata();
       this._fillValidMetadata(metadata);
     } catch (err) {
@@ -47,7 +50,7 @@ export default class RecalculateParentRollupFlexipage extends LightningElement {
         // there can be many different matches across metadata which share the same parent object
         // build up a list of matching metas and append to their CalcItemWhereClause__c the
         // parent recordId
-        if (rollupMetadata.LookupObject__c === this.objectApiName || rollupMetadata.please__LookupObject__c === this.objectApiName) {
+        if (rollupMetadata[this._getNamespaceSafeFieldName('LookupObject__c')] === this.objectApiName) {
           this._addMatchingMetadata(rollupMetadata);
         }
       });
@@ -57,16 +60,21 @@ export default class RecalculateParentRollupFlexipage extends LightningElement {
   }
 
   _addMatchingMetadata(metadata) {
-    const parentLookup = metadata.GrandparentRelationshipFieldPath__c
-      ? metadata.GrandparentRelationshipFieldPath__c.substring(0, metadata.GrandparentRelationshipFieldPath__c.lastIndexOf('.')) + '.Id'
-      : metadata.LookupFieldOnCalcItem__c;
+    const grandparentRelationshipFieldPath = this._getNamespaceSafeFieldName('GrandparentRelationshipFieldPath__c');
+    const lookupFieldOnCalcItem = this._getNamespaceSafeFieldName('LookupFieldOnCalcItem__c');
+    const parentLookup = metadata[grandparentRelationshipFieldPath]
+      ? metadata[grandparentRelationshipFieldPath].substring(0, metadata[grandparentRelationshipFieldPath].lastIndexOf('.')) + '.Id'
+      : metadata[lookupFieldOnCalcItem];
     const equalsParent = parentLookup + " = '" + this.recordId + "'";
 
-    if (metadata.CalcItemWhereClause__c && metadata.CalcItemWhereClause__c.length > 0) {
-      metadata.CalcItemWhereClause__c = metadata.CalcItemWhereClause__c + DELIMITER + equalsParent;
+    const calcItemWhereClause = this._getNamespaceSafeFieldName('CalcItemWhereClause__c');
+    if (metadata[calcItemWhereClause] && metadata[calcItemWhereClause].length > 0) {
+      metadata[calcItemWhereClause] = metadata[calcItemWhereClause] + DELIMITER + equalsParent;
     } else {
-      metadata.CalcItemWhereClause__c = DELIMITER + equalsParent;
+      metadata[calcItemWhereClause] = DELIMITER + equalsParent;
     }
     this._matchingMetas.push(metadata);
   }
+
+  _getNamespaceSafeFieldName = fieldName => `${this._namespaceInfo.namespace + fieldName}`;
 }

--- a/rollup/app/lwc/recalculateParentRollupFlexipage/recalculateParentRollupFlexipage.js
+++ b/rollup/app/lwc/recalculateParentRollupFlexipage/recalculateParentRollupFlexipage.js
@@ -47,7 +47,7 @@ export default class RecalculateParentRollupFlexipage extends LightningElement {
         // there can be many different matches across metadata which share the same parent object
         // build up a list of matching metas and append to their CalcItemWhereClause__c the
         // parent recordId
-        if (rollupMetadata.LookupObject__c === this.objectApiName) {
+        if (rollupMetadata.LookupObject__c === this.objectApiName || rollupMetadata.please__LookupObject__c === this.objectApiName) {
           this._addMatchingMetadata(rollupMetadata);
         }
       });

--- a/rollup/app/lwc/rollupForceRecalculation/__tests__/rollupForceRecalculation.test.js
+++ b/rollup/app/lwc/rollupForceRecalculation/__tests__/rollupForceRecalculation.test.js
@@ -128,7 +128,7 @@ describe('Rollup force recalc tests', () => {
         CalcItemWhereClause__c: '',
         ConcatDelimiter__c: '',
         SplitConcatDelimiterOnCalcItem__c: false,
-        LimitAmount__c: 0,
+        LimitAmount__c: null,
         GrandparentRelationshipFieldPath__c: 'Something__r.SomethingElse__r.Name',
         OneToManyGrandparentFields__c: 'Something__c.SomethingElse__c, SomethingElse__c.Name'
       })

--- a/rollup/app/lwc/rollupForceRecalculation/__tests__/rollupForceRecalculation.test.js
+++ b/rollup/app/lwc/rollupForceRecalculation/__tests__/rollupForceRecalculation.test.js
@@ -1,5 +1,6 @@
 import { createElement } from 'lwc';
 import { getObjectInfo } from 'lightning/uiObjectInfoApi';
+import getNamespaceSafeRollupOperationField from '@salesforce/apex/Rollup.getNamespaceSafeRollupOperationField';
 import performSerializedFullRecalculation from '@salesforce/apex/Rollup.performSerializedFullRecalculation';
 import performSerializedBulkFullRecalc from '@salesforce/apex/Rollup.performSerializedBulkFullRecalc';
 import getBatchRollupStatus from '@salesforce/apex/Rollup.getBatchRollupStatus';
@@ -13,6 +14,25 @@ const mockGetObjectInfo = require('./data/rollupCMDTWireAdapter.json');
 function flushPromises() {
   return new Promise(resolve => setTimeout(resolve, 0));
 }
+
+async function mountComponent() {
+  const fullRecalc = createElement('c-rollup-force-recalculation', {
+    is: RollupForceRecalculation
+  });
+  document.body.appendChild(fullRecalc);
+  await flushPromises('initial rendering cycle');
+  return fullRecalc;
+}
+
+jest.mock(
+  '@salesforce/apex/Rollup.getNamespaceSafeRollupOperationField',
+  () => {
+    return {
+      default: jest.fn()
+    };
+  },
+  { virtual: true }
+);
 
 jest.mock(
   '@salesforce/apex/Rollup.getRollupMetadataByCalcItem',
@@ -53,9 +73,70 @@ function setElementValue(element, value, isCombobox = false) {
   element.dispatchEvent(new CustomEvent(eventName, isCombobox ? { detail: { value: element.value } } : undefined));
 }
 
+async function submitsFormDataWithNamespace(namespace = '') {
+  const fullRecalc = await mountComponent();
+
+  // validate that toggle is not checked
+  const toggle = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="cmdt-toggle"]');
+  expect(toggle).not.toBeNull();
+  expect(fullRecalc.isCMDTRecalc).toBeFalsy();
+
+  const calcItemSObjectName = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="CalcItem__c"]');
+  setElementValue(calcItemSObjectName, 'Contact');
+
+  const opFieldOnCalcItem = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="RollupFieldOnCalcItem__c"]');
+  setElementValue(opFieldOnCalcItem, 'FirstName');
+
+  const lookupFieldOnCalcItem = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="LookupFieldOnCalcItem__c"]');
+  setElementValue(lookupFieldOnCalcItem, 'AccountId');
+
+  const lookupFieldOnLookupObject = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="LookupFieldOnLookupObject__c"]');
+  setElementValue(lookupFieldOnLookupObject, 'Id');
+
+  const rollupFieldOnLookupObject = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="RollupFieldOnLookupObject__c"]');
+  setElementValue(rollupFieldOnLookupObject, 'Name');
+
+  const lookupSObjectName = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="LookupObject__c"]');
+  setElementValue(lookupSObjectName, 'Account');
+
+  const operationName = fullRecalc.shadowRoot.querySelector('lightning-combobox[data-id="RollupOperation__c"]');
+  setElementValue(operationName, 'CONCAT', true);
+
+  const grandparentFieldPath = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="GrandparentRelationshipFieldPath__c"]');
+  setElementValue(grandparentFieldPath, 'Something__r.SomethingElse__r.Name');
+
+  const oneToManyGrandparentFields = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="OneToManyGrandparentFields__c"]');
+  setElementValue(oneToManyGrandparentFields, 'Something__c.SomethingElse__c, SomethingElse__c.Name');
+
+  const submitButton = fullRecalc.shadowRoot.querySelector('lightning-button');
+  submitButton.click();
+
+  await flushPromises('apex controller call');
+  let defaultNamespaceObject = {
+    RollupFieldOnCalcItem__c: 'FirstName',
+    LookupFieldOnCalcItem__c: 'AccountId',
+    LookupFieldOnLookupObject__c: 'Id',
+    RollupFieldOnLookupObject__c: 'Name',
+    LookupObject__c: 'Account',
+    CalcItem__c: 'Contact',
+    RollupOperation__c: 'CONCAT',
+    CalcItemWhereClause__c: '',
+    ConcatDelimiter__c: '',
+    SplitConcatDelimiterOnCalcItem__c: false,
+    LimitAmount__c: null,
+    GrandparentRelationshipFieldPath__c: 'Something__r.SomethingElse__r.Name',
+    OneToManyGrandparentFields__c: 'Something__c.SomethingElse__c, SomethingElse__c.Name'
+  };
+  if (namespace) {
+    defaultNamespaceObject = Object.assign({}, ...Object.keys(defaultNamespaceObject).map(key => ({ [namespace + key]: defaultNamespaceObject[key] })));
+  }
+  expect(performSerializedFullRecalculation.mock.calls[0][0].metadata).toMatch(JSON.stringify(defaultNamespaceObject));
+}
+
 describe('Rollup force recalc tests', () => {
   beforeEach(() => {
     getRollupMetadataByCalcItem.mockResolvedValue({ ...mockMetadata });
+    getNamespaceSafeRollupOperationField.mockResolvedValue('Rollup__mdt.RollupOperation__c');
   });
   afterEach(() => {
     while (document.body.firstChild) {
@@ -65,81 +146,24 @@ describe('Rollup force recalc tests', () => {
   });
 
   it('sets document title', async () => {
-    const fullRecalc = createElement('c-rollup-force-recalculation', {
-      is: RollupForceRecalculation
-    });
-    document.body.appendChild(fullRecalc);
+    await mountComponent();
 
-    await flushPromises('rendering lifecycle');
     expect(document.title).toEqual('Recalculate Rollup');
   });
 
   it('sends form data to apex', async () => {
-    const fullRecalc = createElement('c-rollup-force-recalculation', {
-      is: RollupForceRecalculation
-    });
-    document.body.appendChild(fullRecalc);
+    await submitsFormDataWithNamespace();
+  });
 
-    // validate that toggle is not checked
-    const toggle = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="cmdt-toggle"]');
-    expect(toggle).not.toBeNull();
-    expect(fullRecalc.isCMDTRecalc).toBeFalsy();
-
-    const calcItemSObjectName = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="CalcItem__c"]');
-    setElementValue(calcItemSObjectName, 'Contact');
-
-    const opFieldOnCalcItem = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="RollupFieldOnCalcItem__c"]');
-    setElementValue(opFieldOnCalcItem, 'FirstName');
-
-    const lookupFieldOnCalcItem = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="LookupFieldOnCalcItem__c"]');
-    setElementValue(lookupFieldOnCalcItem, 'AccountId');
-
-    const lookupFieldOnLookupObject = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="LookupFieldOnLookupObject__c"]');
-    setElementValue(lookupFieldOnLookupObject, 'Id');
-
-    const rollupFieldOnLookupObject = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="RollupFieldOnLookupObject__c"]');
-    setElementValue(rollupFieldOnLookupObject, 'Name');
-
-    const lookupSObjectName = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="LookupObject__c"]');
-    setElementValue(lookupSObjectName, 'Account');
-
-    const operationName = fullRecalc.shadowRoot.querySelector('lightning-combobox[data-id="RollupOperation__c"]');
-    setElementValue(operationName, 'CONCAT', true);
-
-    const grandparentFieldPath = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="GrandparentRelationshipFieldPath__c"]');
-    setElementValue(grandparentFieldPath, 'Something__r.SomethingElse__r.Name');
-
-    const oneToManyGrandparentFields = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="OneToManyGrandparentFields__c"]');
-    setElementValue(oneToManyGrandparentFields, 'Something__c.SomethingElse__c, SomethingElse__c.Name');
-
-    const submitButton = fullRecalc.shadowRoot.querySelector('lightning-button');
-    submitButton.click();
-
-    await flushPromises('apex controller call');
-    expect(performSerializedFullRecalculation.mock.calls[0][0].metadata).toMatch(
-      JSON.stringify({
-        RollupFieldOnCalcItem__c: 'FirstName',
-        LookupFieldOnCalcItem__c: 'AccountId',
-        LookupFieldOnLookupObject__c: 'Id',
-        RollupFieldOnLookupObject__c: 'Name',
-        LookupObject__c: 'Account',
-        CalcItem__c: 'Contact',
-        RollupOperation__c: 'CONCAT',
-        CalcItemWhereClause__c: '',
-        ConcatDelimiter__c: '',
-        SplitConcatDelimiterOnCalcItem__c: false,
-        LimitAmount__c: null,
-        GrandparentRelationshipFieldPath__c: 'Something__r.SomethingElse__r.Name',
-        OneToManyGrandparentFields__c: 'Something__c.SomethingElse__c, SomethingElse__c.Name'
-      })
-    );
+  it('sends namespaced form data to apex', async () => {
+    const namespace = 'please__';
+    getNamespaceSafeRollupOperationField.mockReset();
+    getNamespaceSafeRollupOperationField.mockResolvedValue(`${namespace}Rollup__mdt.${namespace}RollupOperation__c`);
+    await submitsFormDataWithNamespace(namespace);
   });
 
   it('sends CMDT data to apex', async () => {
-    const fullRecalc = createElement('c-rollup-force-recalculation', {
-      is: RollupForceRecalculation
-    });
-    document.body.appendChild(fullRecalc);
+    const fullRecalc = await mountComponent();
 
     // validate that toggle gets checked
     const toggle = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="cmdt-toggle"]');
@@ -175,10 +199,7 @@ describe('Rollup force recalc tests', () => {
   });
 
   it('renders CMDT datatable with selected metadata', async () => {
-    const fullRecalc = createElement('c-rollup-force-recalculation', {
-      is: RollupForceRecalculation
-    });
-    document.body.appendChild(fullRecalc);
+    const fullRecalc = await mountComponent();
 
     // validate that toggle gets checked
     const toggle = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="cmdt-toggle"]');
@@ -207,10 +228,7 @@ describe('Rollup force recalc tests', () => {
   });
 
   it('sets error when CMDT is not returned', async () => {
-    const fullRecalc = createElement('c-rollup-force-recalculation', {
-      is: RollupForceRecalculation
-    });
-    document.body.appendChild(fullRecalc);
+    const fullRecalc = await mountComponent();
 
     const toggle = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="cmdt-toggle"]');
     toggle.dispatchEvent(new CustomEvent('change'));
@@ -226,10 +244,7 @@ describe('Rollup force recalc tests', () => {
 
   it('succeeds even when controller returns rejected promise', async () => {
     performSerializedFullRecalculation.mockRejectedValue('error!');
-    const fullRecalc = createElement('c-rollup-force-recalculation', {
-      is: RollupForceRecalculation
-    });
-    document.body.appendChild(fullRecalc);
+    const fullRecalc = await mountComponent();
 
     const submitButton = fullRecalc.shadowRoot.querySelector('lightning-button');
     submitButton.click();
@@ -247,10 +262,7 @@ describe('Rollup force recalc tests', () => {
   it('succeeds even when no process id', async () => {
     performSerializedFullRecalculation.mockResolvedValue('No process Id');
 
-    const fullRecalc = createElement('c-rollup-force-recalculation', {
-      is: RollupForceRecalculation
-    });
-    document.body.appendChild(fullRecalc);
+    const fullRecalc = await mountComponent();
 
     const submitButton = fullRecalc.shadowRoot.querySelector('lightning-button');
     submitButton.click();
@@ -270,10 +282,7 @@ describe('Rollup force recalc tests', () => {
     getBatchRollupStatus.mockResolvedValueOnce('Completed').mockResolvedValueOnce('test');
     performSerializedFullRecalculation.mockResolvedValueOnce('someProcessId');
 
-    const fullRecalc = createElement('c-rollup-force-recalculation', {
-      is: RollupForceRecalculation
-    });
-    document.body.appendChild(fullRecalc);
+    const fullRecalc = await mountComponent();
 
     const submitButton = fullRecalc.shadowRoot.querySelector('lightning-button');
     submitButton.click();
@@ -292,10 +301,7 @@ describe('Rollup force recalc tests', () => {
     getBatchRollupStatus.mockResolvedValue('Completed');
     performSerializedFullRecalculation.mockResolvedValueOnce('someProcessId');
 
-    const fullRecalc = createElement('c-rollup-force-recalculation', {
-      is: RollupForceRecalculation
-    });
-    document.body.appendChild(fullRecalc);
+    const fullRecalc = await mountComponent();
 
     const submitButton = fullRecalc.shadowRoot.querySelector('lightning-button');
     submitButton.click();
@@ -323,10 +329,7 @@ describe('Rollup force recalc tests', () => {
       }
     ];
     getRollupMetadataByCalcItem.mockResolvedValue(mockMetadata);
-    const fullRecalc = createElement('c-rollup-force-recalculation', {
-      is: RollupForceRecalculation
-    });
-    document.body.appendChild(fullRecalc);
+    const fullRecalc = await mountComponent();
 
     const toggle = fullRecalc.shadowRoot.querySelector('lightning-input[data-id="cmdt-toggle"]');
     toggle.dispatchEvent(new CustomEvent('change'));

--- a/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.html
+++ b/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.html
@@ -1,186 +1,188 @@
 <template>
   <div class="slds-box white">
-    <div class="slds-m-bottom_small">After entering the below information, click the submit button to start up your Rollup.</div>
-    <div class="slds-m-bottom_small">
-      Alternatively, you can select a single Child Object based off of your CMDT rollup records and have the recalculation run for all CMDT associated with that
-      SObject type:
-    </div>
-    <lightning-input class="slds-m-bottom_small" data-id="cmdt-toggle" label="Run off of CMDT?" onchange={handleToggle} type="toggle"></lightning-input>
-    <lightning-layout vertical-align="center">
-      <div class="slds-grid slds-grid_vertical slds-gutters_small slds-grid_align-center" role="list">
-        <template if:true={isCMDTRecalc}>
-          <lightning-combobox
-            label="Select Child Object"
-            name="Select Child Object"
-            onchange={handleComboChange}
-            options={rollupMetadataOptions}
-            value={selectedMetadata}
-          ></lightning-combobox>
-          <template if:true={selectedMetadataCMDTRecords}>
-            <lightning-datatable
-              class="slds-m-top_large"
-              columns={cmdtColumns}
-              data-id="datatable"
-              data={selectedMetadataCMDTRecords}
-              key-field="DeveloperName"
-              max-row-selection={maxRowSelection}
-              onrowselection={handleRowSelect}
-              show-row-number-column
-            >
-            </lightning-datatable>
-          </template>
-        </template>
-        <template if:false={isCMDTRecalc}>
-          <lightning-input
-            class="slds-col slds-form-element slds-form-element_horizontal"
-            data-id="CalcItem__c"
-            label="Child Object SObject API Name"
-            name="CalcItem__c"
-            oncommit={handleChange}
-            required
-            type="text"
-          >
-          </lightning-input>
-          <lightning-input
-            class="slds-col slds-form-element slds-form-element_horizontal"
-            data-id="RollupFieldOnCalcItem__c"
-            label="Child Object Calc Field"
-            name="RollupFieldOnCalcItem__c"
-            oncommit={handleChange}
-            required
-            type="text"
-          >
-          </lightning-input>
-          <lightning-input
-            class="slds-col slds-form-element slds-form-element_horizontal"
-            data-id="LookupFieldOnCalcItem__c"
-            label="Child Object Lookup Field"
-            name="LookupFieldOnCalcItem__c"
-            oncommit={handleChange}
-            required
-            type="text"
-          >
-          </lightning-input>
-          <lightning-input
-            class="slds-col slds-form-element slds-form-element_horizontal"
-            data-id="LookupObject__c"
-            label="Rollup Object API Name"
-            name="LookupObject__c"
-            oncommit={handleChange}
-            required
-            type="text"
-          >
-          </lightning-input>
-          <lightning-input
-            class="slds-col slds-form-element slds-form-element_horizontal"
-            data-id="RollupFieldOnLookupObject__c"
-            label="Rollup Object Calc Field"
-            name="RollupFieldOnLookupObject__c"
-            oncommit={handleChange}
-            required
-            type="text"
-          >
-          </lightning-input>
-          <lightning-input
-            class="slds-col slds-form-element slds-form-element_horizontal"
-            data-id="LookupFieldOnLookupObject__c"
-            label="Rollup Object Lookup Field"
-            name="LookupFieldOnLookupObject__c"
-            oncommit={handleChange}
-            required
-            type="text"
-          >
-          </lightning-input>
-          <div>
-            <lightning-combobox
-              class="slds-col slds-form-element slds-form-element_horizontal"
-              data-id="RollupOperation__c"
-              label="Rollup Operation Name"
-              name="RollupOperation__c"
-              onchange={handleChange}
-              options={rollupOperationValues}
-              required
-              value={rollupOperation}
-            ></lightning-combobox>
-            <template if:true={isOrderByRollup}>
-              <div>
-                <c-rollup-order-by data-id="RollupOrderBys__r"></c-rollup-order-by>
-              </div>
-            </template>
-          </div>
-          <lightning-input
-            class="slds-col slds-form-element slds-form-element_horizontal"
-            data-id="LimitAmount__c"
-            label="Limit Amount (Optional) - you can add Order By info optionally after entering this, as well"
-            min="1"
-            name="LimitAmount__c"
-            oncommit={handleChange}
-            type="number"
-          >
-          </lightning-input>
-          <lightning-input
-            class="slds-col slds-form-element slds-form-element_horizontal"
-            data-id="ConcatDelimiter__c"
-            label="Concat Delimiter (Optional)"
-            name="ConcatDelimiter__c"
-            oncommit={handleChange}
-            type="text"
-          >
-          </lightning-input>
-          <div class="slds-grid">
-            <lightning-input
-              class="slds-col slds-form-element slds-form-element_horizontal"
-              data-id="GrandparentRelationshipFieldPath__c"
-              label="Grandparent Relationship Field Path (optional)"
-              name="GrandparentRelationshipFieldPath__c"
-              oncommit={handleChange}
-              type="text"
-            >
-            </lightning-input>
-            <lightning-input
-              class="slds-col slds-form-element slds-form-element_horizontal"
-              data-id="OneToManyGrandparentFields__c"
-              label="One To Many Grandparent Fields (optional)"
-              name="OneToManyGrandparentFields__c"
-              oncommit={handleChange}
-              type="text"
-            >
-            </lightning-input>
-            <lightning-helptext
-              content="Use ObjectApiName.FieldName (or ObjectApiName__c.CustomField__c for custom objects and fields). Can be a comma-separated list for multiple junction object hops"
-            ></lightning-helptext>
-          </div>
-          <div class="slds-grid">
-            <lightning-input
-              class="slds-col slds-form-element slds-form-element_horizontal slds-m-vertical_small"
-              data-id="SplitConcatDelimiterOnCalcItem__c"
-              label="Split Concat Delimiter On Child Object, Too? (Optional)"
-              name="SplitConcatDelimiterOnCalcItem__c"
-              oncommit={handleChange}
-              type="checkbox"
-            >
-            </lightning-input>
-            <lightning-helptext content="Only include the split option for CONCAT_DISTINCT rollups"></lightning-helptext>
-          </div>
-          <div class="slds-grid">
-            <lightning-textarea
-              class="slds-col slds-form-element slds-form-element_horizontal"
-              label="SOQL Where Clause To Exclude Calc Items (Optional)"
-              name="CalcItemWhereClause__c"
-              onchange={handleChange}
-            ></lightning-textarea>
-            <lightning-helptext content="If including a SOQL where clause, do not start with 'WHERE'- this is added automatically"></lightning-helptext>
-          </div>
-        </template>
-        <lightning-button class="slds-col slds-m-top_small" label="Start rollup!" onclick={handleSubmit} variant="brand"></lightning-button>
+    <section class="slds-is-relative">
+      <div class="slds-m-bottom_small">After entering the below information, click the submit button to start up your Rollup.</div>
+      <div class="slds-m-bottom_small">
+        Alternatively, you can select a single Child Object based off of your CMDT rollup records and have the recalculation run for all CMDT associated with
+        that SObject type:
       </div>
-    </lightning-layout>
-    <template if:true={isRollingUp}>
-      <div>Rollup processing ...</div>
-      <lightning-spinner alternative-text="Please wait while rollup is processed" title="Rolling up ...."></lightning-spinner>
-    </template>
+      <lightning-input class="slds-m-bottom_small" data-id="cmdt-toggle" label="Run off of CMDT?" onchange={handleToggle} type="toggle"></lightning-input>
+      <lightning-layout vertical-align="center">
+        <div class="slds-grid slds-grid_vertical slds-gutters_small slds-grid_align-center" role="list">
+          <template if:true={isCMDTRecalc}>
+            <lightning-combobox
+              label="Select Child Object"
+              name="Select Child Object"
+              onchange={handleComboChange}
+              options={rollupMetadataOptions}
+              value={selectedMetadata}
+            ></lightning-combobox>
+            <template if:true={selectedMetadataCMDTRecords}>
+              <lightning-datatable
+                class="slds-m-top_large"
+                columns={cmdtColumns}
+                data-id="datatable"
+                data={selectedMetadataCMDTRecords}
+                key-field="DeveloperName"
+                max-row-selection={maxRowSelection}
+                onrowselection={handleRowSelect}
+                show-row-number-column
+              >
+              </lightning-datatable>
+            </template>
+          </template>
+          <template if:false={isCMDTRecalc}>
+            <lightning-input
+              class="slds-col slds-form-element slds-form-element_horizontal"
+              data-id="CalcItem__c"
+              label="Child Object SObject API Name"
+              name="CalcItem__c"
+              oncommit={handleChange}
+              required
+              type="text"
+            >
+            </lightning-input>
+            <lightning-input
+              class="slds-col slds-form-element slds-form-element_horizontal"
+              data-id="RollupFieldOnCalcItem__c"
+              label="Child Object Calc Field"
+              name="RollupFieldOnCalcItem__c"
+              oncommit={handleChange}
+              required
+              type="text"
+            >
+            </lightning-input>
+            <lightning-input
+              class="slds-col slds-form-element slds-form-element_horizontal"
+              data-id="LookupFieldOnCalcItem__c"
+              label="Child Object Lookup Field"
+              name="LookupFieldOnCalcItem__c"
+              oncommit={handleChange}
+              required
+              type="text"
+            >
+            </lightning-input>
+            <lightning-input
+              class="slds-col slds-form-element slds-form-element_horizontal"
+              data-id="LookupObject__c"
+              label="Rollup Object API Name"
+              name="LookupObject__c"
+              oncommit={handleChange}
+              required
+              type="text"
+            >
+            </lightning-input>
+            <lightning-input
+              class="slds-col slds-form-element slds-form-element_horizontal"
+              data-id="RollupFieldOnLookupObject__c"
+              label="Rollup Object Calc Field"
+              name="RollupFieldOnLookupObject__c"
+              oncommit={handleChange}
+              required
+              type="text"
+            >
+            </lightning-input>
+            <lightning-input
+              class="slds-col slds-form-element slds-form-element_horizontal"
+              data-id="LookupFieldOnLookupObject__c"
+              label="Rollup Object Lookup Field"
+              name="LookupFieldOnLookupObject__c"
+              oncommit={handleChange}
+              required
+              type="text"
+            >
+            </lightning-input>
+            <div>
+              <lightning-combobox
+                class="slds-col slds-form-element slds-form-element_horizontal"
+                data-id="RollupOperation__c"
+                label="Rollup Operation Name"
+                name="RollupOperation__c"
+                onchange={handleChange}
+                options={rollupOperationValues}
+                required
+                value={rollupOperation}
+              ></lightning-combobox>
+              <template if:true={isOrderByRollup}>
+                <div>
+                  <c-rollup-order-by data-id="RollupOrderBys__r"></c-rollup-order-by>
+                </div>
+              </template>
+            </div>
+            <lightning-input
+              class="slds-col slds-form-element slds-form-element_horizontal"
+              data-id="LimitAmount__c"
+              label="Limit Amount (Optional) - you can add Order By info optionally after entering this, as well"
+              min="1"
+              name="LimitAmount__c"
+              oncommit={handleChange}
+              type="number"
+            >
+            </lightning-input>
+            <lightning-input
+              class="slds-col slds-form-element slds-form-element_horizontal"
+              data-id="ConcatDelimiter__c"
+              label="Concat Delimiter (Optional)"
+              name="ConcatDelimiter__c"
+              oncommit={handleChange}
+              type="text"
+            >
+            </lightning-input>
+            <div class="slds-grid">
+              <lightning-input
+                class="slds-col slds-form-element slds-form-element_horizontal"
+                data-id="GrandparentRelationshipFieldPath__c"
+                label="Grandparent Relationship Field Path (optional)"
+                name="GrandparentRelationshipFieldPath__c"
+                oncommit={handleChange}
+                type="text"
+              >
+              </lightning-input>
+              <lightning-input
+                class="slds-col slds-form-element slds-form-element_horizontal"
+                data-id="OneToManyGrandparentFields__c"
+                label="One To Many Grandparent Fields (optional)"
+                name="OneToManyGrandparentFields__c"
+                oncommit={handleChange}
+                type="text"
+              >
+              </lightning-input>
+              <lightning-helptext
+                content="Use ObjectApiName.FieldName (or ObjectApiName__c.CustomField__c for custom objects and fields). Can be a comma-separated list for multiple junction object hops"
+              ></lightning-helptext>
+            </div>
+            <div class="slds-grid">
+              <lightning-input
+                class="slds-col slds-form-element slds-form-element_horizontal slds-m-vertical_small"
+                data-id="SplitConcatDelimiterOnCalcItem__c"
+                label="Split Concat Delimiter On Child Object, Too? (Optional)"
+                name="SplitConcatDelimiterOnCalcItem__c"
+                oncommit={handleChange}
+                type="checkbox"
+              >
+              </lightning-input>
+              <lightning-helptext content="Only include the split option for CONCAT_DISTINCT rollups"></lightning-helptext>
+            </div>
+            <div class="slds-grid">
+              <lightning-textarea
+                class="slds-col slds-form-element slds-form-element_horizontal"
+                label="SOQL Where Clause To Exclude Calc Items (Optional)"
+                name="CalcItemWhereClause__c"
+                onchange={handleChange}
+              ></lightning-textarea>
+              <lightning-helptext content="If including a SOQL where clause, do not start with 'WHERE'- this is added automatically"></lightning-helptext>
+            </div>
+          </template>
+          <lightning-button class="slds-col slds-m-top_small" label="Start rollup!" onclick={handleSubmit} variant="brand"></lightning-button>
+        </div>
+      </lightning-layout>
+      <template if:true={isRollingUp}>
+        <div>Rollup processing ...</div>
+        <lightning-spinner alternative-text="Please wait while rollup is processed" title="Rolling up ...."></lightning-spinner>
+      </template>
+    </section>
     <template if:true={rollupStatus}>
-      <div class="slds-m-top_small">Rollup job status: <b>{rollupStatus}</b></div>
+      <div class="slds-m-top_small">Rollup job status: <b>{rollupStatus} for job: {jobIdToDisplay}</b></div>
     </template>
     <template if:true={error}>
       <div class="slds-m-top_small" data-id="rollupError">There was an error performing your rollup: {error}</div>

--- a/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.html
+++ b/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.html
@@ -187,7 +187,7 @@
       <div class="slds-m-top_small">Rollup job status: <b>{rollupStatus} for job: {jobIdToDisplay}</b></div>
     </template>
     <template if:true={error}>
-      <div class="slds-m-top_small" data-id="rollupError">There was an error performing your rollup: {error}</div>
+      <div class="slds-m-top_small" data-id="rollupError">An error occurred: {error}</div>
     </template>
   </div>
 </template>

--- a/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.html
+++ b/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.html
@@ -6,7 +6,9 @@
         Alternatively, you can select a single Child Object based off of your CMDT rollup records and have the recalculation run for all CMDT associated with
         that SObject type:
       </div>
-      <lightning-input class="slds-m-bottom_small" data-id="cmdt-toggle" label="Run off of CMDT?" onchange={handleToggle} type="toggle"></lightning-input>
+      <template if:true={canDisplayCmdtToggle}>
+        <lightning-input class="slds-m-bottom_small" data-id="cmdt-toggle" label="Run off of CMDT?" onchange={handleToggle} type="toggle"></lightning-input>
+      </template>
       <lightning-layout vertical-align="center">
         <div class="slds-grid slds-grid_vertical slds-gutters_small slds-grid_align-center" role="list">
           <template if:true={isCMDTRecalc}>

--- a/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js
+++ b/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js
@@ -22,7 +22,7 @@ export default class RollupForceRecalculation extends LightningElement {
     CalcItemWhereClause__c: '',
     ConcatDelimiter__c: '',
     SplitConcatDelimiterOnCalcItem__c: false,
-    LimitAmount__c: 0
+    LimitAmount__c: null
   };
 
   @api isCMDTRecalc = false;
@@ -39,6 +39,7 @@ export default class RollupForceRecalculation extends LightningElement {
   isRollingUp = false;
   isOrderByRollup = false;
   rollupStatus;
+  jobIdToDisplay;
   error = '';
 
   _resolvedBatchStatuses = ['Completed', 'Failed', 'Aborted', NO_PROCESS_ID];
@@ -90,7 +91,7 @@ export default class RollupForceRecalculation extends LightningElement {
     this.isOrderByRollup =
       this.rollupOperation.indexOf('FIRST') !== -1 ||
       this.rollupOperation.indexOf('LAST') !== -1 ||
-      this.metadata.LimitAmount__c !== 0 ||
+      this.metadata.LimitAmount__c ||
       this.rollupOperation.indexOf('MOST') !== -1;
   }
 
@@ -156,6 +157,7 @@ export default class RollupForceRecalculation extends LightningElement {
     }
     this.isRollingUp = true;
 
+    this.jobIdToDisplay = jobId;
     this.rollupStatus = await getBatchRollupStatus({ jobId });
 
     // some arbitrary wait time - for a huge batch job, it could take ages to resolve

--- a/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js
+++ b/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js
@@ -1,4 +1,5 @@
 import { api, LightningElement, wire } from 'lwc';
+import getNamespaceSafeRollupOperationField from '@salesforce/apex/Rollup.getNamespaceSafeRollupOperationField';
 import getBatchRollupStatus from '@salesforce/apex/Rollup.getBatchRollupStatus';
 import performSerializedBulkFullRecalc from '@salesforce/apex/Rollup.performSerializedBulkFullRecalc';
 import performSerializedFullRecalculation from '@salesforce/apex/Rollup.performSerializedFullRecalculation';
@@ -7,25 +8,11 @@ import { getObjectInfo, getPicklistValues } from 'lightning/uiObjectInfoApi';
 
 import { getRollupMetadata } from 'c/rollupUtils';
 
-const NO_PROCESS_ID = 'No process Id';
 const MAX_ROW_SELECTION = 200;
 
 export default class RollupForceRecalculation extends LightningElement {
-  metadata = {
-    RollupFieldOnCalcItem__c: '',
-    LookupFieldOnCalcItem__c: '',
-    LookupFieldOnLookupObject__c: '',
-    RollupFieldOnLookupObject__c: '',
-    LookupObject__c: '',
-    CalcItem__c: '',
-    RollupOperation__c: '',
-    CalcItemWhereClause__c: '',
-    ConcatDelimiter__c: '',
-    SplitConcatDelimiterOnCalcItem__c: false,
-    LimitAmount__c: null
-  };
-
-  @api isCMDTRecalc = false;
+  @api
+  isCMDTRecalc = false;
 
   selectedRows = [];
   rollupMetadataOptions = [];
@@ -41,26 +28,70 @@ export default class RollupForceRecalculation extends LightningElement {
   rollupStatus;
   jobIdToDisplay;
   error = '';
+  canDisplayCmdtToggle = false;
 
-  _resolvedBatchStatuses = ['Completed', 'Failed', 'Aborted', NO_PROCESS_ID];
+  _resolvedBatchStatuses = ['Completed', 'Failed', 'Aborted'];
   _localMetadata = {};
+  _rollupOperationFieldName = 'RollupOperation__c';
   _cmdtFieldNames = [
     'MasterLabel',
     'DeveloperName',
-    'RollupOperation__c',
+    this._rollupOperationFieldName,
     'RollupFieldOnCalcItem__c',
     'LookupFieldOnCalcItem__c',
     'LookupFieldOnLookupObject__c',
     'RollupFieldOnLookupObject__c',
     'LookupObject__c'
   ];
+  _namespaceSafeRollupOperationField = '';
+  _metadata = {
+    RollupFieldOnCalcItem__c: '',
+    LookupFieldOnCalcItem__c: '',
+    LookupFieldOnLookupObject__c: '',
+    RollupFieldOnLookupObject__c: '',
+    LookupObject__c: '',
+    CalcItem__c: '',
+    RollupOperation__c: '',
+    CalcItemWhereClause__c: '',
+    ConcatDelimiter__c: '',
+    SplitConcatDelimiterOnCalcItem__c: false,
+    LimitAmount__c: null
+  };
+
+  get namespaceName() {
+    const splitForUnderscores = this._namespaceSafeObjectName.split('__');
+    return splitForUnderscores.length > 2 ? splitForUnderscores[0] + '__' : '';
+  }
+
+  get rollupOperation() {
+    return this._metadata[this._getNamespacedFieldName(this._rollupOperationFieldName)] || '';
+  }
+  set rollupOperation(value) {
+    this._setNamespaceSafeMetadata(this._rollupOperationFieldName, value);
+  }
+
+  // Technically each of these only requires a getter
+  // but in order to be used as reactive wire props, a setter is also needed
+  get _namespaceSafeRollupOperation() {
+    return this._namespaceSafeRollupOperationField;
+  }
+  set _namespaceSafeRollupOperation(value) {
+    this._namespaceSafeRollupOperationField = value;
+  }
+
+  get _namespaceSafeObjectName() {
+    return this._namespaceSafeRollupOperationField.split('.')[0];
+  }
+  set _namespaceSafeObjectName(value) {
+    this._namespaceSafeRollupOperationField = value;
+  }
 
   async connectedCallback() {
     document.title = 'Recalculate Rollup';
-    await this._fetchAvailableCMDT();
+    await Promise.all([this._fetchAvailableCMDT(), this._getNamespaceRollupInfo()]);
   }
 
-  @wire(getObjectInfo, { objectApiName: 'Rollup__mdt' })
+  @wire(getObjectInfo, { objectApiName: '$_namespaceSafeObjectName' })
   getCMDTObjectInfo({ error, data }) {
     if (data) {
       this._cmdtFieldNames.forEach(fieldName => {
@@ -71,7 +102,7 @@ export default class RollupForceRecalculation extends LightningElement {
     }
   }
 
-  @wire(getPicklistValues, { recordTypeId: '012000000000000AAA', fieldApiName: 'Rollup__mdt.RollupOperation__c' })
+  @wire(getPicklistValues, { recordTypeId: '012000000000000AAA', fieldApiName: '$_namespaceSafeRollupOperationField' })
   getRollupOperationValues({ error, data }) {
     if (data) {
       this.rollupOperationValues = data.values;
@@ -87,15 +118,17 @@ export default class RollupForceRecalculation extends LightningElement {
 
   handleChange(event) {
     const value = event.detail ? event.detail.value : event.target.value;
-    this.metadata[event.target.name] = event.target.name === 'LimitAmount__c' ? Number(value) : value;
+    const limitAmountWithoutNamespace = 'LimitAmount__c';
+    this._setNamespaceSafeMetadata(event.target.name, event.target.name === limitAmountWithoutNamespace ? Number(value) : value);
     this.isOrderByRollup =
       this.rollupOperation.indexOf('FIRST') !== -1 ||
       this.rollupOperation.indexOf('LAST') !== -1 ||
-      this.metadata.LimitAmount__c ||
+      this._getNamespaceSafeFieldValue(limitAmountWithoutNamespace) ||
       this.rollupOperation.indexOf('MOST') !== -1;
   }
 
   handleToggle() {
+    this.jobIdToDisplay = null;
     this.rollupStatus = null;
     this.rollupOperation = null;
     this.isCMDTRecalc = !this.isCMDTRecalc;
@@ -106,19 +139,23 @@ export default class RollupForceRecalculation extends LightningElement {
     this.selectedRows = event.detail.selectedRows;
   }
 
-  get rollupOperation() {
-    return this.metadata.RollupOperation__c || '';
-  }
-  set rollupOperation(value) {
-    this.metadata.RollupOperation__c = value;
-  }
-
   async _fetchAvailableCMDT() {
     this._localMetadata = await getRollupMetadata();
 
     Object.keys(this._localMetadata).forEach(localMeta => {
+      if (!this.canDisplayCmdtToggle) {
+        this.canDisplayCmdtToggle = true;
+      }
       this.rollupMetadataOptions.push({ label: localMeta, value: localMeta });
     });
+  }
+
+  async _getNamespaceRollupInfo() {
+    this._namespaceSafeRollupOperation = await getNamespaceSafeRollupOperationField();
+    if (this.namespaceName) {
+      this._metadata = Object.assign({}, ...Object.keys(this._metadata).map(key => ({ [this.namespaceName + key]: this._metadata[key] })));
+      this._cmdtFieldNames = this._cmdtFieldNames.map(fieldName => this._getNamespacedFieldName(fieldName));
+    }
   }
 
   async handleSubmit(event) {
@@ -137,9 +174,9 @@ export default class RollupForceRecalculation extends LightningElement {
         this._getMetadataWithChildrenRecords(localMetas);
         jobId = await performSerializedBulkFullRecalc({ serializedMetadata: JSON.stringify(localMetas), invokePointName: 'FROM_FULL_RECALC_LWC' });
       } else {
-        this._getMetadataWithChildrenRecords([this.metadata]);
+        this._getMetadataWithChildrenRecords([this._metadata]);
         jobId = await performSerializedFullRecalculation({
-          metadata: JSON.stringify(this.metadata)
+          metadata: JSON.stringify(this._metadata)
         });
       }
       await this._getBatchJobStatus(jobId);
@@ -151,8 +188,8 @@ export default class RollupForceRecalculation extends LightningElement {
   }
 
   async _getBatchJobStatus(jobId) {
-    if (!jobId || this._resolvedBatchStatuses.includes(jobId)) {
-      this.rollupStatus = jobId;
+    if (!jobId) {
+      this.rollupStatus = 'Job failed to enqueue, check logs for more info';
       return Promise.resolve();
     }
     this.isRollingUp = true;
@@ -163,7 +200,7 @@ export default class RollupForceRecalculation extends LightningElement {
     // some arbitrary wait time - for a huge batch job, it could take ages to resolve
     const statusPromise = new Promise(resolve => {
       let timeoutId;
-      if (this._resolvedBatchStatuses.includes(this.rollupStatus) === false) {
+      if (this._resolvedBatchStatuses.includes(this.rollupStatus) === false && this._validateAsyncJob(jobId)) {
         timeoutId = setTimeout(() => this._getBatchJobStatus(jobId), 3000);
       } else {
         this.isRollingUp = false;
@@ -185,10 +222,11 @@ export default class RollupForceRecalculation extends LightningElement {
   }
 
   _getMetadataWithChildrenRecords(metadatas) {
-    for (const metadata of metadatas) {
+    const rollupOrderByFieldName = this._getNamespacedFieldName(`RollupOrderBys__r`);
+    for (const _metadata of metadatas) {
       let children;
       if (this.isCMDTRecalc) {
-        children = metadata.RollupOrderBys__r != null ? metadata.RollupOrderBys__r : children;
+        children = _metadata[rollupOrderByFieldName] != null ? _metadata[rollupOrderByFieldName] : children;
       } else {
         const possibleOrderByComponent = this.template.querySelector('c-rollup-order-by');
         if (possibleOrderByComponent) {
@@ -196,8 +234,29 @@ export default class RollupForceRecalculation extends LightningElement {
         }
       }
       if (children && !children.totalSize) {
-        metadata.RollupOrderBys__r = { totalSize: children?.length, done: true, records: children };
+        _metadata[rollupOrderByFieldName] = { totalSize: children?.length, done: true, records: children };
       }
     }
+  }
+
+  _validateAsyncJob(val) {
+    const isValidAsyncJob = val?.slice(0, 3) === '707';
+    if (!isValidAsyncJob) {
+      this.jobIdToDisplay = 'no job Id';
+      this.rollupStatus = val;
+    }
+    return isValidAsyncJob;
+  }
+
+  _getNamespaceSafeFieldValue(fieldName) {
+    return this._metadata[this._getNamespacedFieldName(fieldName)];
+  }
+
+  _setNamespaceSafeMetadata(fieldName, value) {
+    this._metadata[this._getNamespacedFieldName(fieldName)] = value;
+  }
+
+  _getNamespacedFieldName(fieldName) {
+    return this.namespaceName + fieldName;
   }
 }

--- a/rollup/app/lwc/rollupOrderBy/__tests__/rollupOrderBy.test.js
+++ b/rollup/app/lwc/rollupOrderBy/__tests__/rollupOrderBy.test.js
@@ -1,12 +1,13 @@
 import { createElement } from 'lwc';
 import { getObjectInfo } from 'lightning/uiObjectInfoApi';
 
-import getNamespaceSafeRollupOperationField from '@salesforce/apex/Rollup.getNamespaceSafeRollupOperationField';
-
+import getNamespaceInfo from '@salesforce/apex/Rollup.getNamespaceInfo';
 import RollupOrderBy from 'c/rollupOrderBy';
 
+import { mockNamespaceInfo } from '../../__mockData__';
+
 jest.mock(
-  '@salesforce/apex/Rollup.getNamespaceSafeRollupOperationField',
+  '@salesforce/apex/Rollup.getNamespaceInfo',
   () => {
     return {
       default: jest.fn()
@@ -62,7 +63,7 @@ async function mountOrderByElement() {
 
 describe('Rollup force recalc tests', () => {
   beforeEach(() => {
-    getNamespaceSafeRollupOperationField.mockResolvedValue('Rollup__mdt.RollupOperation__c');
+    getNamespaceInfo.mockResolvedValue({ ...mockNamespaceInfo });
   });
   afterEach(() => {
     while (document.body.firstChild) {

--- a/rollup/app/lwc/rollupOrderBy/__tests__/rollupOrderBy.test.js
+++ b/rollup/app/lwc/rollupOrderBy/__tests__/rollupOrderBy.test.js
@@ -1,7 +1,19 @@
 import { createElement } from 'lwc';
 import { getObjectInfo } from 'lightning/uiObjectInfoApi';
 
+import getNamespaceSafeRollupOperationField from '@salesforce/apex/Rollup.getNamespaceSafeRollupOperationField';
+
 import RollupOrderBy from 'c/rollupOrderBy';
+
+jest.mock(
+  '@salesforce/apex/Rollup.getNamespaceSafeRollupOperationField',
+  () => {
+    return {
+      default: jest.fn()
+    };
+  },
+  { virtual: true }
+);
 
 const mockOrderByInfo = {
   fields: {
@@ -49,6 +61,9 @@ async function mountOrderByElement() {
 }
 
 describe('Rollup force recalc tests', () => {
+  beforeEach(() => {
+    getNamespaceSafeRollupOperationField.mockResolvedValue('Rollup__mdt.RollupOperation__c');
+  });
   afterEach(() => {
     while (document.body.firstChild) {
       document.body.removeChild(document.body.firstChild);

--- a/rollup/app/lwc/rollupOrderBy/rollupOrderBy.js
+++ b/rollup/app/lwc/rollupOrderBy/rollupOrderBy.js
@@ -1,7 +1,7 @@
 import { api, LightningElement, wire } from 'lwc';
 import { getObjectInfo } from 'lightning/uiObjectInfoApi';
 
-import getNamespaceSafeRollupOperationField from '@salesforce/apex/Rollup.getNamespaceSafeRollupOperationField';
+import getNamespaceInfo from '@salesforce/apex/Rollup.getNamespaceInfo';
 
 // the @salesforce/schema info for CMDT records doesn't work too well ...
 let ORDER_BY_SCHEMA = {
@@ -40,11 +40,10 @@ export default class RollupOrderBy extends LightningElement {
   }
 
   async _getNamespaceRollupInfo() {
-    const objectToFieldName = await getNamespaceSafeRollupOperationField();
-    const namespacePartitions = objectToFieldName.split('__');
-    if (namespacePartitions.length > 3) {
-      this._namespaceName = namespacePartitions[0] + '__';
-      this._objectApiName = this._namespaceName + this._objectApiName;
+    const namespaceInfo = await getNamespaceInfo();
+    if (namespaceInfo.namespace) {
+      this._namespaceName = namespaceInfo.namespace;
+      this._objectApiName = namespaceInfo.safeObjectName;
       ORDER_BY_SCHEMA = Object.assign({}, ...Object.keys(ORDER_BY_SCHEMA).map(key => ({ [this._namespaceName + key]: ORDER_BY_SCHEMA[key] })));
     }
   }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -403,7 +403,7 @@ global without sharing virtual class Rollup {
   }
 
   protected Boolean getIsRunningAsync() {
-    return System.isBatch() || System.isQueueable() || System.isScheduled() || System.isFuture() || shouldFlattenAsyncProcesses == true;
+    return isContextAsync();
   }
 
   protected virtual String getTypeName() {
@@ -1760,7 +1760,7 @@ global without sharing virtual class Rollup {
   }
 
   public static Boolean hasExceededCurrentRollupLimits(RollupControl__mdt control) {
-    RollupLimits.Tester limitTester = new RollupLimits.Tester(control);
+    RollupLimits.Tester limitTester = new RollupLimits.Tester(control, isContextAsync());
     Boolean hasExceededLimits = limitTester.hasExceededLimits && isDeferralAllowed;
     if (hasExceededLimits) {
       RollupLogger.Instance.log('exceeded limits:', limitTester, LoggingLevel.WARN);
@@ -1799,6 +1799,10 @@ global without sharing virtual class Rollup {
       SplitConcatDelimiterOnCalcItem__c = flowInput.splitConcatDelimiterOnCalcItem,
       UltimateParentLookup__c = flowInput.ultimateParentLookup
     );
+  }
+
+  private static Boolean isContextAsync() {
+    return System.isBatch() || System.isQueueable() || System.isScheduled() || System.isFuture() || shouldFlattenAsyncProcesses == true;
   }
 
   private static Boolean shouldSkipRollupForFlow(Rollup__mdt meta, String flowContext) {

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -241,13 +241,17 @@ global without sharing virtual class Rollup {
   }
 
   public class CalcItemBag {
-    private final Map<Id, SObject> idToCalcItem = new Map<Id, SObject>();
+    private final Map<String, SObject> idToCalcItem = new Map<String, SObject>();
     private Boolean hasBeenCleared = false;
     public Boolean hasQueriedForAdditionalItems = false;
     public CalcItemBag(List<SObject> calcItems) {
       for (SObject calcItem : calcItems) {
         this.add(calcItem);
       }
+    }
+
+    public Set<String> getAllIds() {
+      return this.idToCalcItem.keySet();
     }
 
     public List<SObject> getAll() {
@@ -1755,52 +1759,8 @@ global without sharing virtual class Rollup {
     return matchingMetadata;
   }
 
-  private class LimitTester {
-    private final transient RollupControl__mdt control;
-    public LimitTester(RollupControl__mdt control) {
-      this.control = control;
-    }
-
-    private Boolean hasExceededQueryNumberLimit {
-      get {
-        return this.control?.MaxNumberOfQueries__c < Limits.getQueries();
-      }
-    }
-    private Boolean hasExceededQueryRowLimit {
-      get {
-        return this.control?.MaxQueryRows__c < Limits.getQueryRows();
-      }
-    }
-    private Boolean hasExceededHeapSizeLimit {
-      get {
-        return (Limits.getLimitHeapSize() / 2) < Limits.getHeapSize();
-      }
-    }
-    private Boolean hasExceededDMLRowLimit {
-      get {
-        return this.control?.MaxParentRowsUpdatedAtOnce__c < Limits.getDmlRows();
-      }
-    }
-    private Boolean hasExceededCPUTimeLimit {
-      get {
-        Integer intervalTillTimeout = ((System.isBatch() || System.isQueueable()) && Test.isRunningTest() == false) ? 14000 : 3000;
-        return (Limits.getCpuTime() + intervalTillTimeout) >= Limits.getLimitCpuTime();
-      }
-    }
-
-    public transient Boolean hasExceededLimits {
-      get {
-        return this.hasExceededQueryNumberLimit ||
-          this.hasExceededQueryRowLimit ||
-          this.hasExceededHeapSizeLimit ||
-          this.hasExceededDMLRowLimit ||
-          this.hasExceededCPUTimeLimit;
-      }
-    }
-  }
-
   public static Boolean hasExceededCurrentRollupLimits(RollupControl__mdt control) {
-    LimitTester limitTester = new LimitTester(control);
+    RollupLimits.Tester limitTester = new RollupLimits.Tester(control);
     Boolean hasExceededLimits = limitTester.hasExceededLimits && isDeferralAllowed;
     if (hasExceededLimits) {
       RollupLogger.Instance.log('exceeded limits:', limitTester, LoggingLevel.WARN);

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -436,9 +436,18 @@ global without sharing virtual class Rollup {
    * - LWC-based full recalculation calls
    */
 
+  public class NamespaceInfo {
+    @AuraEnabled
+    public final String safeObjectName = Rollup__mdt.SObjectType.getDescribe().getName();
+    @AuraEnabled
+    public final String safeRollupOperationField = this.safeObjectName + '.' + Rollup__mdt.RollupOperation__c.getDescribe().getName();
+    @AuraEnabled
+    public final String namespace = Rollup.class.getName().substringBefore('Rollup');
+  }
+
   @AuraEnabled(cacheable=true)
-  global static String getNamespaceSafeRollupOperationField() {
-    return Rollup__mdt.SObjectType.getDescribe().getName() + '.' + Rollup__mdt.RollupOperation__c.getDescribe().getName();
+  public static NamespaceInfo getNamespaceInfo() {
+    return new NamespaceInfo();
   }
 
   @AuraEnabled(cacheable=true)

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -2913,7 +2913,7 @@ global without sharing virtual class Rollup {
           BatchChunkSize__c = 2000,
           IsMergeReparentingEnabled__c = true,
           IsRollupLoggingEnabled__c = false,
-          MaxLookupRowsBeforeBatching__c = Limits.getLimitDmlRows() / 3,
+          MaxLookupRowsBeforeBatching__c = Limits.getLimitQueryRows() / 3,
           MaxNumberOfQueries__c = Limits.getLimitQueries() / 2,
           MaxQueryRows__c = Limits.getLimitQueryRows() / 2,
           MaxParentRowsUpdatedAtOnce__c = Limits.getLimitDmlRows() / 2,

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -437,6 +437,11 @@ global without sharing virtual class Rollup {
    */
 
   @AuraEnabled(cacheable=true)
+  global static String getNamespaceSafeRollupOperationField() {
+    return Rollup__mdt.SObjectType.getDescribe().getName() + '.' + Rollup__mdt.RollupOperation__c.getDescribe().getName();
+  }
+
+  @AuraEnabled(cacheable=true)
   global static Map<String, List<Rollup__mdt>> getRollupMetadataByCalcItem() {
     Map<String, List<Rollup__mdt>> calcItemToMetadata = new Map<String, List<Rollup__mdt>>();
     List<Rollup__mdt> localMetadata = getMetadataFromCache(Rollup__mdt.SObjectType);

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -449,13 +449,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
 
     Set<String> objIds = new Set<String>();
-    for (String lookupKey : lookupToCalcItems.keySet()) {
-      CalcItemBag bag = lookupToCalcItems.get(lookupKey);
+    for (CalcItemBag bag : lookupToCalcItems.values()) {
       if (bag.hasQueriedForAdditionalItems == false) {
         bag.hasQueriedForAdditionalItems = true;
-        for (SObject calcItem : bag.getAll()) {
-          objIds.add(calcItem.Id);
-        }
+        objIds.addAll(bag.getAllIds());
       }
       // calling clear in a loop here might look interesting - and it would be a massive problem if not for the
       // bag only responding to the very first clear() invocation. everything after that is a no-op (so, any rollup with more
@@ -474,7 +471,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       ? rollup.calcObjectToUniqueFieldNames
       : this.calcObjectToUniqueFieldNames;
 
-    List<SObject> additionalCalcItems;
     String whereClause = '' + rollup.lookupFieldOnCalcItem + ' = :lookupKeys';
     String query = RollupQueryBuilder.Current.getQuery(
       rollup.calcItemType,
@@ -486,36 +482,38 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
     Boolean hasAlreadyBeenQueried = this.cachedQueryToAdditionalCalcItems.containsKey(query);
     Boolean shouldLimitCalcItemQuery = false;
+    Integer remainingQueryRowsLeft = 0;
+    Integer outstandingItemCount = 0;
 
+    List<SObject> additionalCalcItems;
     if (hasAlreadyBeenQueried) {
       additionalCalcItems = this.cachedQueryToAdditionalCalcItems.get(query);
     } else {
       Set<String> lookupKeys = lookupToCalcItems.keySet();
       String countQuery = RollupQueryBuilder.Current.getQuery(rollup.calcItemType, new List<String>{ 'Count()' }, 'Id', '!=', whereClause);
-      Integer outstandingItemCount;
       if (additionalCalcItemCount != null) {
         outstandingItemCount = additionalCalcItemCount;
         additionalCalcItemCount = null;
       } else {
         outstandingItemCount = Database.countQuery(countQuery);
       }
-      Integer remainingQueryRowsLeft = Limits.getLimitQueryRows() - (Limits.getQueryRows() + 1);
+      remainingQueryRowsLeft = new RollupLimits.Tester(rollup.rollupControl).getRemainingQueryRows();
       shouldLimitCalcItemQuery = outstandingItemCount >= remainingQueryRowsLeft;
 
       if (shouldLimitCalcItemQuery) {
         query = RollupQueryBuilder.Current.getAllRowSafeQuery(rollup.calcItemType, query += '\nLIMIT ' + remainingQueryRowsLeft);
-        hasAlreadyBeenQueried = this.cachedQueryToAdditionalCalcItems.containsKey(query);
+        hasAlreadyBeenQueried = false;
       }
 
-      if (hasAlreadyBeenQueried && shouldLimitCalcItemQuery) {
-        // unsafe to continue querying, as query was already limited in what it could retrieve
-        additionalCalcItems = this.cachedQueryToAdditionalCalcItems.get(query);
+      if (hasAlreadyBeenQueried && shouldLimitCalcItemQuery && outstandingItemCount != remainingQueryRowsLeft) {
+        this.isTimingOut = true;
+        return;
       } else if (outstandingItemCount > 0) {
         RollupLogger.Instance.log('gathering additional calc items with query:', query, LoggingLevel.DEBUG);
         additionalCalcItems = Database.query(query);
         if (hasAlreadyBeenQueried) {
           this.cachedQueryToAdditionalCalcItems.get(query).addAll(additionalCalcItems);
-        } else {
+        } else if (shouldLimitCalcItemQuery == false || remainingQueryRowsLeft >= outstandingItemCount) {
           this.cachedQueryToAdditionalCalcItems.put(query, additionalCalcItems);
         }
       } else {
@@ -528,7 +526,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       String lookupKey = (String) additionalCalcItem.get(rollup.lookupFieldOnCalcItem);
       if (lookupToCalcItems.containsKey(lookupKey)) {
         CalcItemBag bag = lookupToCalcItems.get(lookupKey);
-        bag.hasQueriedForAdditionalItems = bag.hasQueriedForAdditionalItems || shouldLimitCalcItemQuery == false;
+        bag.hasQueriedForAdditionalItems = shouldLimitCalcItemQuery == false || remainingQueryRowsLeft >= outstandingItemCount;
         bag.add(additionalCalcItem);
       }
     }
@@ -554,7 +552,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         roll.traversal = grandparentRollups.get(roll.lookupObj);
       }
 
-      Map<String, CalcItemBag> calcItemsByLookupField = this.getCalcItemsByLookupField(roll, this.lookupObjectToUniqueFieldNames.get(roll.lookupObj));
+      Set<String> uniqueParentObjectFields = this.lookupObjectToUniqueFieldNames.get(roll.lookupObj);
+      Map<String, CalcItemBag> calcItemsByLookupField = this.fullRecalcProcessor != null
+        ? this.fullRecalcProcessor.getCalcItemsByLookupField(roll, uniqueParentObjectFields)
+        : this.getCalcItemsByLookupField(roll, uniqueParentObjectFields);
       // some rollups may not finish retrieving all parent rows the first time around - and that's ok! we can keep
       // trying until all necessary records have been retrieved
       if (roll.traversal?.getIsFinished() == false) {
@@ -571,6 +572,14 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       updatedLookupRecords.putAll(this.getUpdatedLookupItemsByRollup(roll, calcItemsByLookupField, localLookupItems));
     }
 
+    // TODO - possibility here (or in "conditionallyPerformUpdate") to early-indicate to batch full recalcs that certain parent items have been
+    // fully calculated. there were some idiosyncracies when testing this approach - particularly within tests,
+    // where stacked async contexts (like a deferred rollup AND a batch job can both be running at once) are much harder to manage
+    // due to the platform attempting to auto-collapse them for you, which in this specific bit was leading to the
+    // RollupFullBatchRecalculator.statefulLookupToCalcItems map having lookup keys cleared from it too soon
+    // on the upside, figuring this out massively reduces the amount of time it takes for batch full recalcs to run,
+    // so this should be a "next version" priority
+
     if (this.isTimingOut) {
       this.getDML().forceSyncUpdate();
     }
@@ -584,14 +593,71 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     this.processDeferredRollups();
   }
 
+  protected virtual Map<String, CalcItemBag> getCalcItemsByLookupField(RollupAsyncProcessor roll, Set<String> uniqueLookupObjectFields) {
+    Map<String, CalcItemBag> lookupFieldToCalcItems = new Map<String, CalcItemBag>();
+    if (roll.calcItems == null) {
+      return lookupFieldToCalcItems;
+    }
+    if (String.isNotBlank(roll.metadata.GrandparentRelationshipFieldPath__c) || roll.metadata.RollupToUltimateParent__c) {
+      if (roll.traversal == null) {
+        roll.traversal = new RollupRelationshipFieldFinder(
+            roll.rollupControl,
+            roll.metadata,
+            this.calcObjectToUniqueFieldNames.get(roll.calcItemType),
+            uniqueLookupObjectFields,
+            roll.lookupObj,
+            roll.oldCalcItems
+          )
+          .getParents(roll.calcItems);
+      } else if (roll.traversal?.getIsFinished() == false) {
+        roll.traversal.recommence();
+      }
+      return roll.traversal.getIsFinished() ? roll.traversal.getParentLookupToRecords() : lookupFieldToCalcItems;
+    }
+    for (SObject calcItem : roll.calcItems) {
+      if (roll.matchingCalcItemIds.contains(calcItem.Id) == false) {
+        continue;
+      }
+      String key = (String) calcItem.get(roll.lookupFieldOnCalcItem);
+      SObject potentialOldCalcItem = roll.oldCalcItems?.get(calcItem.Id);
+      Boolean hasBlankKey = String.isBlank(key);
+      if (hasBlankKey && potentialOldCalcItem != null) {
+        key = (String) potentialOldCalcItem.get(roll.lookupFieldOnCalcItem);
+      }
+      if (hasBlankKey && potentialOldCalcItem == null) {
+        continue;
+      }
+      if (lookupFieldToCalcItems.containsKey(key) == false) {
+        lookupFieldToCalcItems.put(key, new CalcItemBag(new List<SObject>{ calcItem }));
+      } else {
+        lookupFieldToCalcItems.get(key).add(calcItem);
+      }
+
+      // if the lookup key differs from what it was on the old child object,
+      // include that value as well so that we can fix reparented records' rollup values
+      if (potentialOldCalcItem != null) {
+        String oldKey = (String) potentialOldCalcItem.get(roll.lookupFieldOnCalcItem);
+        if (key == oldKey || String.isBlank(key)) {
+          continue;
+        }
+
+        if (lookupFieldToCalcItems.containsKey(oldKey) == false) {
+          List<SObject> oldItems = this.isEmptyReparentingSet(roll.op) ? new List<SObject>() : new List<SObject>{ potentialOldCalcItem };
+          lookupFieldToCalcItems.put(oldKey, new CalcItemBag(oldItems));
+        } else if (this.isEmptyReparentingSet(roll.op) == false) {
+          lookupFieldToCalcItems.get(oldKey).add(potentialOldCalcItem);
+        }
+      }
+    }
+    return lookupFieldToCalcItems;
+  }
+
   protected virtual List<RollupAsyncProcessor> transformFullRecalcRollups() {
     return new List<RollupAsyncProcessor>();
   }
 
   protected virtual override String getHashedContents() {
-    // the only thing that necessarily makes a rollup unique is the sum total of the metadata behind it
-    // as well as the calc items driving that calculation.
-    // you could have multiple rollups with different Child Object Where Clauses all rolling up to the same field
+    // the only thing that necessarily makes a rollup unique is the metadata behind it
     return String.valueOf(this.metadata);
   }
 
@@ -792,6 +858,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         roll.oldCalcItems = oldCalcItemsWithUpdatedFields;
         this.replaceCalcItems(oldHashCode, roll.oldCalcItems, roll, CollectionType.DICTIONARY);
       }
+      if (this.fullRecalcProcessor != null) {
+        this.fullRecalcProcessor.calcObjectToUniqueFieldNames = this.calcObjectToUniqueFieldNames;
+        this.fullRecalcProcessor.lookupObjectToUniqueFieldNames = this.lookupObjectToUniqueFieldNames;
+      }
     }
   }
 
@@ -820,65 +890,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         potentialRollups.remove(index);
       }
     }
-  }
-
-  private Map<String, CalcItemBag> getCalcItemsByLookupField(RollupAsyncProcessor roll, Set<String> uniqueLookupObjectFields) {
-    Map<String, CalcItemBag> lookupFieldToCalcItems = new Map<String, CalcItemBag>();
-    if (roll.calcItems == null) {
-      return lookupFieldToCalcItems;
-    }
-    if (String.isNotBlank(roll.metadata.GrandparentRelationshipFieldPath__c) || roll.metadata.RollupToUltimateParent__c) {
-      if (roll.traversal == null) {
-        roll.traversal = new RollupRelationshipFieldFinder(
-            roll.rollupControl,
-            roll.metadata,
-            this.calcObjectToUniqueFieldNames.get(roll.calcItemType),
-            uniqueLookupObjectFields,
-            roll.lookupObj,
-            roll.oldCalcItems
-          )
-          .getParents(roll.calcItems);
-      } else if (roll.traversal?.getIsFinished() == false) {
-        roll.traversal.recommence();
-      }
-      return roll.traversal.getIsFinished() ? roll.traversal.getParentLookupToRecords() : lookupFieldToCalcItems;
-    }
-    for (SObject calcItem : roll.calcItems) {
-      if (roll.matchingCalcItemIds.contains(calcItem.Id) == false) {
-        continue;
-      }
-      String key = (String) calcItem.get(roll.lookupFieldOnCalcItem);
-      SObject potentialOldCalcItem = roll.oldCalcItems?.get(calcItem.Id);
-      Boolean hasBlankKey = String.isBlank(key);
-      if (hasBlankKey && potentialOldCalcItem != null) {
-        key = (String) potentialOldCalcItem.get(roll.lookupFieldOnCalcItem);
-      }
-      if (hasBlankKey && potentialOldCalcItem == null) {
-        continue;
-      }
-      if (lookupFieldToCalcItems.containsKey(key) == false) {
-        lookupFieldToCalcItems.put(key, new CalcItemBag(new List<SObject>{ calcItem }));
-      } else {
-        lookupFieldToCalcItems.get(key).add(calcItem);
-      }
-
-      // if the lookup key differs from what it was on the old child object,
-      // include that value as well so that we can fix reparented records' rollup values
-      if (potentialOldCalcItem != null) {
-        String oldKey = (String) potentialOldCalcItem.get(roll.lookupFieldOnCalcItem);
-        if (key == oldKey || String.isBlank(key)) {
-          continue;
-        }
-
-        if (lookupFieldToCalcItems.containsKey(oldKey) == false) {
-          List<SObject> oldItems = this.isEmptyReparentingSet(roll.op) ? new List<SObject>() : new List<SObject>{ potentialOldCalcItem };
-          lookupFieldToCalcItems.put(oldKey, new CalcItemBag(oldItems));
-        } else if (this.isEmptyReparentingSet(roll.op) == false) {
-          lookupFieldToCalcItems.get(oldKey).add(potentialOldCalcItem);
-        }
-      }
-    }
-    return lookupFieldToCalcItems;
   }
 
   private Boolean isEmptyReparentingSet(Op operation) {

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -248,9 +248,9 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     if (this.isNoOp) {
       logMessage = 'no-op, exiting early to avoid burning async job';
     } else if (this.rollupControl.ShouldAbortRun__c) {
-      logMessage = 'RollupControl__mdt.ShouldAbortRun__c set to true, exiting early';
+      logMessage = RollupControl__mdt.ShouldAbortRun__c.getDescribe().getName() + ' set to true, exiting early';
     } else if (RollupSettings__c.getInstance().IsEnabled__c == false && shouldRunWithoutCustomSetting == false) {
-      logMessage = 'RollupSettings__c.IsEnabled__c is false, exiting early';
+      logMessage = RollupSettings__c.IsEnabled__c.getDescribe().getName() + ' is false, exiting early';
     } else if (syncRollups.isEmpty() == false) {
       RollupLogger.Instance.log('about to process sync rollups', LoggingLevel.DEBUG);
       this.process(syncRollups);

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -265,6 +265,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
     if (logMessage != null) {
       RollupLogger.Instance.log(logMessage, LoggingLevel.DEBUG);
+      rollupProcessId = logMessage;
     }
     RollupLogger.Instance.save();
     return rollupProcessId;
@@ -497,7 +498,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       } else {
         outstandingItemCount = Database.countQuery(countQuery);
       }
-      remainingQueryRowsLeft = new RollupLimits.Tester(rollup.rollupControl).getRemainingQueryRows();
+      remainingQueryRowsLeft = new RollupLimits.Tester(rollup.rollupControl, this.getIsRunningAsync()).getRemainingQueryRows();
       shouldLimitCalcItemQuery = outstandingItemCount >= remainingQueryRowsLeft;
 
       if (shouldLimitCalcItemQuery) {

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -1,5 +1,5 @@
 public without sharing virtual class RollupFullBatchRecalculator extends RollupFullRecalcProcessor implements Database.Stateful {
-  private final Map<String, CalcItemBag> statefulLookupToCalcItems;
+  private final Map<String, CalcItemBag> statefulLookupToCalcItems = new Map<String, CalcItemBag>();
 
   public RollupFullBatchRecalculator(
     String queryString,
@@ -10,7 +10,6 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupF
     RollupFullRecalcProcessor postProcessor
   ) {
     super(queryString, invokePoint, rollupMetas, calcItemType, recordIds, postProcessor);
-    this.statefulLookupToCalcItems = new Map<String, CalcItemBag>();
   }
 
   public override Database.QueryLocator start(Database.BatchableContext bc) {
@@ -29,7 +28,7 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupF
      * being batched, even if the inner class is just extending the functionality of its
      * parent class
      */
-    this.getInnerExecute(calcItems)?.runCalc();
+    this.getDelegatedFullRecalcRollup(this.rollupMetas, calcItems, this)?.runCalc();
     RollupLogger.Instance.save();
   }
 
@@ -48,11 +47,19 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupF
     return this.startBatchProcessor();
   }
 
+  protected override Map<String, CalcItemBag> getCalcItemsByLookupField(RollupAsyncProcessor roll, Set<String> uniqueLookupObjectFields) {
+    if (this.statefulLookupToCalcItems.isEmpty() == false) {
+      return this.statefulLookupToCalcItems;
+    }
+    return super.getCalcItemsByLookupField(roll, uniqueLookupObjectFields);
+  }
+
   protected override void retrieveAdditionalCalcItems(Map<String, CalcItemBag> lookupToCalcItems, RollupAsyncProcessor rollup) {
     Map<String, CalcItemBag> lookupKeysThatNeedFilling = new Map<String, CalcItemBag>();
     for (String lookupKey : lookupToCalcItems.keySet()) {
       CalcItemBag bag = lookupToCalcItems.get(lookupKey);
-      if (this.statefulLookupToCalcItems.containsKey(lookupKey)) {
+      CalcItemBag potentiallyStatefulBag = this.statefulLookupToCalcItems.get(lookupKey);
+      if (potentiallyStatefulBag != null && potentiallyStatefulBag.hasQueriedForAdditionalItems) {
         lookupToCalcItems.put(lookupKey, this.statefulLookupToCalcItems.get(lookupKey));
       } else {
         lookupKeysThatNeedFilling.put(lookupKey, bag);
@@ -67,9 +74,5 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupF
       lookupToCalcItems.put(lookupKey, bag);
       this.recordIds.add(lookupKey);
     }
-  }
-
-  private RollupAsyncProcessor getInnerExecute(List<SObject> calcItems) {
-    return this.getDelegatedFullRecalcRollup(this.rollupMetas, calcItems, this);
   }
 }

--- a/rollup/core/classes/RollupLimits.cls
+++ b/rollup/core/classes/RollupLimits.cls
@@ -2,10 +2,15 @@ public without sharing class RollupLimits {
   @TestVisible
   private static Integer stubbedQueryRows;
 
+  private static final Integer SYNC_TIMEOUT_INTERVAL_MS = 3000;
+  private static final Integer ASYNC_TIMEOUT_INTERVAL_MS = 13000;
+
   public class Tester {
     private final transient RollupControl__mdt control;
-    public Tester(RollupControl__mdt control) {
+    private final Boolean isRunningAsync;
+    public Tester(RollupControl__mdt control, Boolean isRunningAsync) {
       this.control = control;
+      this.isRunningAsync = isRunningAsync;
     }
 
     public Boolean hasExceededQueryNumberLimit {
@@ -30,7 +35,7 @@ public without sharing class RollupLimits {
     }
     public Boolean hasExceededCPUTimeLimit {
       get {
-        Integer intervalTillTimeout = ((System.isBatch() || System.isQueueable()) && Test.isRunningTest() == false) ? 14000 : 3000;
+        Integer intervalTillTimeout = this.isRunningAsync ? ASYNC_TIMEOUT_INTERVAL_MS : SYNC_TIMEOUT_INTERVAL_MS;
         return (Limits.getCpuTime() + intervalTillTimeout) >= Limits.getLimitCpuTime();
       }
     }

--- a/rollup/core/classes/RollupLimits.cls
+++ b/rollup/core/classes/RollupLimits.cls
@@ -1,0 +1,57 @@
+public without sharing class RollupLimits {
+  @TestVisible
+  private static Integer stubbedQueryRows;
+
+  public class Tester {
+    private final transient RollupControl__mdt control;
+    public Tester(RollupControl__mdt control) {
+      this.control = control;
+    }
+
+    public Boolean hasExceededQueryNumberLimit {
+      get {
+        return this.control?.MaxNumberOfQueries__c < Limits.getQueries();
+      }
+    }
+    public Boolean hasExceededQueryRowLimit {
+      get {
+        return this.getRemainingQueryRows() < 0;
+      }
+    }
+    public Boolean hasExceededHeapSizeLimit {
+      get {
+        return (Limits.getLimitHeapSize() / 2) < Limits.getHeapSize();
+      }
+    }
+    public Boolean hasExceededDMLRowLimit {
+      get {
+        return this.control?.MaxParentRowsUpdatedAtOnce__c < Limits.getDmlRows();
+      }
+    }
+    public Boolean hasExceededCPUTimeLimit {
+      get {
+        Integer intervalTillTimeout = ((System.isBatch() || System.isQueueable()) && Test.isRunningTest() == false) ? 14000 : 3000;
+        return (Limits.getCpuTime() + intervalTillTimeout) >= Limits.getLimitCpuTime();
+      }
+    }
+
+    public transient Boolean hasExceededLimits {
+      get {
+        return this.hasExceededQueryNumberLimit ||
+          this.hasExceededQueryRowLimit ||
+          this.hasExceededHeapSizeLimit ||
+          this.hasExceededDMLRowLimit ||
+          this.hasExceededCPUTimeLimit;
+      }
+    }
+
+    public Integer getRemainingQueryRows() {
+      Integer queryRowsUsed = stubbedQueryRows != null ? stubbedQueryRows : Limits.getQueryRows();
+      if (this.control?.MaxQueryRows__c == null) {
+        return queryRowsUsed;
+      }
+      Integer remainingQueryRows = this.control.MaxQueryRows__c?.intValue() - queryRowsUsed;
+      return remainingQueryRows > 0 ? remainingQueryRows : 0;
+    }
+  }
+}

--- a/rollup/core/classes/RollupLimits.cls-meta.xml
+++ b/rollup/core/classes/RollupLimits.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>55.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/rollup/core/classes/RollupLimits.cls-meta.xml
+++ b/rollup/core/classes/RollupLimits.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.29';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.30';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/layouts/RollupControl__mdt-Rollup Control Layout.layout-meta.xml
+++ b/rollup/core/layouts/RollupControl__mdt-Rollup Control Layout.layout-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <Layout xmlns="http://soap.sforce.com/2006/04/metadata">
     <layoutSections>
         <customLabel>false</customLabel>
@@ -59,6 +59,10 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
+                <field>MaxQueryRows__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
                 <field>MaxParentRowsUpdatedAtOnce__c</field>
             </layoutItems>
             <layoutItems>
@@ -93,7 +97,7 @@
                 <field>OnlyRunInFlowContexts__c</field>
             </layoutItems>
         </layoutColumns>
-        <layoutColumns/>
+        <layoutColumns />
         <style>TwoColumnsLeftToRight</style>
     </layoutSections>
     <layoutSections>
@@ -128,9 +132,9 @@
         <detailHeading>false</detailHeading>
         <editHeading>false</editHeading>
         <label>Custom Links</label>
-        <layoutColumns/>
-        <layoutColumns/>
-        <layoutColumns/>
+        <layoutColumns />
+        <layoutColumns />
+        <layoutColumns />
         <style>CustomLinks</style>
     </layoutSections>
     <relatedLists>

--- a/scripts/generatePackage.ps1
+++ b/scripts/generatePackage.ps1
@@ -7,6 +7,7 @@ function Get-SFDX-Project-JSON {
 $sfdxProjectJsonPath = "./sfdx-project.json"
 $sfdxProjectJson = Get-SFDX-Project-JSON
 $loggerClassPath = "./rollup/core/classes/RollupLogger.cls"
+$shouldGitAddLoggerClass = $true;
 
 function Invoke-Extra-Code-Coverage-Prep() {
   $extraCodeCoveragePath = "./plugins/ExtraCodeCoverage"
@@ -71,7 +72,9 @@ function Update-Logger-Class {
   $replacementRegEx = '$1' + $versionNumber + '$3'
   $loggerClassContents -replace $targetRegEx, $replacementRegEx | Set-Content -Path $loggerClassPath -NoNewline
   npx prettier --write $loggerClassPath
-  git add $loggerClassPath
+  if ($shouldGitAddLoggerClass -eq $true) {
+    git add $loggerClassPath
+  }
 }
 
 function Update-SFDX-Project-JSON {
@@ -166,10 +169,14 @@ function Generate() {
 function New-Namespaced-Package {
   Write-Host "Generating namespaced version of package..." -ForegroundColor White
 
+  $originalLoggerClassPath = $loggerClassPath
   $namespacedPackageName = "apex-rollup-namespaced"
   $namespacedProjectJsonPath = "rollup-namespaced/sfdx-project.json"
   $originalProjectJsonBackupPath = "./sfdx-project-original.json"
   $versionName = (Get-Package-Directory "apex-rollup").versionName
+  $shouldGitAddLoggerClass = $false
+  $loggerClassPath = "rollup-namespaced/source/rollup/core/classes/RollupLogger.cls"
+  Write-Host "Logger class path for namespaced package will be added to git: $shouldGitAddLoggerClass"
 
   Copy-Item $sfdxProjectJsonPath $originalProjectJsonBackupPath -Force
   Copy-Item $namespacedProjectJsonPath $sfdxProjectJsonPath -Force
@@ -202,4 +209,6 @@ function New-Namespaced-Package {
   git add $sfdxProjectJsonPath -f
   git add $namespacedProjectJsonPath -f
   Remove-Item -Path rollup-namespaced/source -Recurse -Force
+  $shouldGitAddLoggerClass = $true
+  $loggerClassPath = $originalLoggerClassPath
 }

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -5,6 +5,8 @@ $testInvocation = 'npx sfdx force:apex:test:run -s ApexRollupTestSuite -r human 
 $currentUserAlias = 'apex-rollup-scratch-org'
 function Start-Tests() {
   Write-Debug "Deploying metadata ..."
+  # Pipeline recently started failing due to duplicate items ...
+  Remove-Item -Path ./rollup/app/profiles/Admin.profile-meta.xml -Force
   npx sfdx force:source:deploy -p rollup
   npx sfdx force:source:deploy -p extra-tests
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -102,6 +102,6 @@
         "apex-rollup@1.5.27-0": "04t6g000008b0iTAAQ",
         "apex-rollup@1.5.28-0": "04t6g000008b0inAAA",
         "apex-rollup@1.5.29-0": "04t6g000008b0nFAAQ",
-        "apex-rollup@1.5.30-0": "04t6g000007zLnAAAU"
+        "apex-rollup@1.5.30-0": "04t6g000007zLnKAAU"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "TODO",
+            "versionName": "Fixes an issue where full batch recalculations could fail to pick up all calc items when the calc item amount for any given parent exceeded the Max Query Row limit",
             "versionNumber": "1.5.30.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
@@ -99,7 +99,6 @@
         "Apex Rollup - Rollup Callback@0.0.3-0": "04t6g000008Sis0AAC",
         "Nebula Logger - Core@4.8.0-NEXT-ignore-origin-method": "04t5Y0000015lslQAA",
         "apex-rollup": "0Ho6g000000TNcOCAW",
-        "apex-rollup@1.5.26-0": "04t6g000008b0ceAAA",
         "apex-rollup@1.5.27-0": "04t6g000008b0iTAAQ",
         "apex-rollup@1.5.28-0": "04t6g000008b0inAAA",
         "apex-rollup@1.5.29-0": "04t6g000008b0nFAAQ"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -101,6 +101,7 @@
         "apex-rollup": "0Ho6g000000TNcOCAW",
         "apex-rollup@1.5.27-0": "04t6g000008b0iTAAQ",
         "apex-rollup@1.5.28-0": "04t6g000008b0inAAA",
-        "apex-rollup@1.5.29-0": "04t6g000008b0nFAAQ"
+        "apex-rollup@1.5.29-0": "04t6g000008b0nFAAQ",
+        "apex-rollup@1.5.30-0": "04t6g000007zLmvAAE"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Fixes a bug with batch full recalcs that use a small Batch Chunk Size ",
-            "versionNumber": "1.5.29.0",
+            "versionName": "TODO",
+            "versionNumber": "1.5.30.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -102,6 +102,6 @@
         "apex-rollup@1.5.27-0": "04t6g000008b0iTAAQ",
         "apex-rollup@1.5.28-0": "04t6g000008b0inAAA",
         "apex-rollup@1.5.29-0": "04t6g000008b0nFAAQ",
-        "apex-rollup@1.5.30-0": "04t6g000007zLnKAAU"
+        "apex-rollup@1.5.30-0": "04t6g000007zLnjAAE"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -102,6 +102,6 @@
         "apex-rollup@1.5.27-0": "04t6g000008b0iTAAQ",
         "apex-rollup@1.5.28-0": "04t6g000008b0inAAA",
         "apex-rollup@1.5.29-0": "04t6g000008b0nFAAQ",
-        "apex-rollup@1.5.30-0": "04t6g000007zLmvAAE"
+        "apex-rollup@1.5.30-0": "04t6g000007zLnAAAU"
     }
 }


### PR DESCRIPTION
* Further fixes for #376 to properly support parent items with massive numbers of children, including children counts in excess of the 50k per thread query row limit
* Adds `RollupLimit` class (pulling the same out of `Rollup`) to help with stubbing `System.Limit` calls when necessary
* QoL changes to full recalc app - spinner now doesn't lock down the "status" part of the page, and the job id is appended to the job status