### PR TITLE
V1.5.31 - More support for full recalculation default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnjAAE">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLpGAAU">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnjAAE">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLpGAAU">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupCalculatorTests.cls
+++ b/extra-tests/classes/RollupCalculatorTests.cls
@@ -1162,6 +1162,24 @@ private class RollupCalculatorTests {
   }
 
   @IsTest
+  static void respectsDefaultFullRecalcValueMinMaxInsteadOfNull() {
+    Rollup__mdt metadata = new Rollup__mdt(FullRecalculationDefaultNumberValue__c = 5, CalcItem__c = 'Task');
+    RollupCalculator calc = getCalculator(
+      2,
+      Rollup.Op.MIN,
+      Task.CallDurationInSeconds,
+      Opportunity.Amount,
+      metadata,
+      RollupTestUtils.createId(Opportunity.SObjectType),
+      Task.WhatId
+    );
+
+    calc.performRollup(new List<Task>(), new Map<Id, SObject>());
+
+    System.assertEquals(metadata.FullRecalculationDefaultNumberValue__c, calc.getReturnValue(), 'Should correctly find minimum');
+  }
+
+  @IsTest
   static void shouldDefaultToCurrentValueOnMinIfNoOtherMatchingItemsDate() {
     Rollup__mdt metadata = new Rollup__mdt();
     Date today = System.today();

--- a/extra-tests/classes/RollupCalculatorTests.cls
+++ b/extra-tests/classes/RollupCalculatorTests.cls
@@ -19,6 +19,20 @@ private class RollupCalculatorTests {
   }
 
   @IsTest
+  static void fullRecalcDefaultUsedInsteadOfNullWhenSupplied() {
+    Integer defaultVal = 0;
+    Rollup__mdt metadata = configureOrderByMetadata(
+      new Rollup__mdt(CalcItem__c = 'Opportunity', FullRecalculationDefaultNumberValue__c = defaultVal),
+      'CloseDate'
+    );
+    RollupCalculator calc = getCalculator(0, Rollup.Op.FIRST, Opportunity.Amount, Account.AnnualRevenue, metadata, '0011g00003VDGbF002', Account.Id);
+
+    calc.performRollup(new List<Opportunity>(), new Map<Id, SObject>());
+
+    System.assertEquals(defaultVal, calc.getReturnValue());
+  }
+
+  @IsTest
   static void shouldReturnFirstValueBasedOnMetadataField() {
     Rollup__mdt metadata = configureOrderByMetadata(new Rollup__mdt(CalcItem__c = 'Opportunity'), 'CloseDate');
     RollupCalculator calc = getCalculator(0, Rollup.Op.FIRST, Opportunity.Amount, Account.AnnualRevenue, metadata, '0011g00003VDGbF002', Account.Id);

--- a/extra-tests/classes/RollupCalculatorTests.cls
+++ b/extra-tests/classes/RollupCalculatorTests.cls
@@ -287,7 +287,7 @@ private class RollupCalculatorTests {
   // AVERAGE tests
 
   @IsTest
-  static void shouldReturnDefaultWhenNoCalcItemsAverage() {
+  static void shouldReturnNulltWhenNoCalcItemsAverage() {
     Rollup__mdt metadata = configureOrderByMetadata(new Rollup__mdt(CalcItem__c = 'Opportunity'), 'CloseDate');
     RollupCalculator calc = getCalculator(
       0,
@@ -302,6 +302,24 @@ private class RollupCalculatorTests {
     calc.performRollup(new List<Opportunity>(), new Map<Id, SObject>());
 
     System.assertEquals(null, calc.getReturnValue());
+  }
+
+  @IsTest
+  static void shouldReturnFullRecalcDefaultWhenNoCalcItemsAverage() {
+    Rollup__mdt metadata = configureOrderByMetadata(new Rollup__mdt(CalcItem__c = 'Opportunity', FullRecalculationDefaultNumberValue__c = 5), 'CloseDate');
+    RollupCalculator calc = getCalculator(
+      0,
+      Rollup.Op.Average,
+      Opportunity.Amount,
+      Account.AnnualRevenue,
+      metadata,
+      '0011g00003VDGbF002',
+      Opportunity.AccountId
+    );
+
+    calc.performRollup(new List<Opportunity>(), new Map<Id, SObject>());
+
+    System.assertEquals(metadata.FullRecalculationDefaultNumberValue__c, calc.getReturnValue());
   }
 
   @IsTest
@@ -327,7 +345,7 @@ private class RollupCalculatorTests {
       new Map<Id, SObject>()
     );
 
-    System.assertEquals(1, (Decimal) calc.getReturnValue(), 'Nulls should be treated as zeros for average!');
+    System.assertEquals(1, calc.getReturnValue(), 'Nulls should be treated as zeros for average!');
   }
 
   @IsTest
@@ -641,6 +659,44 @@ private class RollupCalculatorTests {
   }
 
   // MOST tests
+
+  @IsTest
+  static void mostReturnsNullIfNoMatchingItems() {
+    RollupCalculator calc = getCalculator(
+      0,
+      Rollup.Op.MOST,
+      Opportunity.Amount,
+      Account.AnnualRevenue,
+      new Rollup__mdt(CalcItem__c = 'Opportunity'),
+      '0011g00003VDGbF002',
+      Opportunity.AccountId
+    );
+    Opportunity opp = new Opportunity(Id = '0066g00003VDGbF001', Amount = 2, AccountId = '0016g00003VDGbF001');
+    calc.setEvaluator(new RollupEvaluator.WhereFieldEvaluator('Amount != ' + opp.Amount, Opportunity.SObjectType));
+
+    calc.performRollup(new List<Opportunity>{ opp }, new Map<Id, SObject>());
+
+    System.assertEquals(null, calc.getReturnValue());
+  }
+
+  @IsTest
+  static void mostReturnsDefaultValWhenSuppliedIfNoMatchingItems() {
+    RollupCalculator calc = getCalculator(
+      0,
+      Rollup.Op.MOST,
+      Opportunity.Amount,
+      Account.AnnualRevenue,
+      new Rollup__mdt(CalcItem__c = 'Opportunity', FullRecalculationDefaultNumberValue__c = 5),
+      '0011g00003VDGbF002',
+      Opportunity.AccountId
+    );
+    Opportunity opp = new Opportunity(Id = '0066g00003VDGbF001', Amount = 2, AccountId = '0016g00003VDGbF001');
+    calc.setEvaluator(new RollupEvaluator.WhereFieldEvaluator('Amount != ' + opp.Amount, Opportunity.SObjectType));
+
+    calc.performRollup(new List<Opportunity>{ opp }, new Map<Id, SObject>());
+
+    System.assertEquals(5, calc.getReturnValue());
+  }
 
   @IsTest
   static void mostCalculatesSequentialValuesCorrectly() {
@@ -1608,6 +1664,27 @@ private class RollupCalculatorTests {
   }
 
   // ALL
+
+  @IsTest
+  static void allUsesFullRecalcDefaultValueWhenNotMatching() {
+    RollupCalculator calc = getCalculator(
+      0,
+      Rollup.Op.ALL,
+      Opportunity.Amount,
+      Account.AnnualRevenue,
+      new Rollup__mdt(FullRecalculationDefaultNumberValue__c = 5),
+      RollupTestUtils.createId(Account.SObjectType),
+      Opportunity.AccountId
+    );
+    calc.setEvaluator(new RollupEvaluator.WhereFieldEvaluator('Amount > 1', Opportunity.SObjectType));
+
+    Opportunity oppOne = new Opportunity(Amount = 1);
+    Opportunity oppTwo = new Opportunity(Amount = 1);
+
+    calc.performRollup(new List<SObject>{ oppOne, oppTwo }, new Map<Id, SObject>());
+
+    System.assertEquals(5, calc.getReturnValue());
+  }
 
   @IsTest
   static void allReportsPositivesCorrectlyAsNumber() {

--- a/extra-tests/classes/RollupCalculatorTests.cls
+++ b/extra-tests/classes/RollupCalculatorTests.cls
@@ -428,6 +428,25 @@ private class RollupCalculatorTests {
   }
 
   @IsTest
+  static void shouldReturnDefaultValueOnFullRecalcIfNoMatchingItemsCountDistinct() {
+    RollupCalculator calc = getCalculator(
+      0,
+      Rollup.Op.COUNT_DISTINCT,
+      Opportunity.Amount,
+      Account.AnnualRevenue,
+      new Rollup__mdt(CalcItem__c = 'Opportunity', FullRecalculationDefaultNumberValue__c = 15),
+      '0011g00003VDGbF002',
+      Opportunity.AccountId
+    );
+    Opportunity opp = new Opportunity(Id = '0066g00003VDGbF001', Amount = 2, AccountId = '0016g00003VDGbF001');
+    calc.setEvaluator(new RollupEvaluator.WhereFieldEvaluator('Amount != ' + opp.Amount, Opportunity.SObjectType));
+
+    calc.performRollup(new List<Opportunity>{ opp }, new Map<Id, SObject>());
+
+    System.assertEquals(15, calc.getReturnValue());
+  }
+
+  @IsTest
   static void resetsDefaultValuesBetweenCountDistinctRuns() {
     RollupCalculator calc = getCalculator(
       0,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.30",
+  "version": "1.5.31",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnoAAE">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLpLAAU">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLnoAAE">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zLpLAAU">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Fixes an issue where full batch recalculations could fail to pick up all calc items when the calc item amount for any given parent exceeded the Max Query Row limit",
-            "versionNumber": "1.0.3.0",
+            "versionName": "THIS_FISCAL_QUARTER date literal bugfix, FIRST/LAST now use default recalc values properly",
+            "versionNumber": "1.0.4.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -24,6 +24,7 @@
         "apex-rollup-namespaced@1.0.0-0": "04t6g000008b0iOAAQ",
         "apex-rollup-namespaced@1.0.1-0": "04t6g000008b0isAAA",
         "apex-rollup-namespaced@1.0.2-0": "04t6g000008b0nKAAQ",
-        "apex-rollup-namespaced@1.0.3-0": "04t6g000007zLnoAAE"
+        "apex-rollup-namespaced@1.0.3-0": "04t6g000007zLnoAAE",
+        "apex-rollup-namespaced@1.0.4-0": "04t6g000007zLpLAAU"
     }
 }

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -5,7 +5,7 @@ public without sharing abstract class RollupCalculator {
   private Boolean isRecursiveRecalc = false;
   private Boolean isFullRecalc = false;
 
-  private final Object defaultVal;
+  protected final Object defaultVal;
   protected final SObjectField opFieldOnCalcItem;
   protected final SObjectField opFieldOnLookupObject;
   protected final SObjectField lookupKeyField;
@@ -1171,13 +1171,17 @@ public without sharing abstract class RollupCalculator {
 
       calcItems = this.winnowItems(calcItems, oldCalcItems);
 
-      Integer retrievalIndex = 0;
-      switch on this.op {
-        when LAST, UPDATE_LAST, DELETE_LAST {
-          retrievalIndex = calcItems.size() - 1;
+      if (calcItems.isEmpty()) {
+        this.returnVal = this.defaultVal;
+      } else {
+        Integer retrievalIndex = 0;
+        switch on this.op {
+          when LAST, UPDATE_LAST, DELETE_LAST {
+            retrievalIndex = calcItems.size() - 1;
+          }
         }
+        this.returnVal = calcItems[retrievalIndex].get(this.opFieldOnCalcItem);
       }
-      this.returnVal = calcItems.isEmpty() ? null : calcItems[retrievalIndex].get(this.opFieldOnCalcItem);
     }
   }
 

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -337,7 +337,7 @@ public without sharing abstract class RollupCalculator {
     String operationName = Rollup.getBaseOperationName(op.name());
     String alias = operationName.toLowerCase() + 'Field';
     List<SObject> aggregate = this.tryQuery(sObjectType, new Set<String>{ operationName + '(' + this.opFieldOnCalcItem + ')' + alias }, objIds);
-    return aggregate.isEmpty() == false ? aggregate[0].get(alias) : null;
+    return aggregate.isEmpty() == false ? aggregate[0].get(alias) : this.defaultVal;
   }
 
   protected Boolean isReparented(SObject calcItem, SObject oldCalcItem) {
@@ -458,7 +458,6 @@ public without sharing abstract class RollupCalculator {
       Boolean isArchivable = sObjectType == Task.SObjectType || sObjectType == Event.SObjectType;
       Boolean isGroupable = isArchivable == false && this.opFieldOnCalcItem.getDescribe().isGroupable();
       List<String> queryFields = new List<String>{ String.valueOf(this.opFieldOnCalcItem) };
-      String calcItemOpField = this.opFieldOnCalcItem.getDescribe().getName();
       if (isGroupable) {
         queryFields.add(this.isIdCount ? 'COUNT()' : 'COUNT(Id)');
       }
@@ -474,6 +473,7 @@ public without sharing abstract class RollupCalculator {
         }
       } else {
         List<SObject> results = Database.query(query);
+        String calcItemOpField = this.opFieldOnCalcItem.getDescribe().getName();
         for (SObject res : results) {
           // have to use the String representation of the this.opFieldOnCalcItem to avoid:
           // System.SObjectException: SObject.FieldName does not belong to SObject type AggregateResult
@@ -630,6 +630,8 @@ public without sharing abstract class RollupCalculator {
       // but otherwise, it's more accurate to be nulling out the parent fields if there isn't a max, for example
       if (aggregate == 0 && op.name().contains('COUNT') == false) {
         aggregate = null;
+      } else if (aggregate == null) {
+        aggregate = this.defaultVal;
       }
       return aggregate;
     }
@@ -1197,6 +1199,7 @@ public without sharing abstract class RollupCalculator {
     ) {
       super(op, opFieldOnCalcItem, opFieldOnLookupObject, null, metadata, lookupKeyField);
     }
+    // TODO default full recalc value support
 
     public override void performRollup(List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
       this.occurrenceToCount.clear();
@@ -1229,6 +1232,7 @@ public without sharing abstract class RollupCalculator {
     ) {
       super(op, opFieldOnCalcItem, opFieldOnLookupObject, null, metadata, lookupKeyField);
     }
+    // TODO default full recalc value support
 
     public override void performRollup(List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
       this.returnVal = null;

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -480,7 +480,7 @@ public without sharing abstract class RollupCalculator {
           this.distinctValues.add(res.get(calcItemOpField));
         }
       }
-      return this.distinctValues.size();
+      return this.distinctValues.isEmpty() && this.defaultVal != null ? this.defaultVal : this.distinctValues.size();
     }
   }
 

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -354,7 +354,7 @@ public without sharing abstract class RollupCalculator {
       List<SObject> allOtherItems = this.tryQuery(sObjectType, queryFields, objIds);
       if (allOtherItems.isEmpty()) {
         // break out of recursion if there's nothing to calculate
-        this.returnVal = null;
+        this.returnVal = this.defaultVal;
       } else {
         Rollup.Op baseOp = Rollup.Op.valueOf(Rollup.getBaseOperationName(op.name()));
         RollupCalculator calc = Factory.getCalculator(baseOp, this.opFieldOnCalcItem, this.opFieldOnLookupObject, this.metadata, this.lookupKeyField);
@@ -459,7 +459,7 @@ public without sharing abstract class RollupCalculator {
       Boolean isGroupable = isArchivable == false && this.opFieldOnCalcItem.getDescribe().isGroupable();
       List<String> queryFields = new List<String>{ String.valueOf(this.opFieldOnCalcItem) };
       if (isGroupable) {
-        queryFields.add(this.isIdCount ? 'COUNT()' : 'COUNT(Id)');
+        queryFields.add('COUNT(' + (this.isIdCount ? '' : 'Id') + ')');
       }
 
       String query =
@@ -1108,7 +1108,7 @@ public without sharing abstract class RollupCalculator {
         newSum += potentialDecimal == null ? 0.00 : (Decimal) potentialDecimal;
       }
 
-      Decimal average = null;
+      Decimal average = (Decimal) this.defaultVal;
       // We can't do the division if the denominator is 0
       if (denominator != 0) {
         Decimal numerator = oldSum + newSum;
@@ -1126,19 +1126,7 @@ public without sharing abstract class RollupCalculator {
       Rollup__mdt metadata,
       SObjectField lookupKeyField
     ) {
-      super(
-        op,
-        opFieldOnCalcItem,
-        opFieldOnLookupObject,
-        // first/last could possibly use either default value
-        // we also have to cast to Object to avoid the compilation error:
-        // "Incompatible types in ternary operator: String, Decimal"
-        (metadata.FullRecalculationDefaultNumberValue__c != null
-          ? (Object) metadata.FullRecalculationDefaultNumberValue__c
-          : (Object) metadata.FullRecalculationDefaultStringValue__c),
-        metadata,
-        lookupKeyField
-      );
+      super(op, opFieldOnCalcItem, opFieldOnLookupObject, getDefaultRecalculationValue(metadata), metadata, lookupKeyField);
       Map<String, SObjectField> fieldMap = this.calcItemSObjectType.getDescribe().fields.getMap();
       for (RollupOrderBy__mdt orderByInfo : this.metadata.RollupOrderBys__r) {
         SObjectField orderByFirstLastField = fieldMap.get(orderByInfo.FieldName__c);
@@ -1197,14 +1185,13 @@ public without sharing abstract class RollupCalculator {
       Rollup__mdt metadata,
       SObjectField lookupKeyField
     ) {
-      super(op, opFieldOnCalcItem, opFieldOnLookupObject, null, metadata, lookupKeyField);
+      super(op, opFieldOnCalcItem, opFieldOnLookupObject, getDefaultRecalculationValue(metadata), metadata, lookupKeyField);
     }
-    // TODO default full recalc value support
 
     public override void performRollup(List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
       this.occurrenceToCount.clear();
       this.largestCountPointer = -1;
-      this.returnVal = null;
+      this.returnVal = this.defaultVal;
       List<SObject> localCalcItems = this.winnowItems(calcItems, oldCalcItems);
 
       for (SObject calcItem : localCalcItems) {
@@ -1230,9 +1217,8 @@ public without sharing abstract class RollupCalculator {
       Rollup__mdt metadata,
       SObjectField lookupKeyField
     ) {
-      super(op, opFieldOnCalcItem, opFieldOnLookupObject, null, metadata, lookupKeyField);
+      super(op, opFieldOnCalcItem, opFieldOnLookupObject, getDefaultRecalculationValue(metadata), metadata, lookupKeyField);
     }
-    // TODO default full recalc value support
 
     public override void performRollup(List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
       this.returnVal = null;
@@ -1248,6 +1234,11 @@ public without sharing abstract class RollupCalculator {
         }
       }
 
+      if (this.defaultVal != null && matches == false) {
+        this.returnVal = this.defaultVal;
+        return;
+      }
+
       switch on this.opFieldOnLookupObject.getDescribe().getType() {
         when CURRENCY, DOUBLE, INTEGER {
           this.returnVal = matches ? 1 : 0;
@@ -1260,5 +1251,14 @@ public without sharing abstract class RollupCalculator {
         }
       }
     }
+  }
+
+  private static Object getDefaultRecalculationValue(Rollup__mdt meta) {
+    // some operations could possibly use either default value
+    // we also have to cast to Object to avoid the compilation error:
+    // "Incompatible types in ternary operator: String, Decimal"
+    return (meta.FullRecalculationDefaultNumberValue__c != null
+      ? (Object) meta.FullRecalculationDefaultNumberValue__c
+      : (Object) meta.FullRecalculationDefaultStringValue__c);
   }
 }

--- a/rollup/core/classes/RollupDateLiteral.cls
+++ b/rollup/core/classes/RollupDateLiteral.cls
@@ -358,7 +358,7 @@ public without sharing abstract class RollupDateLiteral {
   private class NextWeekLiteral extends RollupDateLiteral {
     public NextWeekLiteral() {
       this.ref = getRelativeDatetime(System.today().toStartOfWeek().addDays(7), START_TIME);
-      this.bound = this.ref.addDays(7);
+      this.bound = getRelativeDatetime(this.ref.addDays(7).date(), END_TIME);
     }
   }
 
@@ -378,7 +378,7 @@ public without sharing abstract class RollupDateLiteral {
   private class ThisMonthLiteral extends RollupDateLiteral {
     public ThisMonthLiteral() {
       this.ref = getRelativeDatetime(System.today().toStartOfMonth(), START_TIME);
-      this.bound = this.ref.addMonths(1);
+      this.bound = getRelativeDatetime(this.ref.addMonths(1).date(), END_TIME);
     }
   }
 
@@ -389,6 +389,9 @@ public without sharing abstract class RollupDateLiteral {
     public NextMonthLiteral() {
       this.ref = getRelativeDatetime(System.today().toStartOfMonth().addMonths(1), START_TIME);
       this.bound = getRelativeDatetime(this.ref.addMonths(1).date(), END_TIME);
+      if (this.bound.dayGmt() != 1 && this.bound.day() == 1) {
+        this.bound = this.bound.addDays(-1);
+      }
     }
   }
 
@@ -510,7 +513,10 @@ public without sharing abstract class RollupDateLiteral {
     protected override void setDynamicValue(String num) {
       Integer dateRange = Integer.valueOf(num);
       this.ref = getRelativeDatetime(System.today().toStartOfMonth().addMonths(1), START_TIME);
-      this.bound = getRelativeDatetime(this.ref.addMonths(dateRange).date(), END_TIME);
+      this.bound = getRelativeDatetime(this.ref.addMonths(dateRange).date().toStartOfMonth(), END_TIME);
+      if (this.bound.dayGmt() != 1 && this.bound.day() == 1) {
+        this.bound = this.bound.addDays(-1);
+      }
     }
   }
 

--- a/rollup/core/classes/RollupDateLiteral.cls
+++ b/rollup/core/classes/RollupDateLiteral.cls
@@ -682,9 +682,10 @@ public without sharing abstract class RollupDateLiteral {
   /**
    * Starts 00:00:00 on the first day of the current fiscal quarter and continues through the end of the last day of the fiscal quarter.
    */
-  private class ThisFiscalQuarterLiteral extends ThisQuarterLiteral {
-    protected override Date getThisQuarterStart() {
-      return FISCAL_INFO.CurrentQuarterStartDate;
+  private class ThisFiscalQuarterLiteral extends RollupDateLiteral {
+    public ThisFiscalQuarterLiteral() {
+      this.ref = getRelativeDatetime(FISCAL_INFO.CurrentQuarterStartDate, START_TIME);
+      this.bound = getRelativeDatetime(FISCAL_INFO.CurrentQuarterEndDate, END_TIME);
     }
   }
 

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.30';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.31';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Fixes an issue where full batch recalculations could fail to pick up all calc items when the calc item amount for any given parent exceeded the Max Query Row limit",
-            "versionNumber": "1.5.30.0",
+            "versionName": "THIS_FISCAL_QUARTER date literal bugfix, batch full recalc speedup",
+            "versionNumber": "1.5.31.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "THIS_FISCAL_QUARTER date literal bugfix, batch full recalc speedup",
+            "versionName": "THIS_FISCAL_QUARTER date literal bugfix, FIRST/LAST now use default recalc values properly",
             "versionNumber": "1.5.31.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -102,6 +102,7 @@
         "apex-rollup@1.5.27-0": "04t6g000008b0iTAAQ",
         "apex-rollup@1.5.28-0": "04t6g000008b0inAAA",
         "apex-rollup@1.5.29-0": "04t6g000008b0nFAAQ",
-        "apex-rollup@1.5.30-0": "04t6g000007zLnjAAE"
+        "apex-rollup@1.5.30-0": "04t6g000007zLnjAAE",
+        "apex-rollup@1.5.31-0": "04t6g000007zLpGAAU"
     }
 }


### PR DESCRIPTION
* Added comprehensive support for rollup operations where, previously, if a Default Full Recalculation Value was supplied, it wasn't always used. As a reminder, `null` is the default value for parents without matching children (based on the same behavior that SOQL exhibits), but you can use `Rollup__mdt.FullRecalculationDefaultNumberValue__c` and `Rollup__mdt.FullRecalculationDefaultStringValue__c` to customize these values. All rollup operations now support those defaults.
* Fixed a few issues with rollup date literals - these have continued to persist, despite a comprehensive test suite for such things, because there are very subtle differences (sometimes on the order of a single second) in how date literals are calculated on the backend (with SOQL) and occasionally date math in Apex clashes with what the expected result might be.