### PR TITLE
v1.5.38 - Parent Recalc Button bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zMCdAAM">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjOcAAI">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zMCdAAM">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjOcAAI">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupCalculatorTests.cls
+++ b/extra-tests/classes/RollupCalculatorTests.cls
@@ -721,29 +721,6 @@ private class RollupCalculatorTests {
     System.assertEquals(opp.CloseDate, calc.getReturnValue());
   }
 
-  @IsTest
-  static void updateMostWorks() {
-    RollupCalculator calc = getCalculator(
-      null,
-      Rollup.Op.UPDATE_MOST,
-      Opportunity.CloseDate,
-      Account.AnnualRevenue,
-      new Rollup__mdt(CalcItem__c = 'Opportunity'),
-      '0011g00003VDGbF002',
-      Opportunity.AccountId
-    );
-
-    Opportunity opp = new Opportunity(CloseDate = System.today(), Id = RollupTestUtils.createId(Opportunity.SObjectType));
-    calc.performRollup(new List<SObject>{ opp }, new Map<Id, SObject>());
-
-    System.assertEquals(opp.CloseDate, calc.getReturnValue());
-
-    opp.CloseDate = opp.CloseDate.addDays(-1);
-    calc.performRollup(new List<SObject>{ opp }, new Map<Id, SObject>());
-
-    System.assertEquals(opp.CloseDate, calc.getReturnValue());
-  }
-
   // SUM tests
 
   @IsTest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.37",
+  "version": "1.5.38",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zMCiAAM">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjOhAAI">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000007zMCiAAM">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjOhAAI">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Adding support for dated conversion rates multi-currency orgs",
-            "versionNumber": "1.0.10.0",
+            "versionName": "Fixed a bug on the parent recalc button when used in conjunction with RollupOrderBy__mdt records. Added FlowOutput to Full Recalc CMDT-driven Invocable invocable",
+            "versionNumber": "1.0.11.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -31,6 +31,7 @@
         "apex-rollup-namespaced@1.0.7-0": "04t6g000007zLxLAAU",
         "apex-rollup-namespaced@1.0.8-0": "04t6g000007zM2gAAE",
         "apex-rollup-namespaced@1.0.9-0": "04t6g000007zM7DAAU",
-        "apex-rollup-namespaced@1.0.10-0": "04t6g000007zMCiAAM"
+        "apex-rollup-namespaced@1.0.10-0": "04t6g000007zMCiAAM",
+        "apex-rollup-namespaced@1.0.11-0": "04t6g000008fjOhAAI"
     }
 }

--- a/rollup/app/lwc/recalculateParentRollupFlexipage/__tests__/recalculateParentRollupFlexipage.test.js
+++ b/rollup/app/lwc/recalculateParentRollupFlexipage/__tests__/recalculateParentRollupFlexipage.test.js
@@ -154,6 +154,7 @@ describe('recalc parent rollup from flexipage tests', () => {
     // once recalc has finished ...
     // we need to validate that what was sent includes our custom rollup invocation point
     matchingMetadata[0].CalcItemWhereClause__c = " ||| AccountId = '" + FAKE_RECORD_ID + "'";
+    matchingMetadata[0].RollupOrderBys__r = { totalSize: 0, done: true, records: [] };
     expect(parentRecalcEl.shadowRoot.querySelector('lightning-spinner')).toBeFalsy();
     expect(performSerializedBulkFullRecalc.mock.calls[0][0]).toEqual({
       serializedMetadata: JSON.stringify(matchingMetadata),
@@ -183,6 +184,7 @@ describe('recalc parent rollup from flexipage tests', () => {
     await flushPromises();
 
     matchingMetadata[0].CalcItemWhereClause__c = " ||| RollupParent__r.RollupGrandparent__r.Id = '" + FAKE_RECORD_ID + "'";
+    matchingMetadata[0].RollupOrderBys__r = { totalSize: 0, done: true, records: [] };
     expect(parentRecalcEl.shadowRoot.querySelector('lightning-spinner')).toBeFalsy();
     expect(performSerializedBulkFullRecalc.mock.calls[0][0]).toEqual({
       serializedMetadata: JSON.stringify(matchingMetadata),
@@ -219,6 +221,7 @@ describe('recalc parent rollup from flexipage tests', () => {
     await flushPromises('wait for click event to call controller');
 
     matchingMetadata[0].please__CalcItemWhereClause__c = " ||| AccountId = '" + FAKE_RECORD_ID + "'";
+    matchingMetadata[0].please__RollupOrderBys__r = { totalSize: 0, done: true, records: [] };
     expect(parentRecalcEl.shadowRoot.querySelector('lightning-spinner')).toBeFalsy();
     expect(performSerializedBulkFullRecalc.mock.calls[0][0]).toEqual({
       serializedMetadata: JSON.stringify(matchingMetadata),

--- a/rollup/app/lwc/recalculateParentRollupFlexipage/recalculateParentRollupFlexipage.js
+++ b/rollup/app/lwc/recalculateParentRollupFlexipage/recalculateParentRollupFlexipage.js
@@ -2,7 +2,7 @@ import { api, LightningElement } from 'lwc';
 import performSerializedBulkFullRecalc from '@salesforce/apex/Rollup.performSerializedBulkFullRecalc';
 import getNamespaceInfo from '@salesforce/apex/Rollup.getNamespaceInfo';
 
-import { getRollupMetadata } from 'c/rollupUtils';
+import { getRollupMetadata, transformToSerializableChildren } from 'c/rollupUtils';
 
 const DELIMITER = ' ||| ';
 
@@ -73,6 +73,10 @@ export default class RecalculateParentRollupFlexipage extends LightningElement {
     } else {
       metadata[calcItemWhereClause] = DELIMITER + equalsParent;
     }
+    const orderByFieldName = this._getNamespaceSafeFieldName('RollupOrderBys__r');
+    const children = metadata[orderByFieldName];
+    transformToSerializableChildren(metadata, orderByFieldName, children);
+
     this._matchingMetas.push(metadata);
   }
 

--- a/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.html
+++ b/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.html
@@ -6,6 +6,12 @@
         Alternatively, you can select a single Child Object based off of your CMDT rollup records and have the recalculation run for all CMDT associated with
         that SObject type:
       </div>
+      <template if:true={isLoadingCustomMetadata}>
+        <div class="slds-is-relative slds-is-fixed-left">
+          Checking if there's custom metadata ...
+          <lightning-spinner alternative-text="Please wait while CMDT is retrieved" title="Checking if there's custom metadata ...."></lightning-spinner>
+        </div>
+      </template>
       <template if:true={canDisplayCmdtToggle}>
         <lightning-input class="slds-m-bottom_small" data-id="cmdt-toggle" label="Run off of CMDT?" onchange={handleToggle} type="toggle"></lightning-input>
       </template>

--- a/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js
+++ b/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js
@@ -123,7 +123,9 @@ export default class RollupForceRecalculation extends LightningElement {
   }
 
   async _fetchAvailableCMDT() {
+    this.isLoadingCustomMetadata = true;
     this._localMetadata = await getRollupMetadata();
+    this.isLoadingCustomMetadata = false;
 
     Object.keys(this._localMetadata).forEach(localMeta => {
       if (!this.canDisplayCmdtToggle) {
@@ -156,11 +158,12 @@ export default class RollupForceRecalculation extends LightningElement {
           this._displayErrorToast('Select a valid option', 'Child Object(s) must be selected!');
           return;
         }
-
+        this.isRollingUp = true;
         const localMetas = [...this.selectedRows];
         this._getMetadataWithChildrenRecords(localMetas);
         jobId = await performSerializedBulkFullRecalc({ serializedMetadata: JSON.stringify(localMetas), invokePointName: 'FROM_FULL_RECALC_LWC' });
       } else {
+        this.isRollingUp = true;
         this._getMetadataWithChildrenRecords([this._metadata]);
         jobId = await performSerializedFullRecalculation({
           metadata: JSON.stringify(this._metadata)
@@ -179,7 +182,6 @@ export default class RollupForceRecalculation extends LightningElement {
       this.rollupStatus = 'Job failed to enqueue, check logs for more info';
       return Promise.resolve();
     }
-    this.isRollingUp = true;
 
     this.jobIdToDisplay = jobId;
     this.rollupStatus = await getBatchRollupStatus({ jobId });

--- a/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js
+++ b/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js
@@ -6,7 +6,7 @@ import performSerializedFullRecalculation from '@salesforce/apex/Rollup.performS
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import { getObjectInfo, getPicklistValues } from 'lightning/uiObjectInfoApi';
 
-import { getRollupMetadata } from 'c/rollupUtils';
+import { getRollupMetadata, transformToSerializableChildren } from 'c/rollupUtils';
 
 const MAX_ROW_SELECTION = 200;
 
@@ -223,9 +223,7 @@ export default class RollupForceRecalculation extends LightningElement {
           children = possibleOrderByComponent.orderBys;
         }
       }
-      if (children && !children.totalSize) {
-        _metadata[rollupOrderByFieldName] = { totalSize: children?.length, done: true, records: children };
-      }
+      transformToSerializableChildren(_metadata, rollupOrderByFieldName, children);
     }
   }
 

--- a/rollup/app/lwc/rollupUtils/rollupUtils.js
+++ b/rollup/app/lwc/rollupUtils/rollupUtils.js
@@ -32,4 +32,10 @@ const getRollupMetadata = async () => {
   return cleanedMetaByCalcItem;
 };
 
-export { getRollupMetadata };
+const transformToSerializableChildren = (record, key, children) => {
+  if (children && !children.totalSize) {
+    record[key] = { totalSize: children?.length ?? 0, done: true, records: children ?? [] };
+  }
+};
+
+export { getRollupMetadata, transformToSerializableChildren };

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -45,6 +45,7 @@ global without sharing virtual class Rollup {
   protected Boolean isCDCUpdate = false;
   protected Integer queryCount;
   protected RollupCalcItemReplacer calcItemReplacer;
+  protected TriggerOperation triggerContext;
 
   // Lazy-load section. Lots of additional lines, but with the benefit that we keep the heap size down for instances of Rollup
   // that never reference these variables
@@ -169,7 +170,6 @@ global without sharing virtual class Rollup {
     CONCAT,
     COUNT_DISTINCT,
     COUNT,
-    DELETE_ALL,
     DELETE_AVERAGE,
     DELETE_CONCAT_DISTINCT,
     DELETE_CONCAT,
@@ -179,10 +179,7 @@ global without sharing virtual class Rollup {
     DELETE_LAST,
     DELETE_MAX,
     DELETE_MIN,
-    DELETE_MOST,
-    DELETE_NONE,
     DELETE_SUM,
-    DELETE_SOME,
     FIRST,
     LAST,
     MAX,
@@ -191,7 +188,6 @@ global without sharing virtual class Rollup {
     NONE,
     SOME,
     SUM,
-    UPDATE_ALL,
     UPDATE_AVERAGE,
     UPDATE_CONCAT_DISTINCT,
     UPDATE_CONCAT,
@@ -201,10 +197,7 @@ global without sharing virtual class Rollup {
     UPDATE_LAST,
     UPDATE_MAX,
     UPDATE_MIN,
-    UPDATE_MOST,
-    UPDATE_NONE,
-    UPDATE_SUM,
-    UPDATE_SOME
+    UPDATE_SUM
   }
 
   public class FilterResults {
@@ -1982,11 +1975,12 @@ global without sharing virtual class Rollup {
       } else {
         // if the same items get run through different rollup operations in the same transaction (rare, but not impossible ...)
         // we need to reset the CMDT to the correct base operation prior to appending the new context
-        meta.RollupOperation__c =
-          rollupContext +
-          (meta.RollupOperation__c.contains('UPDATE_') || meta.RollupOperation__c.contains('DELETE_')
-            ? meta.RollupOperation__c.substringAfter('_')
-            : meta.RollupOperation__c);
+        meta.RollupOperation__c = (meta.RollupOperation__c.contains('UPDATE_') || meta.RollupOperation__c.contains('DELETE_')
+          ? meta.RollupOperation__c.substringAfter('_')
+          : meta.RollupOperation__c);
+        if (OP_NAME_TO_OP.containsKey(rollupContext + meta.RollupOperation__c)) {
+          meta.RollupOperation__c = rollupContext + meta.RollupOperation__c;
+        }
       }
     }
 
@@ -2481,6 +2475,7 @@ global without sharing virtual class Rollup {
         matchingOperation = TriggerOperation.BEFORE_DELETE;
       }
     }
+    apexContext = matchingOperation;
     populateCachedApexOperations(sObjectType, matchingOperation);
 
     return flowContext == 'INSERT' ? '' : flowContext + '_';
@@ -2847,6 +2842,7 @@ global without sharing virtual class Rollup {
       rollupControl,
       rollupMetadata
     );
+    processor.triggerContext = apexContext;
     return addRollup(rollupConductor, processor);
   }
 

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -653,7 +653,7 @@ global without sharing virtual class Rollup {
   global class FlowOutput {
     @InvocableVariable(label='Is Success' description='Was rollup enqueued successfully?')
     global Boolean isSuccess;
-    @InvocableVariable(label='Status Message' description='"SUCCESS" when isSuccess is true, otherwise the encountered error message')
+    @InvocableVariable(label='Status Message' description='"SUCCESS" (or more info) when isSuccess is true, otherwise the encountered error message')
     global String message;
     global FlowOutput() {
       this.isSuccess = true;

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -1079,6 +1079,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     Map<String, SObject> unprocessedCalcItems = new Map<String, SObject>();
     RollupSObjectUpdater updater = new RollupSObjectUpdater(roll.opFieldOnLookupObject);
     RollupCalculator calc;
+    String priorKey;
     for (Integer index = lookupItems.size() - 1; index >= 0; index--) {
       SObject lookupRecord = lookupItems[index];
       if (lookupRecord.getSObjectType() != roll.lookupObj) {
@@ -1113,6 +1114,14 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
           Object priorValToUse = roll.isFullRecalc && this.parentRollupFieldHasBeenReset(roll, lookupRecord) == false ? null : priorVal;
           calc = this.getCalculator(calc, roll, localCalcItems, lookupRecord, priorValToUse, key, roll.lookupFieldOnCalcItem);
           this.conditionallyPerformUpdate(priorVal, calc, lookupRecord, roll, recordsToUpdate, updater, 'lookup', localCalcItems);
+        }
+        if (priorKey != null && key != priorKey) {
+          // once we've fully processed a parent (in separate batches)
+          // it's safe to clear the stateful map
+          this.fullRecalcProcessor?.previouslyResetParents.remove(priorKey);
+          priorKey = key;
+        } else if (priorKey == null) {
+          priorKey = key;
         }
       }
     }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -663,6 +663,12 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     return this.metadata?.ShouldRunWithoutCustomSettingEnabled__c == true;
   }
 
+  private void clearPreviouslyResetParents(RollupAsyncProcessor processor, SObject parent) {
+    String key = this.getParentResetKey(String.valueOf(processor.opFieldOnLookupObject), parent);
+    this.previouslyResetParents.remove(key);
+    this.fullRecalcProcessor?.previouslyResetParents.remove(key);
+  }
+
   private Boolean hasParentRollupFieldBeenReset(String rollupFieldName, SObject parent) {
     String resetKey = this.getParentResetKey(rollupFieldName, parent);
     Boolean hasParentRollupFieldBeenReset = this.previouslyResetParents.contains(resetKey);
@@ -1118,7 +1124,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         if (priorKey != null && key != priorKey) {
           // once we've fully processed a parent (in separate batches)
           // it's safe to clear the stateful map
-          this.fullRecalcProcessor?.previouslyResetParents.remove(priorKey);
+          this.clearPreviouslyResetParents(roll, lookupRecord);
           priorKey = key;
         } else if (priorKey == null) {
           priorKey = key;

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -463,7 +463,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       // calling clear in a loop here might look interesting - and it would be a massive problem if not for the
       // bag only responding to the very first clear() invocation. everything after that is a no-op (so, any rollup with more
       // than one rollup operation going at a time)
-      if (rollup.op.name().contains('DELETE')) {
+      if (rollup.triggerContext == System.TriggerOperation.BEFORE_DELETE) {
         bag.clear();
       }
     }
@@ -942,7 +942,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   private Boolean isEmptyReparentingSet(Op operation) {
     switch on operation {
       // reparenting is handled already for these operations
-      when ALL, DELETE_ALL, DELETE_MOST, DELETE_NONE, DELETE_SOME, MOST, NONE, SOME, UPDATE_ALL, UPDATE_MOST, UPDATE_NONE, UPDATE_SOME {
+      when ALL, MOST, NONE, SOME {
         return true;
       }
       when else {

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -46,7 +46,7 @@ public without sharing abstract class RollupCalculator {
     ) {
       RollupCalculator calc;
       switch on op {
-        when ALL, DELETE_ALL, DELETE_NONE, DELETE_SOME, NONE, SOME, UPDATE_ALL, UPDATE_NONE, UPDATE_SOME {
+        when ALL, NONE, SOME {
           calc = new ConditionalCalculator(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField);
         }
         when AVERAGE, UPDATE_AVERAGE, DELETE_AVERAGE {
@@ -61,7 +61,7 @@ public without sharing abstract class RollupCalculator {
         when FIRST, UPDATE_FIRST, DELETE_FIRST, LAST, UPDATE_LAST, DELETE_LAST {
           calc = new FirstLastRollupCalculator(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField);
         }
-        when MOST, DELETE_MOST, UPDATE_MOST {
+        when MOST {
           calc = new MostRollupCalculator(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField);
         }
         when else {
@@ -304,7 +304,7 @@ public without sharing abstract class RollupCalculator {
       }
       if (currentItemMatches) {
         items.add(this.getTransformedCalcItem(item));
-        if (this.op == Rollup.Op.SOME || this.op == Rollup.Op.UPDATE_SOME) {
+        if (this.op == Rollup.Op.SOME) {
           break;
         }
       }
@@ -1228,10 +1228,10 @@ public without sharing abstract class RollupCalculator {
       List<SObject> filteredItems = this.winnowItems(new List<SObject>(calcItems), oldCalcItems);
       Boolean matches = false;
       switch on this.op {
-        when ALL, DELETE_ALL, UPDATE_ALL {
+        when ALL {
           matches = calcItems.size() == filteredItems.size();
         }
-        when NONE, DELETE_NONE, DELETE_SOME, SOME, UPDATE_NONE, UPDATE_SOME {
+        when NONE, SOME {
           matches = filteredItems.isEmpty() == this.op.name().contains(Rollup.Op.SOME.name()) == false;
         }
       }

--- a/rollup/core/classes/RollupCurrencyInfo.cls
+++ b/rollup/core/classes/RollupCurrencyInfo.cls
@@ -10,6 +10,8 @@ public without sharing virtual class RollupCurrencyInfo {
   private static Boolean hasLoadedDatedCurrencyInfo = false;
 
   // Can't be Schema.SObjectType => Schema.SObjectField because not all orgs have OppLineItems/Splits
+  // TODO technically there's a hierarchy for OpportunityLineItem that goes Opportunity.CloseDate > ServiceDate > (ProductDate || ScheduleDate)
+  // it may make more sense to have a switch on the SObjectType and handle accordingly
   private static final Map<String, List<String>> DATED_MULTICURRENCY_SUPPORTED_OBJECTS = new Map<String, List<String>>{
     'Opportunity' => new List<String>{ 'CloseDate' },
     'OpportunityLineItem' => new List<String>{ 'ServiceDate' },

--- a/rollup/core/classes/RollupFlowFullRecalcDispatcher.cls
+++ b/rollup/core/classes/RollupFlowFullRecalcDispatcher.cls
@@ -9,7 +9,7 @@ global without sharing class RollupFlowFullRecalcDispatcher {
   }
 
   @InvocableMethod(category='Rollups' label='Full Recalc CMDT-driven Invocable')
-  public static void performFullRecalcRollups(List<FlowInput> inputs) {
+  public static List<Rollup.FlowOutput> performFullRecalcRollups(List<FlowInput> inputs) {
     List<Rollup__mdt> localRollupMetadata = Rollup.getMetadataFromCache(Rollup__mdt.SObjectType);
     Set<String> rollupDeveloperNames = new Set<String>();
     for (FlowInput input : inputs) {
@@ -27,8 +27,14 @@ global without sharing class RollupFlowFullRecalcDispatcher {
         selectedRollupMetadata.add(rollup);
       }
     }
+    List<Rollup.FlowOutput> flowOutputs = new List<Rollup.FlowOutput>();
+    Rollup.FlowOutput flowOutput = new Rollup.FlowOutput();
+    flowOutput.message = 'No matching metadata, did not start bulk full recalc';
+    flowOutputs.add(flowOutput);
     if (selectedRollupMetadata.isEmpty() == false) {
-      Rollup.performBulkFullRecalc(selectedRollupMetadata, Rollup.InvocationPoint.FROM_FULL_RECALC_FLOW.name());
+      String enqueuedJobId = Rollup.performBulkFullRecalc(selectedRollupMetadata, Rollup.InvocationPoint.FROM_FULL_RECALC_FLOW.name());
+      flowOutput.message = 'Job enqueued with Id: ' + enqueuedJobId;
     }
+    return flowOutputs;
   }
 }

--- a/rollup/core/classes/RollupFullRecalcProcessor.cls
+++ b/rollup/core/classes/RollupFullRecalcProcessor.cls
@@ -88,7 +88,6 @@ public abstract without sharing class RollupFullRecalcProcessor extends RollupAs
   public override void storeParentResetField(RollupAsyncProcessor processor, SObject parent) {
     this.addToPreviouslyResetParents(processor, parent);
     this.postProcessor?.recordIds.add(parent.Id);
-    this.postProcessor?.addToPreviouslyResetParents(processor, parent);
   }
 
   public void storeParentFieldsToClear(List<SObject> parentRecordsToClear) {

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.38-beta';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.38';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.37';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.38-beta';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "TODO",
+            "versionName": "Fixed a bug on the parent recalc button when used in conjunction with RollupOrderBy__mdt records. Added FlowOutput to Full Recalc CMDT-driven Invocable invocable",
             "versionNumber": "1.5.38.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -103,6 +103,7 @@
         "apex-rollup@1.5.34-0": "04t6g000007zLxGAAU",
         "apex-rollup@1.5.35-0": "04t6g000007zM2bAAE",
         "apex-rollup@1.5.36-0": "04t6g000007zM78AAE",
-        "apex-rollup@1.5.37-0": "04t6g000007zMCdAAM"
+        "apex-rollup@1.5.37-0": "04t6g000007zMCdAAM",
+        "apex-rollup@1.5.38-0": "04t6g000008fjOcAAI"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Adding support for dated conversion rates multi-currency orgs",
-            "versionNumber": "1.5.37.0",
+            "versionName": "TODO",
+            "versionNumber": "1.5.38.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
* fixes a bug reported by Stephen Stanley where the parent recalc button failed if Rollup Order Bys were defined
* trims even further down on heap size usage by clearing a stateful map being used by the batch full recalc processor - it's only necessary to maintain state until a parent record has finished being processed, at which point a ton of heap can be freed up by 
* removed a few unneeded enum values for operations like `MOST`, `ALL`, `NONE` and `SOME` since most code paths here follow the same logic
* now provide feedback faster when clicking the "Start Rollup!" button on the full recalc app. Thanks to @benblackthorn and @attilah for reporting this issue!