### PR TITLE
V1.5.40 - Enable Logging for Custom RollupControl__mdt records

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjSFAAY">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjSUAAY">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjSFAAY">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjSUAAY">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -254,10 +254,10 @@ private class RollupFullRecalcTests {
 
     List<Rollup__mdt> metadata = new List<Rollup__mdt>{
       new Rollup__mdt(
-        CalcItem__c = Application__c.SObjectType.getDescribe().getName(),
+        CalcItem__c = Application__c.SObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getName(),
         LookupObject__c = 'Account',
         RollupToUltimateParent__c = true,
-        LookupFieldOnCalcItem__c = ParentApplication__c.SObjectType.getDescribe().getName(),
+        LookupFieldOnCalcItem__c = Application__c.ParentApplication__c.getDescribe().getName(),
         UltimateParentLookup__c = 'ParentId',
         RollupOperation__c = 'SUM',
         RollupFieldOnLookupObject__c = 'AnnualRevenue',
@@ -298,9 +298,9 @@ private class RollupFullRecalcTests {
 
     List<Rollup__mdt> metadata = new List<Rollup__mdt>{
       new Rollup__mdt(
-        CalcItem__c = Application__c.SObjectType.getDescribe().getName(),
+        CalcItem__c = Application__c.SObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getName(),
         LookupObject__c = 'Individual',
-        LookupFieldOnCalcItem__c = ParentApplication__c.SObjectType.getDescribe().getName(),
+        LookupFieldOnCalcItem__c = Application__c.ParentApplication__c.getDescribe().getName(),
         RollupOperation__c = 'SUM',
         RollupFieldOnLookupObject__c = 'ConsumerCreditScore',
         RollupFieldOnCalcItem__c = Application__c.Engagement_Score__c.getDescribe().getName(),
@@ -1580,10 +1580,10 @@ private class RollupFullRecalcTests {
 
     List<Rollup__mdt> metas = new List<Rollup__mdt>{
       new Rollup__mdt(
-        CalcItem__c = RollupChild__c.SObjectType.getDescribe().getName(),
+        CalcItem__c = RollupChild__c.SObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getName(),
         RollupFieldOnCalcItem__c = RollupChild__c.NumberField__c.getDescribe().getName(),
         LookupFieldOnCalcItem__c = RollupChild__c.RollupParent__c.getDescribe().getName(),
-        LookupObject__c = RollupGrandparent__c.SObjectType.getDescribe().getName(),
+        LookupObject__c = RollupGrandparent__c.SObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getName(),
         LookupFieldOnLookupObject__c = RollupGrandparent__c.Id.getDescribe().getName(),
         RollupFieldOnLookupObject__c = RollupGrandparent__c.AmountFromChildren__c.getDescribe().getName(),
         RollupOperation__c = 'SUM',

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -123,7 +123,7 @@ private class RollupIntegrationTests {
     ParentApplication__c parentApp = new ParentApplication__c(Name = 'Hi');
     insert parentApp;
 
-    String baseId = Application__c.SObjectType.getDescribe().getKeyPrefix() + '0'.repeat(11);
+    String baseId = Application__c.SObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getKeyPrefix() + '0'.repeat(11);
     List<Application__c> applications = new List<Application__c>{
       new Application__c(
         Id = baseId + 1,
@@ -156,7 +156,7 @@ private class RollupIntegrationTests {
     input.rollupFieldOnCalcItem = Application__c.Engagement_Score__c.getDescribe().getName();
     input.rollupFieldOnOpObject = ParentApplication__c.Engagement_Rollup__c.getDescribe().getName();
     input.rollupOperation = 'AVERAGE';
-    input.rollupSObjectName = ParentApplication__c.SObjectType.getDescribe().getName();
+    input.rollupSObjectName = ParentApplication__c.SObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getName();
     input.calcItemWhereClause =
       Application__c.Something_With_Underscores__c.getDescribe().getName() +
       ' != \'' +
@@ -522,9 +522,9 @@ private class RollupIntegrationTests {
     input.rollupFieldOnCalcItem = Application__c.Engagement_Score__c.getDescribe().getName();
     input.rollupFieldOnOpObject = ParentApplication__c.Engagement_Rollup__c.getDescribe().getName();
     input.rollupOperation = 'SUM';
-    input.rollupSObjectName = ParentApplication__c.SObjectType.getDescribe().getName();
+    input.rollupSObjectName = ParentApplication__c.SObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getName();
     input.isRollupStartedFromParent = true;
-    input.calcItemTypeWhenRollupStartedFromParent = Application__c.SObjectType.getDescribe().getName();
+    input.calcItemTypeWhenRollupStartedFromParent = Application__c.SObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getName();
 
     Test.startTest();
     Rollup.performRollup(new List<Rollup.FlowInput>{ input });
@@ -610,7 +610,7 @@ private class RollupIntegrationTests {
     Rollup.records = appLogs;
     Rollup.rollupMetadata = new List<Rollup__mdt>{
       new Rollup__mdt(
-        CalcItem__c = ApplicationLog__c.SObjectType.getDescribe().getName(),
+        CalcItem__c = ApplicationLog__c.SObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getName(),
         RollupFieldOnCalcItem__c = ApplicationLog__c.Object__c.getDescribe().getName(),
         LookupFieldOnCalcItem__c = ApplicationLog__c.Application__c.getDescribe().getName(),
         LookupObject__c = 'Account',
@@ -757,7 +757,7 @@ private class RollupIntegrationTests {
     Rollup.shouldFlattenAsyncProcesses = true;
     Rollup.rollupMetadata = new List<Rollup__mdt>{
       new Rollup__mdt(
-        CalcItem__c = ApplicationLog__c.SObjectType.getDescribe().getName(),
+        CalcItem__c = ApplicationLog__c.SObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getName(),
         RollupFieldOnCalcItem__c = 'Name',
         LookupFieldOnCalcItem__c = ApplicationLog__c.Application__c.getDescribe().getName(),
         LookupObject__c = 'Account',
@@ -811,7 +811,7 @@ private class RollupIntegrationTests {
     Rollup.shouldRun = true;
     Rollup.FlowInput input = new Rollup.FlowInput();
     input.recordsToRollup = parentApps;
-    input.calcItemTypeWhenRollupStartedFromParent = ApplicationLog__c.SObjectType.getDescribe().getName();
+    input.calcItemTypeWhenRollupStartedFromParent = ApplicationLog__c.SObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getName();
     input.rollupFieldOnCalcItem = ApplicationLog__c.Name.getDescribe().getName();
     input.lookupFieldOnCalcItem = ApplicationLog__c.Application__c.getDescribe().getName();
     input.rollupSObjectName = 'Account';

--- a/extra-tests/classes/RollupLoggerTests.cls
+++ b/extra-tests/classes/RollupLoggerTests.cls
@@ -1,11 +1,10 @@
 @IsTest
-public class RollupLoggerTests {
+private class RollupLoggerTests {
   static Boolean wasSaved = false;
   static Object localLogObject;
   static String locallogString;
   static LoggingLevel localLogLevel;
 
-  // Type.forName requires public visibility
   @IsTest
   static void shouldLogUsingCustomLoggerWhenSupplied() {
     setup();
@@ -19,7 +18,6 @@ public class RollupLoggerTests {
   @IsTest
   static void shouldLogCustomObjectWhenSupplied() {
     setup();
-
     Account acc = new Account();
 
     RollupLogger.Instance.log('hello', acc, LoggingLevel.FINE);
@@ -58,11 +56,28 @@ public class RollupLoggerTests {
     System.assertEquals(false, wasSaved);
   }
 
+  @IsTest
+  static void updatesRollupControlForLoggers() {
+    Rollup.defaultControl = new RollupControl__mdt(IsRollupLoggingEnabled__c = false);
+    RollupPlugin.pluginMocks = new List<RollupPlugin__mdt>{ new RollupPlugin__mdt(DeveloperName = ControlUpdatingLogger.class.getName()) };
+
+    RollupLogger.Instance.log('Should not be logged', LoggingLevel.DEBUG);
+    System.assertEquals('logging isn\'t enabled, no further output', localLogString);
+
+    RollupLogger.Instance.updateRollupControl(new RollupControl__mdt(IsRollupLoggingEnabled__c = true));
+    String expectedLogMessage = 'hi';
+    RollupLogger.Instance.log(expectedLogMessage, LoggingLevel.INFO);
+
+    System.assertEquals(expectedLogMessage, localLogString);
+    System.assertEquals(LoggingLevel.INFO, localLogLevel);
+  }
+
   private static void setup() {
     Rollup.defaultControl = new RollupControl__mdt(IsRollupLoggingEnabled__c = true);
     RollupPlugin.pluginMocks = new List<RollupPlugin__mdt>{ new RollupPlugin__mdt(DeveloperName = ExampleLogger.class.getName()) };
   }
 
+  // Type.forName requires public visibility
   public class ExampleLogger implements RollupLogger.ILogger {
     public void log(String logString, LoggingLevel logLevel) {
       locallogString = logString;
@@ -75,6 +90,16 @@ public class RollupLoggerTests {
     }
     public void save() {
       wasSaved = true;
+    }
+    public ExampleLogger updateRollupControl(RollupControl__mdt control) {
+      return this;
+    }
+  }
+
+  public class ControlUpdatingLogger extends RollupLogger {
+    public override void log(String logString, Object logObject, System.LoggingLevel logLevel) {
+      locallogString = logString;
+      localLogLevel = logLevel;
     }
   }
 }

--- a/extra-tests/classes/RollupTestUtils.cls
+++ b/extra-tests/classes/RollupTestUtils.cls
@@ -6,7 +6,7 @@ public class RollupTestUtils {
   private static Integer startingNumber = 1;
   public static String createId(Schema.SObjectType sObjectType) {
     String result = String.valueOf(startingNumber++);
-    return sObjectType.getDescribe().getKeyPrefix() + '0'.repeat(12 - result.length()) + result;
+    return sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getKeyPrefix() + '0'.repeat(12 - result.length()) + result;
   }
 
   public static List<Rollup.FlowInput> prepareFlowTest(List<SObject> records, String rollupContext, String rollupOperation) {
@@ -19,7 +19,7 @@ public class RollupTestUtils {
     flowInput.rollupContext = rollupContext;
     flowInput.rollupFieldOnCalcItem = ContactPointAddress.PreferenceRank.getDescribe().getName();
     flowInput.rollupFieldOnOpObject = Account.AnnualRevenue.getDescribe().getName();
-    flowInput.rollupSObjectName = Account.SObjectType.getDescribe().getName();
+    flowInput.rollupSObjectName = Account.SObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getName();
     flowInput.rollupOperation = rollupOperation;
     flowInput.splitConcatDelimiterOnCalcItem = false;
 

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -3764,7 +3764,7 @@ private class RollupTests {
   static void encapsulatesNamespaceInfoProperly() {
     Rollup.NamespaceInfo namespaceInfo = Rollup.getNamespaceInfo();
 
-    String rollupObjectName = Rollup__mdt.SObjectType.getDescribe().getName();
+    String rollupObjectName = Rollup__mdt.SObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getName();
     System.assertEquals(rollupObjectName + '.' + Rollup__mdt.RollupOperation__c.getDescribe().getName(), nameSpaceInfo.safeRollupOperationField);
     System.assertEquals(rollupObjectName, nameSpaceInfo.safeObjectName);
     System.assertEquals(Rollup.class.getName() == 'Rollup' ? '' : Rollup.class.getName().substringBefore('.Rollup') + '__', nameSpaceInfo.namespace);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.39",
+  "version": "1.5.40",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjSKAAY">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjSZAAY">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjSKAAY">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjSZAAY">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Making Rollup.flatten() safer",
-            "versionNumber": "1.0.12.0",
+            "versionName": "Logging updates to respect specific Rollup Controls when they differ from the Org Default",
+            "versionNumber": "1.0.13.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -33,6 +33,7 @@
         "apex-rollup-namespaced@1.0.9-0": "04t6g000007zM7DAAU",
         "apex-rollup-namespaced@1.0.10-0": "04t6g000007zMCiAAM",
         "apex-rollup-namespaced@1.0.11-0": "04t6g000008fjOhAAI",
-        "apex-rollup-namespaced@1.0.12-0": "04t6g000008fjSKAAY"
+        "apex-rollup-namespaced@1.0.12-0": "04t6g000008fjSKAAY",
+        "apex-rollup-namespaced@1.0.13-0": "04t6g000008fjSZAAY"
     }
 }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -47,6 +47,8 @@ global without sharing virtual class Rollup {
   protected RollupCalcItemReplacer calcItemReplacer;
   protected TriggerOperation triggerContext;
 
+  private Boolean hasResetLogger = false;
+
   // Lazy-load section. Lots of additional lines, but with the benefit that we keep the heap size down for instances of Rollup
   // that never reference these variables
   private static final Map<SObjectType, Set<TriggerOperation>> CACHED_APEX_OPERATIONS {
@@ -119,6 +121,19 @@ global without sharing virtual class Rollup {
       return rollups;
     }
     set;
+  }
+
+  protected final RollupLogger.ILogger logger {
+    get {
+      if (this.logger == null) {
+        this.logger = RollupLogger.Instance;
+      } else if (this.getIsRunningAsync() && this.hasResetLogger == false) {
+        this.hasResetLogger = true;
+        RollupLogger.setLogger(this.logger);
+      }
+      return logger;
+    }
+    private set;
   }
 
   /**
@@ -315,7 +330,7 @@ global without sharing virtual class Rollup {
   }
 
   public virtual String runCalc() {
-    RollupLogger.Instance.log('no-op!', LoggingLevel.WARN);
+    this.logger.log('no-op!', LoggingLevel.WARN);
     return 'Not implemented';
   }
 
@@ -477,6 +492,7 @@ global without sharing virtual class Rollup {
       }
     }
     List<Rollup__mdt> matchingMetadata = (List<Rollup__mdt>) JSON.deserialize(serializedMetadata, List<Rollup__mdt>.class);
+    updateLoggingControl(matchingMetadata);
     RollupLogger.Instance.log('bulk full recalc called with data:', matchingMetadata, LoggingLevel.DEBUG);
 
     String potentialWhereClause = '';
@@ -728,6 +744,8 @@ global without sharing virtual class Rollup {
     }
     if (metaToInputWrapper.isEmpty()) {
       return flowOutputs;
+    } else {
+      updateLoggingControl(new List<Rollup__mdt>(metaToInputWrapper.keySet()));
     }
 
     Map<SObjectType, List<Rollup>> localRollups = new Map<SObjectType, List<Rollup>>();
@@ -2580,6 +2598,7 @@ global without sharing virtual class Rollup {
      */
     Map<String, SObjectField> calcItemFields = sObjectType.getDescribe().fields.getMap();
     RollupFieldInitializer init = RollupFieldInitializer.Current;
+    updateLoggingControl(rollupOperations);
 
     for (Rollup__mdt rollupMetadata : rollupOperations) {
       Op rollupOp = OP_NAME_TO_OP.get(rollupMetadata.RollupOperation__c.toUpperCase());
@@ -2613,6 +2632,9 @@ global without sharing virtual class Rollup {
         localControl = getSingleControlOrDefault(RollupControl__mdt.TriggerOrInvocableName__c, controlKey, specificControl);
       }
       setControlToSyncForSingularParentRecalcs(localControl, rollupInvokePoint);
+      if (rollupConductor.rollupControl != null && rollupConductor.rollupControl != localControl) {
+        rollupConductor.rollupControl.IsRollupLoggingEnabled__c = localControl.IsRollupLoggingEnabled__c;
+      }
 
       FilterResults filterResults = filter(calcItems, oldCalcItems, eval, rollupMetadata, sObjectType, rollupConductor.calcItemReplacer);
 
@@ -2936,5 +2958,20 @@ global without sharing virtual class Rollup {
       }
     }
     return results;
+  }
+
+  private static void updateLoggingControl(List<Rollup__mdt> metadatas) {
+    Id controlId;
+    for (Rollup__mdt meta : metadatas) {
+      if (controlId == null || meta.RollupControl__c != null && meta.RollupControl__c != CACHED_DEFAULT.Id) {
+        controlId = meta.RollupControl__c;
+      } else if (meta.RollupControl__c == CACHED_DEFAULT.Id) {
+        controlId = null;
+        break;
+      }
+    }
+    if (controlId != null) {
+      RollupLogger.Instance.updateRollupControl(getSingleControlOrDefault(RollupControl__mdt.Id, controlId, defaultControl));
+    }
   }
 }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -446,7 +446,7 @@ global without sharing virtual class Rollup {
 
   public class NamespaceInfo {
     @AuraEnabled
-    public final String safeObjectName = Rollup__mdt.SObjectType.getDescribe().getName();
+    public final String safeObjectName = Rollup__mdt.SObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getName();
     @AuraEnabled
     public final String safeRollupOperationField = this.safeObjectName + '.' + Rollup__mdt.RollupOperation__c.getDescribe().getName();
     @AuraEnabled
@@ -1686,7 +1686,7 @@ global without sharing virtual class Rollup {
     String serializedMeta = JSON.serialize(meta).removeEnd('}');
 
     String orderByRelationshipName;
-    List<Schema.ChildRelationship> potentiallyMatchingRelationships = Rollup__mdt.SObjectType.getDescribe().getChildRelationships();
+    List<Schema.ChildRelationship> potentiallyMatchingRelationships = Rollup__mdt.SObjectType.getDescribe(SObjectDescribeOptions.FULL).getChildRelationships();
     for (Schema.ChildRelationship relationship : potentiallyMatchingRelationships) {
       if (relationship.getChildSObject() == RollupOrderBy__mdt.SObjectType) {
         orderByRelationshipName = relationship.getRelationshipName();
@@ -2522,7 +2522,7 @@ global without sharing virtual class Rollup {
   }
 
   private static List<Rollup__mdt> getRollupMetadataBySObject(SObjectType sObjectType) {
-    String sObjectName = sObjectType.getDescribe().getName();
+    String sObjectName = sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getName();
     List<Rollup__mdt> rollupMetadatas = getMetadataFromCache(Rollup__mdt.SObjectType);
     for (Integer index = rollupMetadatas.size() - 1; index >= 0; index--) {
       Rollup__mdt meta = rollupMetadatas[index];
@@ -2552,7 +2552,7 @@ global without sharing virtual class Rollup {
     List<String> validRelationshipNames = meta.GrandparentRelationshipFieldPath__c.split('\\.');
     // remove the last field since it's not a relationship
     validRelationshipNames.remove(validRelationshipNames.size() - 1);
-    for (SObjectField fieldToken : sObjectType.getDescribe().fields.getMap().values()) {
+    for (SObjectField fieldToken : sObjectType.getDescribe(SObjectDescribeOptions.FULL).fields.getMap().values()) {
       if (fieldToken.getDescribe().getRelationshipName() == null) {
         continue;
       } else if (validRelationshipNames.contains(fieldToken.getDescribe().getRelationshipName())) {
@@ -2596,7 +2596,7 @@ global without sharing virtual class Rollup {
      * We have rollup operations to perform. That's great!
      * Let's get ready to rollup!
      */
-    Map<String, SObjectField> calcItemFields = sObjectType.getDescribe().fields.getMap();
+    Map<String, SObjectField> calcItemFields = sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).fields.getMap();
     RollupFieldInitializer init = RollupFieldInitializer.Current;
     updateLoggingControl(rollupOperations);
 

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -205,7 +205,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     String query = 'SELECT Id FROM Organization WHERE Name != \'' + UserInfo.getOrganizationName() + '\'';
     Set<String> objIds = new Set<String>(); // bind variable
     if (this.rollups.isEmpty()) {
-      RollupLogger.Instance.log('No matching rollups remaining, exiting early', LoggingLevel.WARN);
+      this.logger.log('No matching rollups remaining, exiting early', LoggingLevel.WARN);
     } else {
       RollupAsyncProcessor firstRollup = this.rollups.get(0);
       SObjectType sObjectType = firstRollup.lookupObj;
@@ -213,9 +213,9 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       Set<String> uniqueLookupObjectFields = this.lookupObjectToUniqueFieldNames.get(sObjectType);
       objIds = this.getCalcItemsByLookupField(firstRollup, uniqueLookupObjectFields).keySet();
       query = RollupQueryBuilder.Current.getQuery(sObjectType, new List<String>(uniqueLookupObjectFields), lookupFieldForLookupObject, '=');
-      RollupLogger.Instance.log('starting batch with query:', query, LoggingLevel.DEBUG);
+      this.logger.log('starting batch with query:', query, LoggingLevel.DEBUG);
     }
-    RollupLogger.Instance.save();
+    this.logger.save();
     return Database.getQueryLocator(query);
   }
 
@@ -230,7 +230,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
     this.lookupItems = lookupItems;
     this.process(this.rollups);
-    RollupLogger.Instance.save();
+    this.logger.save();
   }
 
   public virtual void finish(Database.BatchableContext context) {
@@ -264,9 +264,9 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     } else if (RollupSettings__c.getInstance().IsEnabled__c == false && shouldRunWithoutCustomSetting == false) {
       logMessage = String.valueOf(RollupSettings__c.SObjectType) + '.' + String.valueOf(RollupSettings__c.IsEnabled__c) + ' is false, exiting early';
     } else if (syncRollups.isEmpty() == false) {
-      RollupLogger.Instance.log('about to process sync rollups', LoggingLevel.DEBUG);
+      this.logger.log('about to process sync rollups', LoggingLevel.DEBUG);
       this.process(syncRollups);
-      RollupLogger.Instance.log('finished running sync rollups', LoggingLevel.DEBUG);
+      this.logger.log('finished running sync rollups', LoggingLevel.DEBUG);
     } else {
       Integer totalCountOfRecords = this.getLookupRecordsCount(this.rollups);
       shouldRunAsBatch =
@@ -276,10 +276,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       rollupProcessId = this.getAsyncRollup()?.beginAsyncRollup();
     }
     if (logMessage != null) {
-      RollupLogger.Instance.log(logMessage, LoggingLevel.DEBUG);
+      this.logger.log(logMessage, LoggingLevel.DEBUG);
       rollupProcessId = logMessage;
     }
-    RollupLogger.Instance.save();
+    this.logger.save();
     return rollupProcessId;
   }
 
@@ -416,13 +416,13 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   protected void logFinish() {
-    RollupLogger.Instance.log(this.getTypeName() + ' finished successfully', LoggingLevel.DEBUG);
-    RollupLogger.Instance.save();
+    this.logger.log(this.getTypeName() + ' finished successfully', LoggingLevel.DEBUG);
+    this.logger.save();
   }
 
   protected String beginAsyncRollup() {
     this.isTimingOut = false;
-    RollupLogger.Instance.log('about to start for ' + this.getTypeName(), this, LoggingLevel.DEBUG);
+    this.logger.log('about to start for ' + this.getTypeName(), this, LoggingLevel.DEBUG);
     return this.startAsyncWork();
   }
 
@@ -530,7 +530,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         if (this.childToUnexpectedFullRecalc.containsKey(rollup.calcItemType)) {
           this.childToUnexpectedFullRecalc.get(rollup.calcItemType).addMetadata(rollup.metadata);
         } else {
-          RollupLogger.Instance.log('Populating unexpected full recalc for ' + outstandingItemCount + ' items', LoggingLevel.DEBUG);
+          this.logger.log('Populating unexpected full recalc for ' + outstandingItemCount + ' items', LoggingLevel.DEBUG);
           RollupFullRecalcProcessor fullBatchProcessor = new RollupFullBatchRecalculator(
             RollupQueryBuilder.Current.getQuery(
               rollup.calcItemType,
@@ -551,7 +551,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         return;
       }
       if (outstandingItemCount > 0) {
-        RollupLogger.Instance.log('gathering additional calc items with query:', query, LoggingLevel.DEBUG);
+        this.logger.log('gathering additional calc items with query:', query, LoggingLevel.DEBUG);
         additionalCalcItems = Database.query(query);
 
         if (hasAlreadyBeenQueried) {
@@ -607,7 +607,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       }
 
       List<SObject> localLookupItems = this.getLookupItems(calcItemsByLookupField, updatedLookupRecords, roll);
-      RollupLogger.Instance.log('starting rollup for:', roll, LoggingLevel.DEBUG);
+      this.logger.log('starting rollup for:', roll, LoggingLevel.DEBUG);
       updatedLookupRecords.putAll(this.getUpdatedLookupItemsByRollup(roll, calcItemsByLookupField, localLookupItems));
     }
 
@@ -697,7 +697,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
   private Boolean getIsTimingOut(RollupControl__mdt control, RollupAsyncProcessor processor) {
     if (this.isTimingOut == false && hasExceededCurrentRollupLimits(control)) {
-      RollupLogger.Instance.log('Starting to time out ...', LoggingLevel.WARN);
+      this.logger.log('Starting to time out ...', LoggingLevel.WARN);
       this.isTimingOut = true;
     }
     if (this.isTimingOut) {
@@ -830,7 +830,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       return;
     }
     Boolean isAllowedToContinue = this.rollupControl.MaxRollupRetries__c >= stackDepth;
-    RollupLogger.Instance.log(
+    this.logger.log(
       'Number of deferred rollups: ' +
       this.deferredRollups.size() +
       ', still allowed to re-queue?: ' +
@@ -849,12 +849,12 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     this.isTimingOut = false;
 
     if (isDeferralAllowed) {
-      RollupLogger.Instance.log('deferred rollups remaining:', this.rollups, LoggingLevel.DEBUG);
+      this.logger.log('deferred rollups remaining:', this.rollups, LoggingLevel.DEBUG);
       this.getAsyncRollup()?.beginAsyncRollup();
     } else if (this.rollups.isEmpty() == false) {
-      RollupLogger.Instance.log('deferral was explicitly disallowed for rollups:', this.rollups, LoggingLevel.ERROR);
+      this.logger.log('deferral was explicitly disallowed for rollups:', this.rollups, LoggingLevel.ERROR);
     }
-    RollupLogger.Instance.save();
+    this.logger.save();
   }
 
   private void setupCalcItemData(Rollup roll) {
@@ -1256,7 +1256,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         }
 
         oldLookupsRollup.calcItems = reparentedCalcItems;
-        RollupLogger.Instance.log('reparenting operation:', oldLookupsRollup, LoggingLevel.DEBUG);
+        this.logger.log('reparenting operation:', oldLookupsRollup, LoggingLevel.DEBUG);
         calc = this.getCalculator(calc, oldLookupsRollup, reparentedCalcItems, lookupRecord, priorVal, key, roll.lookupFieldOnCalcItem);
         this.conditionallyPerformUpdate(priorVal, calc, lookupRecord, roll, recordsToUpdate, updater, 'reparented', reparentedCalcItems);
       }
@@ -1273,18 +1273,18 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     String logKey,
     List<SObject> localCalcItems
   ) {
-    RollupLogger.Instance.log(logKey + ' record prior to rolling up:', lookupRecord, LoggingLevel.DEBUG);
+    this.logger.log(logKey + ' record prior to rolling up:', lookupRecord, LoggingLevel.DEBUG);
     Object newVal = calc.getReturnValue();
     if (this.rollupControl.ShouldSkipResettingParentFields__c == true && ((localCalcItems.isEmpty() == false && newVal == null) || localCalcItems.isEmpty())) {
       newVal = priorVal;
     }
     if (priorVal != newVal) {
       String key = (String) lookupRecord.get(roll.lookupFieldOnLookupObject);
-      RollupLogger.Instance.log('updating record ...', LoggingLevel.FINE);
+      this.logger.log('updating record ...', LoggingLevel.FINE);
       updater.updateField(lookupRecord, newVal);
       recordsToUpdate.put(key, lookupRecord);
     }
     this.storeParentResetField(roll, lookupRecord);
-    RollupLogger.Instance.log(logKey + ' record after rolling up:', lookupRecord, LoggingLevel.DEBUG);
+    this.logger.log(logKey + ' record after rolling up:', lookupRecord, LoggingLevel.DEBUG);
   }
 }

--- a/rollup/core/classes/RollupCalcItemReplacer.cls
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls
@@ -151,7 +151,7 @@ public without sharing class RollupCalcItemReplacer {
     Boolean hasOwnerClause = metadata.CalcItemWhereClause__c?.contains(owner) == true;
     Boolean hasTypeClause = metadata.CalcItemWhereClause__c?.contains(typeField) == true;
     SObjectType sObjectType = firstItem.getSObjectType();
-    Map<String, Schema.SObjectField> fieldMap = sObjectType.getDescribe().fields.getMap();
+    Map<String, Schema.SObjectField> fieldMap = sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).fields.getMap();
     Boolean hasPolyMorphicFields = hasOwnerClause || hasTypeClause || fieldMap.get(metadata.LookupFieldOnCalcItem__c)?.getDescribe().isNamePointing() == true;
 
     if (hasPolyMorphicFields == false) {

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -261,7 +261,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
 
     private Set<String> getValidRelationshipNames(SObjectType sObjectType) {
       Set<String> localRelationshipNames = new Set<String>();
-      List<SObjectField> fields = sObjectType.getDescribe().fields.getMap().values();
+      List<SObjectField> fields = sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).fields.getMap().values();
       for (SObjectField field : fields) {
         String relationshipName = field.getDescribe().getRelationshipName();
         // filter out polymorphic relationship fields that can't be queried
@@ -690,7 +690,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
         return null;
       }
       // handle compound fields separately
-      Boolean hasField = sObjectType.getDescribe().fields.getMap().containsKey(fieldPath);
+      Boolean hasField = sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).fields.getMap().containsKey(fieldPath);
       if (fieldPath.contains('.') && hasField == false) {
         return this.getRelationshipFieldValue(item, fieldPath, sObjectType);
       } else if ((hasField && item.getPopulatedFieldsAsMap().containsKey(fieldPath)) || (hasField && item.get(fieldPath) == null)) {
@@ -707,7 +707,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       String originalName = relationshipName;
       relationshipName = getRelationshipNameFromField(relationshipName);
 
-      SObjectField fieldToken = sObjectType.getDescribe().fields.getMap().get(relationshipName);
+      SObjectField fieldToken = sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).fields.getMap().get(relationshipName);
       if (fieldToken == null) {
         // it could be a rollup started from the parent using a parent-level where clause
         try {

--- a/rollup/core/classes/RollupFieldInitializer.cls
+++ b/rollup/core/classes/RollupFieldInitializer.cls
@@ -66,7 +66,7 @@ public virtual class RollupFieldInitializer {
   }
 
   public Schema.DescribeSObjectResult getDescribeFromName(String sObjectName) {
-    return Schema.describeSObjects(new List<String>{ sObjectName })[0];
+    return Schema.describeSObjects(new List<String>{ sObjectName }, SObjectDescribeOptions.DEFERRED)[0];
   }
 
   public class PicklistController extends RollupFieldInitializer {

--- a/rollup/core/classes/RollupFinalizer.cls
+++ b/rollup/core/classes/RollupFinalizer.cls
@@ -24,7 +24,7 @@ public without sharing class RollupFinalizer implements Finalizer {
 
   private void logUnhandledException(FinalizerContext fc) {
     if (wasCalled == false) {
-      // a finalizer can be re-queued up to five times, but we view this as a one-time "get out of jail free logger"
+      // a finalizer can be re-queued up to five times, but we view this as a one-time "get out of jail free" logger
       wasCalled = true;
       RollupLogger.Instance.log('finalizer logging failure from:', fc?.getException(), LoggingLevel.ERROR);
       RollupLogger.Instance.save();

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -17,7 +17,7 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupF
   }
 
   public virtual override void execute(Database.BatchableContext bc, List<SObject> calcItems) {
-    RollupLogger.Instance.log('starting full batch recalc run:', this, LoggingLevel.DEBUG);
+    this.logger.log('starting full batch recalc run:', this, LoggingLevel.DEBUG);
     /**
      * this batch class is a glorified "for loop" for the calc items, dispatching
      * them to the overall Rollup framework while breaking us out of the query limits
@@ -26,7 +26,7 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupF
      * parent class
      */
     this.process(this.getDelegatedFullRecalcRollups(calcItems));
-    RollupLogger.Instance.save();
+    this.logger.save();
   }
 
   public override Boolean isBatch() {

--- a/rollup/core/classes/RollupFullRecalcProcessor.cls
+++ b/rollup/core/classes/RollupFullRecalcProcessor.cls
@@ -72,7 +72,7 @@ public abstract without sharing class RollupFullRecalcProcessor extends RollupAs
 
   public void finish() {
     if (this.postProcessor != null) {
-      RollupLogger.Instance.log('Starting post-full recalc processor', this.postProcessor, LoggingLevel.DEBUG);
+      this.logger.log('Starting post-full recalc processor', this.postProcessor, LoggingLevel.DEBUG);
       // chain jobs together so that if recalc job is being tracked within the Recalc Rollups app,
       // job continuity is established between the full recalc and then any downstream job that runs
       // (as the postProcessor)
@@ -131,7 +131,7 @@ public abstract without sharing class RollupFullRecalcProcessor extends RollupAs
 
   protected List<SObject> getCalcItems() {
     if (QUERY_TO_CALC_ITEMS.containsKey(this.queryString)) {
-      RollupLogger.Instance.log('returning pre-queried records from cache', LoggingLevel.FINE);
+      this.logger.log('returning pre-queried records from cache', LoggingLevel.FINE);
       return QUERY_TO_CALC_ITEMS.get(this.queryString);
     }
     List<SObject> localCalcItems = Database.query(this.queryString);

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.39';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.40';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -11,7 +11,11 @@ public without sharing virtual class RollupLogger implements ILogger {
     this.currentLoggingLevel = this.getLogLevel();
   }
 
-  public static final ILogger Instance {
+  public static void setLogger(ILogger logger) {
+    Instance = logger;
+  }
+
+  public static ILogger Instance {
     get {
       if (Instance == null) {
         Instance = getRollupLogger();
@@ -25,6 +29,7 @@ public without sharing virtual class RollupLogger implements ILogger {
     void log(String logString, LoggingLevel logLevel);
     void log(String logString, Object logObject, LoggingLevel logLevel);
     void save();
+    ILogger updateRollupControl(RollupControl__mdt control);
   }
 
   public void log(String logString, LoggingLevel logLevel) {
@@ -39,6 +44,10 @@ public without sharing virtual class RollupLogger implements ILogger {
 
   public virtual void save() {
     // this is a no-op by default; sub-classes can opt in if they need to perform DML
+  }
+
+  public ILogger updateRollupControl(RollupControl__mdt control) {
+    return this;
   }
 
   protected String getBaseLoggingMessage() {
@@ -188,6 +197,12 @@ public without sharing virtual class RollupLogger implements ILogger {
           logger.save();
         }
       }
+    }
+
+    public CombinedLogger updateRollupControl(RollupControl__mdt control) {
+      this.control = control;
+      this.log('updating control record', control, LoggingLevel.INFO);
+      return this;
     }
   }
 }

--- a/rollup/core/classes/RollupParentResetProcessor.cls
+++ b/rollup/core/classes/RollupParentResetProcessor.cls
@@ -64,7 +64,7 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
     if (parentItems.isEmpty()) {
       return;
     }
-    RollupLogger.Instance.log('resetting parent fields for: ' + parentItems.size() + ' items', LoggingLevel.DEBUG);
+    this.logger.log('resetting parent fields for: ' + parentItems.size() + ' items', LoggingLevel.DEBUG);
     Map<String, Schema.SObjectField> parentFields = parentItems.get(0).getSObjectType().getDescribe().fields.getMap();
     for (SObject parentItem : parentItems) {
       for (Rollup__mdt rollupMeta : this.rollupMetas) {

--- a/rollup/core/classes/RollupQueryBuilder.cls
+++ b/rollup/core/classes/RollupQueryBuilder.cls
@@ -22,7 +22,7 @@ public without sharing class RollupQueryBuilder {
     fieldNames.clear();
     fieldNames.addAll(lowerCaseFieldNames);
 
-    this.addCurrencyIsoCodeForMultiCurrencyOrgs(fieldNames, lowerCaseFieldNames, sObjectType.getDescribe());
+    this.addCurrencyIsoCodeForMultiCurrencyOrgs(fieldNames, lowerCaseFieldNames, sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED));
 
     String originalWhereClause = optionalWhereClause;
     Boolean isBlank = String.isBlank(originalWhereClause);
@@ -75,7 +75,7 @@ public without sharing class RollupQueryBuilder {
   private String adjustWhereClauseForPolymorphicFields(SObjectType sObjectType, List<String> fieldNames, String optionalWhereClause) {
     // you can't filter on *.Owner for polymorphic fields - or even select them, for that matter. Instead we have to massage the query to use
     // TYPEOF instead
-    Map<String, SObjectField> fieldNameToField = sObjectType.getDescribe().fields.getMap();
+    Map<String, SObjectField> fieldNameToField = sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).fields.getMap();
     if (this.hasPolymorphicOwnerClause(optionalWhereClause, fieldNameToField) == false || fieldNames.contains('Count()')) {
       return optionalWhereClause;
     }

--- a/rollup/core/classes/RollupRelationshipFieldFinder.cls
+++ b/rollup/core/classes/RollupRelationshipFieldFinder.cls
@@ -617,7 +617,7 @@ public without sharing class RollupRelationshipFieldFinder {
     }
     records = Database.query(query);
 
-    Map<String, SObjectField> fieldMap = sObjectType.getDescribe().fields.getMap();
+    Map<String, SObjectField> fieldMap = sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).fields.getMap();
     SObjectField field = this.getField(fieldMap, this.currentRelationshipName);
     for (SObject record : records) {
       this.trackTraversalIds((Id) record.get(oneToManyFieldName), record.Id, field, new Set<Id>());
@@ -627,7 +627,7 @@ public without sharing class RollupRelationshipFieldFinder {
   }
 
   private String getChildRelationshipFromType(Schema.SObjectType sObjectType, String relationshipName) {
-    for (Schema.ChildRelationship child : sObjectType.getDescribe().getChildRelationships()) {
+    for (Schema.ChildRelationship child : sObjectType.getDescribe(SObjectDescribeOptions.FULL).getChildRelationships()) {
       if (child.getRelationshipName() == relationshipName) {
         return child.getChildSObject().getDescribe().getName();
       }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -105,6 +105,7 @@
         "apex-rollup@1.5.36-0": "04t6g000007zM78AAE",
         "apex-rollup@1.5.37-0": "04t6g000007zMCdAAM",
         "apex-rollup@1.5.38-0": "04t6g000008fjOcAAI",
-        "apex-rollup@1.5.39-0": "04t6g000008fjSFAAY"
+        "apex-rollup@1.5.39-0": "04t6g000008fjSFAAY",
+        "apex-rollup@1.5.40-0": "04t6g000008fjSUAAY"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Making Rollup.flatten() safer",
-            "versionNumber": "1.5.39.0",
+            "versionName": "Logging updates to respect specific Rollup Controls when they differ from the Org Default",
+            "versionNumber": "1.5.40.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
* Fixes #363 by enabling logging for rollups controlled by something other than the Org Default RollupControl__mdt CMDT record for @solo-1234
* Updating SObjectDescribe calls where appropriate to use the SObjectDescribeOptions to fix new scan violations