### PR TITLE
V1.5.41 - executeBatch Safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjSUAAY">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjSyAAI">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjSUAAY">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjSyAAI">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.40",
+  "version": "1.5.41",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjSZAAY">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjT3AAI">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjSZAAY">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjT3AAI">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Logging updates to respect specific Rollup Controls when they differ from the Org Default",
-            "versionNumber": "1.0.13.0",
+            "versionName": "Prevents executeBatch call for deferred rollups when full batch recalculation is already in progress",
+            "versionNumber": "1.0.14.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -34,6 +34,7 @@
         "apex-rollup-namespaced@1.0.10-0": "04t6g000007zMCiAAM",
         "apex-rollup-namespaced@1.0.11-0": "04t6g000008fjOhAAI",
         "apex-rollup-namespaced@1.0.12-0": "04t6g000008fjSKAAY",
-        "apex-rollup-namespaced@1.0.13-0": "04t6g000008fjSZAAY"
+        "apex-rollup-namespaced@1.0.13-0": "04t6g000008fjSZAAY",
+        "apex-rollup-namespaced@1.0.14-0": "04t6g000008fjT3AAI"
     }
 }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -305,7 +305,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     RollupAsyncProcessor roll;
     if (this.rollups.size() == 1 && this.rollups[0] instanceof RollupFullRecalcProcessor) {
       roll = this.rollups[0];
-    } else if (this instanceof RollupFullRecalcProcessor) {
+    } else if (this instanceof RollupFullRecalcProcessor && ((RollupFullRecalcProcessor) this).isBatch() == false) {
       roll = this;
     } else if (System.isBatch() == false && (shouldRunAsBatch || canEnqueue == false)) {
       // safe to batch because the QueryLocator will only return one type of SObject

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.40';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.41';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -12,7 +12,8 @@ function Start-Tests() {
   npx sfdx force:source:deploy -p rollup
   npx sfdx force:source:deploy -p extra-tests
 
-  Write-Debug "Starting test run ..."
+  $currentBranch = Get-Current-Git-Branch
+  Write-Debug "Starting test run on branch $currentBranch ..."
   Invoke-Expression $testInvocation
   $testRunId = Get-Content tests/apex/test-run-id.txt
   $specificTestRunJson = Get-Content "tests/apex/test-result-$testRunId.json" | ConvertFrom-Json
@@ -21,7 +22,7 @@ function Start-Tests() {
     $testFailure = $true
   }
 
-  if ($false -eq $testFailure && Get-Current-Git-Branch -ne "main") {
+  if ($false -eq $testFailure -And $currentBranch.Contains("main") -eq $false) {
     Start-Integration-Tests
   }
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Actually stopping pipeline from running integration tests on merges to main",
+            "versionName": "Prevents executeBatch call for deferred rollups when full batch recalculation is already in progress",
             "versionNumber": "1.5.41.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Logging updates to respect specific Rollup Controls when they differ from the Org Default",
-            "versionNumber": "1.5.40.0",
+            "versionName": "Actually stopping pipeline from running integration tests on merges to main",
+            "versionNumber": "1.5.41.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -106,6 +106,7 @@
         "apex-rollup@1.5.37-0": "04t6g000007zMCdAAM",
         "apex-rollup@1.5.38-0": "04t6g000008fjOcAAI",
         "apex-rollup@1.5.39-0": "04t6g000008fjSFAAY",
-        "apex-rollup@1.5.40-0": "04t6g000008fjSUAAY"
+        "apex-rollup@1.5.40-0": "04t6g000008fjSUAAY",
+        "apex-rollup@1.5.41-0": "04t6g000008fjSyAAI"
     }
 }


### PR DESCRIPTION
* Prevents `Database.executeBatch` call during full batch recalculations to avoid `Database.executeBatch cannot be called from a batch start, batch execute, or future method.`