### PR TITLE
V1.5.42 - Async Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjSyAAI">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjThAAI">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjSyAAI">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjThAAI">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupSObjectUpdaterTests.cls
+++ b/extra-tests/classes/RollupSObjectUpdaterTests.cls
@@ -76,13 +76,19 @@ public class RollupSObjectUpdaterTests {
   }
 
   @IsTest
-  static void doesNotUpdateRecordsWhichOnlyContainId() {
+  static void onlyUpdatesRecordsWithRollupChanges() {
     Account acc = new Account(Name = 'Should Not Be Updated');
     insert acc;
     acc = [SELECT Id, LastModifiedDate FROM Account];
     waitSeconds(1);
 
-    new RollupSObjectUpdater().doUpdate(new List<SObject>{ new Account(Id = acc.Id) });
+    List<String> fieldNames = new List<String>{ 'Id' };
+    if (RollupCurrencyInfo.isMultiCurrency()) {
+      fieldNames.add(RollupCurrencyInfo.CURRENCY_ISO_CODE_FIELD_NAME);
+    }
+
+    Id accId = acc.Id;
+    new RollupSObjectUpdater().doUpdate(Database.query('SELECT ' + String.join(fieldNames, ',') + ' FROM Account WHERE Id = :accId'));
 
     Account updatedAccount = [SELECT Id, LastModifiedDate FROM Account];
     System.assertEquals(acc, updatedAccount, 'Last modified date should not have updated if only Id was passed');

--- a/extra-tests/classes/RollupSObjectUpdaterTests.cls
+++ b/extra-tests/classes/RollupSObjectUpdaterTests.cls
@@ -1,6 +1,7 @@
 @IsTest
 public class RollupSObjectUpdaterTests {
   private static Boolean dispatcherMockWasCalled = false;
+  private static List<SObject> mockUpdatedRecords;
 
   @IsTest
   static void shouldAllowDatetimeToBeSavedAsDate() {
@@ -104,6 +105,25 @@ public class RollupSObjectUpdaterTests {
 
     Account updatedAccount = [SELECT Id, LastModifiedDate FROM Account];
     System.assertEquals(acc, updatedAccount);
+  }
+
+  @IsTest
+  static void doesNotSplitUpdatesWhenForcedSyncUpdateEnabled() {
+    RollupSObjectUpdater.UPDATER_NAME = MockUpdater.class.getName();
+    RollupPlugin.pluginMocks = new List<RollupPlugin__mdt>{ new RollupPlugin__mdt(DeveloperName = RollupSObjectUpdater.UPDATER_NAME) };
+    RollupSObjectUpdater updater = new RollupSObjectUpdater();
+    updater.forceSyncUpdate();
+    updater.addRollupControl(new RollupControl__mdt(MaxParentRowsUpdatedAtOnce__c = 1));
+
+    updater.doUpdate(new List<SObject>{ new Account(), new Contact() });
+
+    System.assertEquals(2, mockUpdatedRecords.size());
+  }
+
+  public class MockUpdater implements RollupSObjectUpdater.IUpdater {
+    public void performUpdate(List<SObject> recordsToUpdate, Database.DMLOptions options) {
+      mockUpdatedRecords = recordsToUpdate;
+    }
   }
 
   @SuppressWarnings('PMD.EmptyWhileStmt')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.41",
+  "version": "1.5.42",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjT3AAI">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjTmAAI">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjT3AAI">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjTmAAI">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Prevents executeBatch call for deferred rollups when full batch recalculation is already in progress",
-            "versionNumber": "1.0.14.0",
+            "versionName": "Properly prevent second queueable from firing when an update should be synchronous",
+            "versionNumber": "1.0.15.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -35,6 +35,7 @@
         "apex-rollup-namespaced@1.0.11-0": "04t6g000008fjOhAAI",
         "apex-rollup-namespaced@1.0.12-0": "04t6g000008fjSKAAY",
         "apex-rollup-namespaced@1.0.13-0": "04t6g000008fjSZAAY",
-        "apex-rollup-namespaced@1.0.14-0": "04t6g000008fjT3AAI"
+        "apex-rollup-namespaced@1.0.14-0": "04t6g000008fjT3AAI",
+        "apex-rollup-namespaced@1.0.15-0": "04t6g000008fjTmAAI"
     }
 }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -2579,9 +2579,13 @@ global without sharing virtual class Rollup {
     Evaluator eval,
     InvocationPoint rollupInvokePoint
   ) {
-    calcItems = CALC_ITEM_REPLACER.replace(calcItems, rollupOperations);
-    if (oldCalcItems?.isEmpty() == false) {
-      oldCalcItems = new Map<Id, SObject>(CALC_ITEM_REPLACER.replace(oldCalcItems.values(), rollupOperations));
+    switch on rollupInvokePoint {
+      when FROM_APEX, FROM_INVOCABLE {
+        calcItems = CALC_ITEM_REPLACER.replace(calcItems, rollupOperations);
+        if (oldCalcItems?.isEmpty() == false) {
+          oldCalcItems = new Map<Id, SObject>(CALC_ITEM_REPLACER.replace(oldCalcItems.values(), rollupOperations));
+        }
+      }
     }
     RollupAsyncProcessor rollupConductor = RollupAsyncProcessor.getConductor(rollupInvokePoint, calcItems, oldCalcItems);
     if (rollupOperations.isEmpty() || calcItems.isEmpty()) {
@@ -2606,15 +2610,9 @@ global without sharing virtual class Rollup {
       SObjectField calcLookupField = init.getSObjectFieldByName(calcItemFields, rollupMetadata.LookupFieldOnCalcItem__c);
 
       Schema.DescribeSObjectResult lookupDescribe = init.getDescribeFromName(rollupMetadata.LookupObject__c);
-      Map<String, SObjectField> lookuopItemFields = lookupDescribe.fields.getMap();
-      SObjectField lookupFieldOnOpObject = init.getSObjectFieldByName(lookuopItemFields, rollupMetadata.LookupFieldOnLookupObject__c);
-      SObjectField rollupFieldOnOpObject = init.getSObjectFieldByName(lookuopItemFields, rollupMetadata.RollupFieldOnLookupObject__c);
-
-      // reset the CMDT field-level definitions using the SObjectField tokens
-      rollupMetadata.RollupFieldOnCalcItem__c = rollupFieldOnCalcItem.getDescribe().getName();
-      rollupMetadata.LookupFieldOnCalcItem__c = calcLookupField.getDescribe().getName();
-      rollupMetadata.LookupFieldOnLookupObject__c = lookupFieldOnOpObject.getDescribe().getName();
-      rollupMetadata.RollupFieldOnLookupObject__c = rollupFieldOnOpObject.getDescribe().getName();
+      Map<String, SObjectField> lookupItemFields = lookupDescribe.fields.getMap();
+      SObjectField lookupFieldOnOpObject = init.getSObjectFieldByName(lookupItemFields, rollupMetadata.LookupFieldOnLookupObject__c);
+      SObjectField rollupFieldOnOpObject = init.getSObjectFieldByName(lookupItemFields, rollupMetadata.RollupFieldOnLookupObject__c);
 
       if (rollupMetadata.IsFullRecordSet__c != true && isFullRecalcOp(getBaseOperationName(rollupMetadata.RollupOperation__c))) {
         rollupMetadata.IsFullRecordSet__c = true;
@@ -2946,12 +2944,12 @@ global without sharing virtual class Rollup {
     // mean inadvertently filtering the items for other rollups on the same child SObject type. Instead, we track the matching Ids
     // to avoid unintended side-effects
     for (SObject item : calcItems) {
-      // if the where clause would exclude something, but we're in an update
-      // and the old value wouldn't have been excluded, pass it on through
-      // to be handled further downstream
       if (results.eval.matches(item) || calcItemReplacer.hasProcessedMetadata(new List<Rollup__mdt>{ metadata }, calcItems) == false) {
         results.matchingItemIds.add(item.Id);
-      } else if (oldCalcItems != null && oldCalcItems.containsKey(item.Id) && results.eval.matches(oldCalcItems.get(item.Id))) {
+      } else if (oldCalcItems?.containsKey(item.Id) == true && results.eval.matches(oldCalcItems.get(item.Id))) {
+        // if the where clause would exclude something, but we're in an update
+        // and the old value wouldn't have been excluded, pass it on through
+        // to be handled further downstream
         results.matchingItemIds.add(item.Id);
       } else if (metadata?.IsFullRecordSet__c == true) {
         results.matchingItemIds.add(item.Id);

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -31,6 +31,11 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     ITERABLE
   }
 
+  private enum ParentUpdateType {
+    LOOKUP,
+    REPARENTED
+  }
+
   protected final Set<String> previouslyResetParents {
     get {
       if (previouslyResetParents == null) {
@@ -124,6 +129,8 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     this.calcItemReplacer = innerRollup.calcItemReplacer;
     this.lookupItems = innerRollup.lookupItems;
     this.previouslyResetParents.addAll(innerRollup.previouslyResetParents);
+    this.calcObjectToUniqueFieldNames = innerRollup.calcObjectToUniqueFieldNames;
+    this.lookupObjectToUniqueFieldNames = innerRollup.lookupObjectToUniqueFieldNames;
   }
 
   // Inner rollup constructor - a rollup solely concerned with calculations
@@ -1097,14 +1104,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         List<SObject> localCalcItems = bag.getAll();
 
         if (this.getIsTimingOut(this.rollupControl, roll) || (this.isValidAdditionalCalcItemRetrieval(roll) && bag.hasQueriedForAdditionalItems == false)) {
-          // this loop only gets entered into for one rollup because there's another early return checking isTimingOut in the outer method
-          SObject replacementLookupRecord = lookupRecord.getSObjectType().newSObject();
-          for (String fieldName : lookupRecord.getPopulatedFieldsAsMap().keySet()) {
-            if (fieldName != roll.opFieldOnLookupObject.getDescribe().getName()) {
-              replacementLookupRecord.put(fieldName, lookupRecord.getPopulatedFieldsAsMap().get(fieldName));
-            }
-          }
-          recordsToUpdate.put(lookupRecord.Id, replacementLookupRecord);
           unprocessedCalcItems.putAll(localCalcItems);
           lookupItems.remove(index);
           continue;
@@ -1119,7 +1118,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
           Object priorVal = lookupRecord.get(roll.opFieldOnLookupObject);
           Object priorValToUse = roll.isFullRecalc && this.parentRollupFieldHasBeenReset(roll, lookupRecord) == false ? null : priorVal;
           calc = this.getCalculator(calc, roll, localCalcItems, lookupRecord, priorValToUse, key, roll.lookupFieldOnCalcItem);
-          this.conditionallyPerformUpdate(priorVal, calc, lookupRecord, roll, recordsToUpdate, updater, 'lookup', localCalcItems);
+          this.conditionallyPerformUpdate(priorVal, calc, lookupRecord, roll, recordsToUpdate, updater, ParentUpdateType.LOOKUP, localCalcItems);
         }
         if (priorKey != null && key != priorKey) {
           // once we've fully processed a parent (in separate batches)
@@ -1141,12 +1140,13 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
   private void deferCalculationsWhenApproachingLimits(RollupAsyncProcessor roll, List<SObject> unprocessedCalcItems) {
     if (unprocessedCalcItems.isEmpty() == false) {
+      roll.calcItems = unprocessedCalcItems;
       this.deferredRollups.add(roll);
     }
   }
 
   private void populateReparentedItems(RollupAsyncProcessor roll, List<SObject> localCalcItems, Map<String, List<SObject>> oldLookupItems) {
-    if (this.isEmptyReparentingSet(roll.op)) {
+    if (this.isEmptyReparentingSet(roll.op) || roll.oldCalcItems?.isEmpty() == true) {
       return;
     }
     for (Integer index = localCalcItems.size() - 1; index >= 0; index--) {
@@ -1206,11 +1206,11 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
     if (rollupCalc == null) {
       rollupCalc = RollupCalculator.Factory.getCalculator(rollupOp, roll.opFieldOnCalcItem, roll.opFieldOnLookupObject, roll.metadata, lookupKeyField);
+      rollupCalc.setEvaluator(roll.eval);
+      rollupCalc.setCDCUpdate(this.isCDCUpdate);
+      rollupCalc.setFullRecalc(roll.isFullRecalc);
     }
-    rollupCalc.setFullRecalc(roll.isFullRecalc);
     rollupCalc.setDefaultValues(lookupRecordKey, priorVal);
-    rollupCalc.setEvaluator(roll.eval);
-    rollupCalc.setCDCUpdate(this.isCDCUpdate);
     rollupCalc.setMultiCurrencyInfo(lookupRecord);
     rollupCalc.performRollup(calcItems, roll.oldCalcItems);
     return rollupCalc;
@@ -1258,7 +1258,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         oldLookupsRollup.calcItems = reparentedCalcItems;
         this.logger.log('reparenting operation:', oldLookupsRollup, LoggingLevel.DEBUG);
         calc = this.getCalculator(calc, oldLookupsRollup, reparentedCalcItems, lookupRecord, priorVal, key, roll.lookupFieldOnCalcItem);
-        this.conditionallyPerformUpdate(priorVal, calc, lookupRecord, roll, recordsToUpdate, updater, 'reparented', reparentedCalcItems);
+        this.conditionallyPerformUpdate(priorVal, calc, lookupRecord, roll, recordsToUpdate, updater, ParentUpdateType.REPARENTED, reparentedCalcItems);
       }
     }
   }
@@ -1270,9 +1270,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     RollupAsyncProcessor roll,
     Map<String, SObject> recordsToUpdate,
     RollupSObjectUpdater updater,
-    String logKey,
+    ParentUpdateType parentUpdateType,
     List<SObject> localCalcItems
   ) {
+    String logKey = parentUpdateType.name().toLowerCase();
     this.logger.log(logKey + ' record prior to rolling up:', lookupRecord, LoggingLevel.DEBUG);
     Object newVal = calc.getReturnValue();
     if (this.rollupControl.ShouldSkipResettingParentFields__c == true && ((localCalcItems.isEmpty() == false && newVal == null) || localCalcItems.isEmpty())) {

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -687,9 +687,9 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   private Boolean isValidAdditionalCalcItemRetrieval(RollupAsyncProcessor roll) {
-    if (this.fullRecalcProcessor != null && this.fullRecalcProcessor.isBatch()) {
+    if (this.fullRecalcProcessor != null) {
       // if we aren't batching, safe to assume a full recalc has already pulled the rest of the records back
-      return this.fullRecalcProcessor?.isBatch() != true;
+      return this.fullRecalcProcessor.isBatch() != true;
     } else {
       return roll.isFullRecalc || roll.metadata.IsFullRecordSet__c == true;
     }

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -26,7 +26,6 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupF
      * parent class
      */
     this.process(this.getDelegatedFullRecalcRollups(calcItems));
-    this.logger.save();
   }
 
   public override Boolean isBatch() {

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.41';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.42';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupPlugin.cls
+++ b/rollup/core/classes/RollupPlugin.cls
@@ -1,19 +1,22 @@
 public without sharing class RollupPlugin {
   @TestVisible
-  private static List<RollupPlugin__mdt> pluginMocks;
+  private static List<RollupPlugin__mdt> pluginMocks = new List<RollupPlugin__mdt>();
   @TestVisible
   private static RollupPluginParameter__mdt parameterMock;
 
   public RollupPlugin__mdt getInstance(String developerNameOrId) {
-    return pluginMocks != null && pluginMocks.isEmpty() == false ? pluginMocks.remove(0) : RollupPlugin__mdt.getInstance(developerNameOrId);
+    for (RollupPlugin__mdt plugin : pluginMocks) {
+      if (plugin.DeveloperName == developerNameOrId) {
+        return plugin;
+      }
+    }
+    return RollupPlugin__mdt.getInstance(developerNameOrId);
   }
 
   public List<RollupPlugin__mdt> getInstances() {
     List<RollupPlugin__mdt> plugins = new List<RollupPlugin__mdt>();
     plugins.addAll(RollupPlugin__mdt.getAll().values());
-    if (pluginMocks != null) {
-      plugins.addAll(pluginMocks);
-    }
+    plugins.addAll(pluginMocks);
     return plugins;
   }
 

--- a/rollup/core/classes/RollupSObjectUpdater.cls
+++ b/rollup/core/classes/RollupSObjectUpdater.cls
@@ -148,7 +148,9 @@ public without sharing virtual class RollupSObjectUpdater {
       if (populatedFields.size() == 1 && populatedFields.contains('Id')) {
         records.remove(index);
       } else if (
-        RollupCurrencyInfo.isMultiCurrency() && new Set<String>{ 'Id', RollupCurrencyInfo.CURRENCY_ISO_CODE_FIELD_NAME }.containsAll(populatedFields)
+        RollupCurrencyInfo.isMultiCurrency() &&
+        populatedFields.isEmpty() == false &&
+        new Set<String>{ 'Id', RollupCurrencyInfo.CURRENCY_ISO_CODE_FIELD_NAME }.containsAll(populatedFields)
       ) {
         records.remove(index);
       }

--- a/rollup/core/classes/RollupSObjectUpdater.cls
+++ b/rollup/core/classes/RollupSObjectUpdater.cls
@@ -143,16 +143,13 @@ public without sharing virtual class RollupSObjectUpdater {
   }
 
   private void winnowRecords(List<SObject> records) {
-    List<String> baseFields = new List<String>{ 'Id' };
+    Set<String> baseFields = new Set<String>{ 'Id' };
     if (RollupCurrencyInfo.isMultiCurrency()) {
       baseFields.add(RollupCurrencyInfo.CURRENCY_ISO_CODE_FIELD_NAME);
     }
     for (Integer index = records.size() - 1; index >= 0; index--) {
       SObject record = records.get(index);
-      Map<String, Object> populatedFields = record.getPopulatedFieldsAsMap();
-      if (populatedFields.size() == 1 && record.get('Id') != null) {
-        records.remove(index);
-      } else if (RollupCurrencyInfo.isMultiCurrency() && populatedFields.size() == 2 && populatedFields.keySet().containsAll(baseFields)) {
+      if (record.getPopulatedFieldsAsMap().keySet() == baseFields) {
         records.remove(index);
       }
     }

--- a/rollup/core/classes/RollupSObjectUpdater.cls
+++ b/rollup/core/classes/RollupSObjectUpdater.cls
@@ -1,5 +1,6 @@
 public without sharing virtual class RollupSObjectUpdater {
-  private static final String UPDATER_NAME = 'RollupCustomUpdater';
+  @TestVisible
+  private static String UPDATER_NAME = 'RollupCustomUpdater';
   @TestVisible
   private static final String DISPATCH_NAME = 'RollupDispatch';
   private static final SObjectSorter SORTER = new SObjectSorter();
@@ -125,7 +126,7 @@ public without sharing virtual class RollupSObjectUpdater {
   }
 
   private void splitUpdates(List<SObject> recordsToUpdate) {
-    if (this.rollupControl.MaxParentRowsUpdatedAtOnce__c < recordsToUpdate.size()) {
+    if (this.rollupControl.MaxParentRowsUpdatedAtOnce__c < recordsToUpdate.size() && this.forceSyncUpdate == false) {
       Integer maxIndexToRemove = recordsToUpdate.size() / 2;
       List<SObject> asyncUpdateList = new List<SObject>();
       while (recordsToUpdate.size() > maxIndexToRemove) {

--- a/rollup/core/classes/RollupSObjectUpdater.cls
+++ b/rollup/core/classes/RollupSObjectUpdater.cls
@@ -143,13 +143,13 @@ public without sharing virtual class RollupSObjectUpdater {
   }
 
   private void winnowRecords(List<SObject> records) {
-    Set<String> baseFields = new Set<String>{ 'Id' };
-    if (RollupCurrencyInfo.isMultiCurrency()) {
-      baseFields.add(RollupCurrencyInfo.CURRENCY_ISO_CODE_FIELD_NAME);
-    }
     for (Integer index = records.size() - 1; index >= 0; index--) {
-      SObject record = records.get(index);
-      if (record.getPopulatedFieldsAsMap().keySet() == baseFields) {
+      Set<String> populatedFields = records.get(index).getPopulatedFieldsAsMap().keySet();
+      if (populatedFields.size() == 1 && populatedFields.contains('Id')) {
+        records.remove(index);
+      } else if (
+        RollupCurrencyInfo.isMultiCurrency() && new Set<String>{ 'Id', RollupCurrencyInfo.CURRENCY_ISO_CODE_FIELD_NAME }.containsAll(populatedFields)
+      ) {
         records.remove(index);
       }
     }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Prevents executeBatch call for deferred rollups when full batch recalculation is already in progress",
-            "versionNumber": "1.5.41.0",
+            "versionName": "Properly prevent second queueable from firing when an update should be synchronous",
+            "versionNumber": "1.5.42.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -107,6 +107,7 @@
         "apex-rollup@1.5.38-0": "04t6g000008fjOcAAI",
         "apex-rollup@1.5.39-0": "04t6g000008fjSFAAY",
         "apex-rollup@1.5.40-0": "04t6g000008fjSUAAY",
-        "apex-rollup@1.5.41-0": "04t6g000008fjSyAAI"
+        "apex-rollup@1.5.41-0": "04t6g000008fjSyAAI",
+        "apex-rollup@1.5.42-0": "04t6g000008fjThAAI"
     }
 }


### PR DESCRIPTION
* Prevent too many queueables error by ensuring `RollupSObjectUpdater` does not split updates when in the midst of timing out
* Cleaned up some async code paths to continually refine CPU time usage