### PR TITLE
v1.5.44 - Updated most logging levels to INFO

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ As well, don't miss [the Wiki](../../wiki), which includes more advanced informa
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjW7AAI">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjXeAAI">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjW7AAI">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjXeAAI">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -1031,7 +1031,7 @@ public class RollupLogger {
 
 You can implement `RollupLogger.ILogger` with your own code and specify that class name in the `Rollup Plugin` CMDT records. _Alternatively_, you can also _extend_ `RollupLogger` itself and override its own logging methods; this gives you the benefit of built-in message formatting through the use of the protected method `getLogStringFromObject`, found in `RollupLogger.cls`. For more info, refer to that class and its methods. Either way, the API name for the CMDT record **must** include `Logger` in order to work (eg: `RollupCustomObjectLogger`, `RollupNebulaLoggerAdapter`).
 
-You can use the included `Rollup Plugin Parameter` CMDT record `Logging Debug Level` to fine-tune the logging level you'd like to use when making use of Apex debug logs (from method #3, above). Valid entries conform to the `LoggingLevel` enum: ERROR, WARN, INFO, DEBUG, FINE, FINER, FINEST. FINEST provides the highest level of detail; ERROR provides the least.
+You can use the included `Rollup Plugin Parameter` CMDT record `Logging Debug Level` to fine-tune the logging level you'd like to use when making use of Apex debug logs (from method #3, above). Valid entries conform to the `LoggingLevel` enum: ERROR, WARN, INFO, DEBUG, FINE, FINER, FINEST. FINEST provides the highest level of detail; ERROR provides the least. INFO will provide a high-level overview, while DEBUG will contain data about individual parent records being rolled up. The granularity of the data logged will continue to get finer as you move towards FINEST as the logging level.
 
 ### Other Rollup Plugins
 

--- a/extra-tests/classes/RollupParentResetProcessorTests.cls
+++ b/extra-tests/classes/RollupParentResetProcessorTests.cls
@@ -132,4 +132,26 @@ private class RollupParentResetProcessorTests {
     System.assertEquals(0, resetAccount.AnnualRevenue);
     System.assertEquals('a', resetAccount.AccountNumber);
   }
+
+  @IsTest
+  static void skipsTransformWhenDisabled() {
+    upsert new RollupSettings__c(IsEnabled__c = true);
+    Rollup.defaultControl = Rollup.getDefaultControl();
+    Rollup.defaultControl.ShouldSkipResettingParentFields__c = true;
+    Rollup.defaultControl.ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.Synchronous;
+
+    RollupParentResetProcessor processor = new RollupParentResetProcessor(
+      new List<Rollup__mdt>{ new Rollup__mdt(RollupFieldOnLookupObject__c = 'AnnualRevenue', LookupObject__c = 'Account') },
+      Account.SObjectType,
+      'SELECT Id\nFROM Account WHERE Id != null',
+      new Set<String>(),
+      null
+    );
+
+    Test.startTest();
+    Rollup.batch(new List<Rollup>{ processor });
+    Test.stopTest();
+
+    System.assertEquals(0, [SELECT COUNT() FROM AsyncApexJob WHERE ApexClass.Name = :RollupParentResetProcessor.class.getName()]);
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.43",
+  "version": "1.5.44",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjWCAAY">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjXjAAI">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjWCAAY">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjXjAAI">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Allows the rolling up of text fields to date/datetime fields",
-            "versionNumber": "1.0.16.0",
+            "versionName": "Logging granularity updates",
+            "versionNumber": "1.0.17.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -37,6 +37,7 @@
         "apex-rollup-namespaced@1.0.13-0": "04t6g000008fjSZAAY",
         "apex-rollup-namespaced@1.0.14-0": "04t6g000008fjT3AAI",
         "apex-rollup-namespaced@1.0.15-0": "04t6g000008fjTmAAI",
-        "apex-rollup-namespaced@1.0.16-0": "04t6g000008fjWCAAY"
+        "apex-rollup-namespaced@1.0.16-0": "04t6g000008fjWCAAY",
+        "apex-rollup-namespaced@1.0.17-0": "04t6g000008fjXjAAI"
     }
 }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -493,7 +493,7 @@ global without sharing virtual class Rollup {
     }
     List<Rollup__mdt> matchingMetadata = (List<Rollup__mdt>) JSON.deserialize(serializedMetadata, List<Rollup__mdt>.class);
     updateLoggingControl(matchingMetadata);
-    RollupLogger.Instance.log('bulk full recalc called with data:', matchingMetadata, LoggingLevel.DEBUG);
+    RollupLogger.Instance.log('bulk full recalc called with data:', matchingMetadata, LoggingLevel.INFO);
 
     String potentialWhereClause = '';
     String delimiter = ' ||| ';
@@ -711,7 +711,7 @@ global without sharing virtual class Rollup {
       }
 
       flowInput.rollupOperation = flowInput.rollupOperation.toUpperCase();
-      RollupLogger.Instance.log('processing invocable data:', flowInput, LoggingLevel.DEBUG);
+      RollupLogger.Instance.log('processing invocable data:', flowInput, LoggingLevel.INFO);
 
       if (flowInput.recordsToRollup?.isEmpty() != false) {
         flowOutput.message = 'No records to rollup, returning early';
@@ -786,7 +786,7 @@ global without sharing virtual class Rollup {
             roll.rollupControl.ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.Synchronous;
           }
         }
-        RollupLogger.Instance.log(logMessage, rollupConductor, LoggingLevel.DEBUG);
+        RollupLogger.Instance.log(logMessage, rollupConductor, LoggingLevel.INFO);
       }
     }
 
@@ -2167,7 +2167,7 @@ global without sharing virtual class Rollup {
         fullRecalc.isNoOp = wrappedMeta.recordCount == 0;
       }
       fullRecalc.queryCount = wrappedMeta.recordCount;
-      RollupLogger.Instance.log('full recalc prepared:', fullRecalc, LoggingLevel.DEBUG);
+      RollupLogger.Instance.log('full recalc prepared:', fullRecalc, LoggingLevel.INFO);
       fullRecalcRollups.add(fullRecalc);
       CACHED_FULL_RECALCS.add(fullRecalc);
     }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -2193,10 +2193,13 @@ global without sharing virtual class Rollup {
     SObjectType calcItemType,
     InvocationPoint invokePoint
   ) {
+    Id rollupControlId;
     for (Rollup__mdt meta : wrappedMeta.metadata) {
       meta.IsFullRecordSet__c = true;
       meta.RollupOperation__c = getBaseOperationName(meta.RollupOperation__c);
+      rollupControlId = meta.RollupControl__c;
     }
+    RollupControl__mdt control = getSingleControlOrDefault(RollupControl__mdt.Id, rollupControlId, defaultControl);
     SObjectType parentType = RollupFieldInitializer.Current.getDescribeFromName(wrappedMeta.metadata[0].LookupObject__c).getSObjectType();
     String equality = invokePoint == InvocationPoint.FROM_SINGULAR_PARENT_RECALC_LWC ? '=' : '!=';
     String parentQuery = RollupQueryBuilder.Current.getQuery(parentType, new List<String>{ 'Id' }, 'Id', equality);
@@ -2212,7 +2215,10 @@ global without sharing virtual class Rollup {
       wrappedMeta.recordCount < parentResetProcessor.rollupControl.MaxLookupRowsBeforeBatching__c;
     if (wrappedMeta.recordCount == 0 && wrappedMeta.metadata.isEmpty() == false && isFullRecalcApp) {
       return parentResetProcessor;
-    } else if (invokePoint != InvocationPoint.FROM_FULL_RECALC_LWC && invokePoint != InvocationPoint.FROM_FULL_RECALC_FLOW) {
+    } else if (
+      (invokePoint != InvocationPoint.FROM_FULL_RECALC_LWC && invokePoint != InvocationPoint.FROM_FULL_RECALC_FLOW) ||
+      control.ShouldSkipResettingParentFields__c
+    ) {
       parentResetProcessor = null;
     }
 
@@ -2965,7 +2971,7 @@ global without sharing virtual class Rollup {
   private static void updateLoggingControl(List<Rollup__mdt> metadatas) {
     Id controlId;
     for (Rollup__mdt meta : metadatas) {
-      if (controlId == null || meta.RollupControl__c != null && meta.RollupControl__c != CACHED_DEFAULT.Id) {
+      if (controlId == null && meta.RollupControl__c != null && meta.RollupControl__c != CACHED_DEFAULT.Id) {
         controlId = meta.RollupControl__c;
       } else if (meta.RollupControl__c == CACHED_DEFAULT.Id) {
         controlId = null;

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -495,10 +495,7 @@ global without sharing virtual class Rollup {
     updateLoggingControl(matchingMetadata);
     RollupLogger.Instance.log('bulk full recalc called with data:', matchingMetadata, LoggingLevel.INFO);
 
-    String potentialWhereClause = '';
     String delimiter = ' ||| ';
-    String lookupFieldName;
-    Integer delimiterIndex = -1;
     String possibleParentId;
 
     Map<SObjectType, RollupMetadata> childToMetaWrapper = new Map<SObjectType, RollupMetadata>();
@@ -510,22 +507,29 @@ global without sharing virtual class Rollup {
       validationRuleWrapper.fullRecalculationDefaultNumberValue = matchingMeta.FullRecalculationDefaultNumberValue__c;
       enforceValidationRules(validationRuleWrapper);
 
-      if (localInvokePoint == InvocationPoint.FROM_SINGULAR_PARENT_RECALC_LWC && String.isBlank(potentialWhereClause)) {
-        delimiterIndex = matchingMeta.CalcItemWhereClause__c.indexOf(delimiter);
-        potentialWhereClause = matchingMeta.CalcItemWhereClause__c.substring(delimiterIndex + delimiter.length(), matchingMeta.CalcItemWhereClause__c.length());
-        possibleParentId = potentialWhereClause.substringAfter(' = ').remove('\'');
-        lookupFieldName = matchingMeta.LookupFieldOnCalcItem__c;
-      } else if (String.isNotBlank(potentialWhereClause)) {
-        potentialWhereClause = potentialWhereClause.replace(lookupFieldName, matchingMeta.LookupFieldOnCalcItem__c);
-        lookupFieldName = matchingMeta.LookupFieldOnCalcItem__c;
-      }
-      if (delimiterIndex != -1) {
-        matchingMeta.CalcItemWhereClause__c = matchingMeta.CalcItemWhereClause__c?.substringBeforeLast(delimiter);
-        if (String.isNotBlank(matchingMeta.CalcItemWhereClause__c)) {
-          matchingMeta.CalcItemWhereClause__c += ' AND ' + potentialWhereClause;
-        } else {
-          matchingMeta.CalcItemWhereClause__c = potentialWhereClause;
+      if (localInvokePoint == InvocationPoint.FROM_SINGULAR_PARENT_RECALC_LWC && possibleParentId == null) {
+        Integer delimiterIndex = matchingMeta.CalcItemWhereClause__c?.indexOf(delimiter);
+        if (delimiterIndex != null && delimiterIndex > -1) {
+          possibleParentId = matchingMeta.CalcItemWhereClause__c.substring(delimiterIndex + delimiter.length(), matchingMeta.CalcItemWhereClause__c.length())
+            .substringAfter(' = ')
+            .remove('\'');
         }
+      }
+      if (possibleParentId != null) {
+        String lookupFieldName = String.isNotBlank(matchingMeta.GrandparentRelationshipFieldPath__c)
+          ? matchingMeta.GrandparentRelationshipFieldPath__c.substringBeforeLast('.') + '.' + matchingMeta.LookupFieldOnLookupObject__c
+          : matchingMeta.LookupFieldOnCalcItem__c;
+        matchingMeta.CalcItemWhereClause__c = matchingMeta.CalcItemWhereClause__c?.substringBeforeLast(delimiter);
+        if (matchingMeta.CalcItemWhereClause__c == null) {
+          matchingMeta.CalcItemWhereClause__c = '';
+        }
+        matchingMeta.CalcItemWhereClause__c +=
+          (String.isNotBlank(matchingMeta.CalcItemWhereClause__c) ? ' AND ' : '') +
+          lookupFieldName +
+          ' = ' +
+          '\'' +
+          possibleParentId +
+          '\'';
       }
 
       SObjectType childType = RollupFieldInitializer.Current.getDescribeFromName(matchingMeta.CalcItem__c).getSObjectType();

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -1,4 +1,4 @@
-global virtual without sharing class RollupAsyncProcessor extends Rollup implements Database.Batchable<SObject>, System.Comparable {
+global virtual without sharing class RollupAsyncProcessor extends Rollup implements Database.Batchable<SObject>, Database.RaisesPlatformEvents, System.Comparable {
   private final Evaluator eval;
   private final Op op;
   private final SObjectField lookupFieldOnCalcItem;
@@ -220,7 +220,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       Set<String> uniqueLookupObjectFields = this.lookupObjectToUniqueFieldNames.get(sObjectType);
       objIds = this.getCalcItemsByLookupField(firstRollup, uniqueLookupObjectFields).keySet();
       query = RollupQueryBuilder.Current.getQuery(sObjectType, new List<String>(uniqueLookupObjectFields), lookupFieldForLookupObject, '=');
-      this.logger.log('starting batch with query:', query, LoggingLevel.DEBUG);
+      this.logger.log('starting batch with query:', query, LoggingLevel.INFO);
     }
     this.logger.save();
     return Database.getQueryLocator(query);
@@ -237,7 +237,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
     this.lookupItems = lookupItems;
     this.process(this.rollups);
-    this.logger.save();
   }
 
   public virtual void finish(Database.BatchableContext context) {
@@ -264,6 +263,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
     String rollupProcessId = this.getNoProcessId();
     String logMessage;
+    System.LoggingLevel logLevel = System.LoggingLevel.INFO;
     if (this.isNoOp) {
       logMessage = 'no-op, exiting early to avoid burning async job';
     } else if (this.rollupControl.ShouldAbortRun__c) {
@@ -271,9 +271,9 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     } else if (RollupSettings__c.getInstance().IsEnabled__c == false && shouldRunWithoutCustomSetting == false) {
       logMessage = String.valueOf(RollupSettings__c.SObjectType) + '.' + String.valueOf(RollupSettings__c.IsEnabled__c) + ' is false, exiting early';
     } else if (syncRollups.isEmpty() == false) {
-      this.logger.log('about to process sync rollups', LoggingLevel.DEBUG);
+      this.logger.log('about to process sync rollups', logLevel);
       this.process(syncRollups);
-      this.logger.log('finished running sync rollups', LoggingLevel.DEBUG);
+      this.logger.log('finished running sync rollups', logLevel);
     } else {
       Integer totalCountOfRecords = this.getLookupRecordsCount(this.rollups);
       shouldRunAsBatch =
@@ -283,7 +283,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       rollupProcessId = this.getAsyncRollup()?.beginAsyncRollup();
     }
     if (logMessage != null) {
-      this.logger.log(logMessage, LoggingLevel.DEBUG);
+      this.logger.log(logMessage, logLevel);
       rollupProcessId = logMessage;
     }
     this.logger.save();
@@ -423,13 +423,13 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   protected void logFinish() {
-    this.logger.log(this.getTypeName() + ' finished successfully', LoggingLevel.DEBUG);
+    this.logger.log(this.getTypeName() + ' finished successfully', LoggingLevel.INFO);
     this.logger.save();
   }
 
   protected String beginAsyncRollup() {
     this.isTimingOut = false;
-    this.logger.log('about to start for ' + this.getTypeName(), this, LoggingLevel.DEBUG);
+    this.logger.log('about to start for ' + this.getTypeName(), this, LoggingLevel.INFO);
     return this.startAsyncWork();
   }
 
@@ -537,7 +537,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         if (this.childToUnexpectedFullRecalc.containsKey(rollup.calcItemType)) {
           this.childToUnexpectedFullRecalc.get(rollup.calcItemType).addMetadata(rollup.metadata);
         } else {
-          this.logger.log('Populating unexpected full recalc for ' + outstandingItemCount + ' items', LoggingLevel.DEBUG);
+          this.logger.log('Populating unexpected full recalc for ' + outstandingItemCount + ' items', LoggingLevel.INFO);
           RollupFullRecalcProcessor fullBatchProcessor = new RollupFullBatchRecalculator(
             RollupQueryBuilder.Current.getQuery(
               rollup.calcItemType,
@@ -614,7 +614,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       }
 
       List<SObject> localLookupItems = this.getLookupItems(calcItemsByLookupField, updatedLookupRecords, roll);
-      this.logger.log('starting rollup for:', roll, LoggingLevel.DEBUG);
+      this.logger.log('starting rollup for:', roll, LoggingLevel.INFO);
       updatedLookupRecords.putAll(this.getUpdatedLookupItemsByRollup(roll, calcItemsByLookupField, localLookupItems));
     }
 
@@ -624,6 +624,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     this.getDML().doUpdate(updatedLookupRecords.values());
     this.populateOtherDeferredRollups();
     this.processDeferredRollups();
+    this.logger.save();
   }
 
   protected virtual List<RollupAsyncProcessor> transformFullRecalcRollups() {
@@ -844,7 +845,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       isAllowedToContinue +
       ' with stackDepth: ' +
       this.stackDepth,
-      LoggingLevel.DEBUG
+      LoggingLevel.INFO
     );
 
     Boolean isDeferralAllowed = this.getIsDeferralAllowed() && isAllowedToContinue;
@@ -856,12 +857,11 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     this.isTimingOut = false;
 
     if (isDeferralAllowed) {
-      this.logger.log('deferred rollups remaining:', this.rollups, LoggingLevel.DEBUG);
+      this.logger.log('deferred rollups remaining:', this.rollups, LoggingLevel.INFO);
       this.getAsyncRollup()?.beginAsyncRollup();
     } else if (this.rollups.isEmpty() == false) {
       this.logger.log('deferral was explicitly disallowed for rollups:', this.rollups, LoggingLevel.ERROR);
     }
-    this.logger.save();
   }
 
   private void setupCalcItemData(Rollup roll) {

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -1,4 +1,4 @@
-public without sharing virtual class RollupFullBatchRecalculator extends RollupFullRecalcProcessor implements Database.Stateful {
+public without sharing virtual class RollupFullBatchRecalculator extends RollupFullRecalcProcessor implements Database.Stateful, Database.RaisesPlatformEvents {
   public RollupFullBatchRecalculator(
     String queryString,
     InvocationPoint invokePoint,
@@ -17,7 +17,7 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupF
   }
 
   public virtual override void execute(Database.BatchableContext bc, List<SObject> calcItems) {
-    this.logger.log('starting full batch recalc run:', this, LoggingLevel.DEBUG);
+    this.logger.log('starting full batch recalc run:', this, LoggingLevel.INFO);
     /**
      * this batch class is a glorified "for loop" for the calc items, dispatching
      * them to the overall Rollup framework while breaking us out of the query limits

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -17,7 +17,7 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupF
   }
 
   public virtual override void execute(Database.BatchableContext bc, List<SObject> calcItems) {
-    this.logger.log('starting full batch recalc run:', this, LoggingLevel.INFO);
+    this.logger.log('starting full batch chunk:', this, LoggingLevel.INFO);
     /**
      * this batch class is a glorified "for loop" for the calc items, dispatching
      * them to the overall Rollup framework while breaking us out of the query limits
@@ -26,6 +26,7 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupF
      * parent class
      */
     this.process(this.getDelegatedFullRecalcRollups(calcItems));
+    this.logger.log('batch chunk end', LoggingLevel.INFO);
   }
 
   public override Boolean isBatch() {

--- a/rollup/core/classes/RollupFullRecalcProcessor.cls
+++ b/rollup/core/classes/RollupFullRecalcProcessor.cls
@@ -72,7 +72,7 @@ public abstract without sharing class RollupFullRecalcProcessor extends RollupAs
 
   public void finish() {
     if (this.postProcessor != null) {
-      this.logger.log('Starting post-full recalc processor', this.postProcessor, LoggingLevel.DEBUG);
+      this.logger.log('Starting post-full recalc processor', this.postProcessor, LoggingLevel.INFO);
       // chain jobs together so that if recalc job is being tracked within the Recalc Rollups app,
       // job continuity is established between the full recalc and then any downstream job that runs
       // (as the postProcessor)

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.43';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.44';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupParentResetProcessor.cls
+++ b/rollup/core/classes/RollupParentResetProcessor.cls
@@ -83,7 +83,9 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
   }
 
   protected override String startAsyncWork() {
-    return System.enqueueJob(new QueueableResetProcessor(this, this.rollupControl.BatchChunkSize__c.intValue()));
+    return this.rollupControl.ShouldSkipResettingParentFields__c
+      ? this.getNoProcessId()
+      : System.enqueueJob(new QueueableResetProcessor(this, this.rollupControl.BatchChunkSize__c.intValue()));
   }
 
   private Integer getNumberOfItems() {

--- a/rollup/core/classes/RollupParentResetProcessor.cls
+++ b/rollup/core/classes/RollupParentResetProcessor.cls
@@ -43,10 +43,11 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
     this.objIds.addAll(this.recordIds);
     String processId = this.getNoProcessId();
     if (isValidRun == false || this.rollupControl.ShouldSkipResettingParentFields__c == true) {
+      this.logger.log('Parent reset processor no-op', LoggingLevel.INFO);
       return processId;
     }
     Boolean isOverLimit = this.getNumberOfItems() > maxQueryRows;
-    if (isOverLimit && System.isBatch() == false) {
+    if (isOverLimit && this.isBatch() == false) {
       // avoids: System.AsyncException: Database.executeBatch cannot be called from a batch start, batch execute, or future method
       processId = super.startAsyncWork();
     } else if (isOverLimit && Limits.getLimitQueueableJobs() > Limits.getQueueableJobs()) {
@@ -64,7 +65,7 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
     if (parentItems.isEmpty()) {
       return;
     }
-    this.logger.log('resetting parent fields for: ' + parentItems.size() + ' items', LoggingLevel.DEBUG);
+    this.logger.log('resetting parent fields for: ' + parentItems.size() + ' items', LoggingLevel.INFO);
     Map<String, Schema.SObjectField> parentFields = parentItems.get(0).getSObjectType().getDescribe().fields.getMap();
     for (SObject parentItem : parentItems) {
       for (Rollup__mdt rollupMeta : this.rollupMetas) {

--- a/rollup/core/layouts/RollupControl__mdt-Rollup Control Layout.layout-meta.xml
+++ b/rollup/core/layouts/RollupControl__mdt-Rollup Control Layout.layout-meta.xml
@@ -87,6 +87,10 @@
                 <behavior>Edit</behavior>
                 <field>ReplaceCalcItemsAsyncWhenOverCount__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>ShouldSkipResettingParentFields__c</field>
+            </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
     </layoutSections>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -109,6 +109,7 @@
         "apex-rollup@1.5.40-0": "04t6g000008fjSUAAY",
         "apex-rollup@1.5.41-0": "04t6g000008fjSyAAI",
         "apex-rollup@1.5.42-0": "04t6g000008fjThAAI",
-        "apex-rollup@1.5.43-0": "04t6g000008fjW7AAI"
+        "apex-rollup@1.5.43-0": "04t6g000008fjW7AAI",
+        "apex-rollup@1.5.44-0": "04t6g000008fjXeAAI"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Allows the rolling up of text fields to date/datetime fields",
-            "versionNumber": "1.5.43.0",
+            "versionName": "Logging granularity updates",
+            "versionNumber": "1.5.44.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
* Updated logging levels to `INFO` for most high-level rollup operations. This allows `DEBUG` to be used to filter down to being able to answer the question "what did my parent-level records look like before/after rolling up?"
* Fixed an issue found while investigating #404 where the parent reset processor was occasionally running for full recalcs even when explicitly disabled via `RollupControl__mdt.ShouldSkipResettingParentFields__c`