### PR TITLE
v1.5.54 - Further repository work, logging updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ coverage/
 plugins/ExtraCodeCoverage
 .sf/
 rollup-namespaced/source
+sfge-*.log.gz

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjg2AAA">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjhPAAQ">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjg2AAA">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjhPAAQ">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupRepositoryTests.cls
+++ b/extra-tests/classes/RollupRepositoryTests.cls
@@ -4,7 +4,7 @@ private class RollupRepositoryTests {
   static void transformsCountQueriesProperly() {
     String queryString = 'SELECT Id, AnnualRevenue, Name\nFROM Account';
 
-    Integer accountCount = new RollupRepository(System.AccessLevel.SYSTEM_MODE).getCount(queryString, new Set<String>());
+    Integer accountCount = new RollupRepository(System.AccessLevel.SYSTEM_MODE).setQuery(queryString).getCount();
 
     System.assertEquals(0, accountCount);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.53",
+  "version": "1.5.54",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjg7AAA">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjhUAAQ">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjg7AAA">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjhUAAQ">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Add extra type safety when multiple children types are being rolled up to the same grandparent",
-            "versionNumber": "1.0.26.0",
+            "versionName": "Quality of life updates as far as how rollup queries are performed, updated RollupLogger to global visibility",
+            "versionNumber": "1.0.27.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -47,6 +47,7 @@
         "apex-rollup-namespaced@1.0.23-0": "04t6g000008fjeLAAQ",
         "apex-rollup-namespaced@1.0.24-0": "04t6g000008fjeuAAA",
         "apex-rollup-namespaced@1.0.25-0": "04t6g000008fjfdAAA",
-        "apex-rollup-namespaced@1.0.26-0": "04t6g000008fjg7AAA"
+        "apex-rollup-namespaced@1.0.26-0": "04t6g000008fjg7AAA",
+        "apex-rollup-namespaced@1.0.27-0": "04t6g000008fjhUAAQ"
     }
 }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1569,18 +1569,18 @@ global without sharing virtual class Rollup {
       }
     }
 
-    List<Id> objIds = new List<Id>();
+    List<Id> updatedRecordIds = new List<Id>();
     for (SObject cdcRecord : cdcRecords) {
       header = (EventBus.ChangeEventHeader) cdcRecord.get('ChangeEventHeader');
       uniqueFieldNames.addAll(header.changedfields);
-      objIds.addAll(header.getRecordIds());
+      updatedRecordIds.addAll(header.getRecordIds());
     }
 
     String queryString = RollupQueryBuilder.Current.getQuery(sObjectType, new List<String>(uniqueFieldNames), 'Id', '=');
     // getting the items back from the database before putting them into the map is an important step
     // we COULD just initialize the map with the query, but then the map's .values() list doesn't return
     // anything for .getSObjectType() - which we need, further downstream
-    List<SObject> cdcCalcItems = new RollupRepository(accessLevel).setQuery(queryString).setArg(objIds).get();
+    List<SObject> cdcCalcItems = new RollupRepository(accessLevel).setQuery(queryString).setArg(updatedRecordIds).get();
     Map<Id, SObject> cdcCalcItemsMap = new Map<Id, SObject>(cdcCalcItems);
 
     Rollup rollupToReturn = runFromApex(matchingMetadata, null, cdcCalcItems, cdcCalcItemsMap);
@@ -2219,8 +2219,10 @@ global without sharing virtual class Rollup {
 
   private static void appendQueryCount(RollupMetadata metaWrapper, Rollup__mdt meta, String whereClause, Schema.SObjectType childType) {
     if (metaWrapper.recordCount != RollupRepository.SENTINEL_COUNT_VALUE) {
-      String countQuery = RollupQueryBuilder.Current.getQuery(childType, new List<String>(), meta.LookupFieldOnLookupObject__c, '!=', whereClause);
-      Integer currentCount = new RollupRepository(RollupMetaPicklists.getAccessLevel(meta)).setQuery(countQuery).setArg(new Set<String>()).getCount();
+      Integer currentCount = new RollupRepository(RollupMetaPicklists.getAccessLevel(meta))
+        .setQuery(RollupQueryBuilder.Current.getQuery(childType, new List<String>(), meta.LookupFieldOnLookupObject__c, '!=', whereClause))
+        .setArg(new Set<String>())
+        .getCount();
       metaWrapper.recordCount = currentCount == RollupRepository.SENTINEL_COUNT_VALUE ? currentCount : metaWrapper.recordCount + currentCount;
     }
   }
@@ -2838,14 +2840,10 @@ global without sharing virtual class Rollup {
       if (updatedChildTypes.contains(calcItemSObject) == false) {
         updatedChildTypes.add(calcItemSObject);
 
-        String queryString = RollupQueryBuilder.Current.getQuery(
-          calcItemSObject,
-          new List<String>{ 'Id', meta.LookupFieldOnCalcItem__c },
-          meta.LookupFieldOnCalcItem__c,
-          '='
-        );
         List<SObject> recordsToReparent = new RollupRepository(RollupMetaPicklists.getAccessLevel(meta))
-          .setQuery(queryString)
+          .setQuery(
+            RollupQueryBuilder.Current.getQuery(calcItemSObject, new List<String>{ 'Id', meta.LookupFieldOnCalcItem__c }, meta.LookupFieldOnCalcItem__c, '=')
+          )
           .setArg(mergedIdToCurrentParentId.keySet())
           .get();
         for (SObject childToReparent : recordsToReparent) {

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -2901,6 +2901,7 @@ global without sharing virtual class Rollup {
     );
     processor.triggerContext = apexContext;
     processor.accessLevel = RollupMetaPicklists.getAccessLevel(rollupMetadata);
+    rollupConductor.accessLevel = processor.accessLevel;
     return addRollup(rollupConductor, processor);
   }
 

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1580,7 +1580,7 @@ global without sharing virtual class Rollup {
     // getting the items back from the database before putting them into the map is an important step
     // we COULD just initialize the map with the query, but then the map's .values() list doesn't return
     // anything for .getSObjectType() - which we need, further downstream
-    List<SObject> cdcCalcItems = new RollupRepository(accessLevel).get(queryString, objIds);
+    List<SObject> cdcCalcItems = new RollupRepository(accessLevel).setQuery(queryString).setArg(objIds).get();
     Map<Id, SObject> cdcCalcItemsMap = new Map<Id, SObject>(cdcCalcItems);
 
     Rollup rollupToReturn = runFromApex(matchingMetadata, null, cdcCalcItems, cdcCalcItemsMap);
@@ -2220,8 +2220,7 @@ global without sharing virtual class Rollup {
   private static void appendQueryCount(RollupMetadata metaWrapper, Rollup__mdt meta, String whereClause, Schema.SObjectType childType) {
     if (metaWrapper.recordCount != RollupRepository.SENTINEL_COUNT_VALUE) {
       String countQuery = RollupQueryBuilder.Current.getQuery(childType, new List<String>(), meta.LookupFieldOnLookupObject__c, '!=', whereClause);
-      Set<String> emptyCollection = new Set<String>();
-      Integer currentCount = new RollupRepository(RollupMetaPicklists.getAccessLevel(meta)).getCount(countQuery, emptyCollection);
+      Integer currentCount = new RollupRepository(RollupMetaPicklists.getAccessLevel(meta)).setQuery(countQuery).setArg(new Set<String>()).getCount();
       metaWrapper.recordCount = currentCount == RollupRepository.SENTINEL_COUNT_VALUE ? currentCount : metaWrapper.recordCount + currentCount;
     }
   }
@@ -2845,7 +2844,10 @@ global without sharing virtual class Rollup {
           meta.LookupFieldOnCalcItem__c,
           '='
         );
-        List<SObject> recordsToReparent = new RollupRepository(RollupMetaPicklists.getAccessLevel(meta)).get(queryString, mergedIdToCurrentParentId.keySet());
+        List<SObject> recordsToReparent = new RollupRepository(RollupMetaPicklists.getAccessLevel(meta))
+          .setQuery(queryString)
+          .setArg(mergedIdToCurrentParentId.keySet())
+          .get();
         for (SObject childToReparent : recordsToReparent) {
           childToReparent.put(meta.LookupFieldOnCalcItem__c, mergedIdToCurrentParentId.get((Id) childToReparent.get(meta.LookupFieldOnCalcItem__c)));
           recordsToUpdate.add(childToReparent);

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -277,7 +277,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     } else if (RollupSettings__c.getInstance().IsEnabled__c == false && shouldRunWithoutCustomSetting == false) {
       logMessage = String.valueOf(RollupSettings__c.SObjectType) + '.' + String.valueOf(RollupSettings__c.IsEnabled__c) + ' is false, exiting early';
     } else if (syncRollups.isEmpty() == false) {
-      this.logger.log('about to process sync rollups', logLevel);
+      this.logger.log(this.getTypeName() + ': about to process sync rollups', logLevel);
       this.process(syncRollups);
       logMessage = 'finished running sync rollups';
       if (this.rollups.isEmpty()) {
@@ -292,7 +292,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       rollupProcessId = this.getAsyncRollup()?.beginAsyncRollup();
     }
     if (logMessage != null) {
-      this.logger.log(logMessage, logLevel);
+      this.logger.log(this.getTypeName() + ': ' + logMessage, logLevel);
       rollupProcessId = logMessage;
     }
     this.logger.save();
@@ -585,7 +585,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         if (this.childToUnexpectedFullRecalc.containsKey(rollup.calcItemType)) {
           this.childToUnexpectedFullRecalc.get(rollup.calcItemType).addMetadata(rollup.metadata);
         } else {
-          this.logger.log('Populating unexpected full recalc for ' + outstandingItemCount + ' items', LoggingLevel.INFO);
+          this.logger.log(this.getTypeName() + ': Populating unexpected full recalc for ' + outstandingItemCount + ' items', LoggingLevel.INFO);
           RollupFullRecalcProcessor fullBatchProcessor = new RollupFullBatchRecalculator(
             query.substringBeforeLast('\nLIMIT'),
             this.invokePoint,
@@ -600,7 +600,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         return;
       }
       if (outstandingItemCount > 0) {
-        this.logger.log('gathering additional calc items with query:', query, LoggingLevel.DEBUG);
+        this.logger.log(this.getTypeName() + ': gathering additional calc items with query:', query, LoggingLevel.DEBUG);
         additionalCalcItems = repo.setQuery(query).get();
 
         if (hasAlreadyBeenQueried) {
@@ -755,7 +755,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
   private Boolean getIsTimingOut(RollupControl__mdt control, RollupAsyncProcessor processor) {
     if (this.isTimingOut == false && hasExceededCurrentRollupLimits(control)) {
-      this.logger.log('Starting to time out ...', LoggingLevel.WARN);
+      this.logger.log(this.getTypeName() + ': starting to time out ...', LoggingLevel.WARN);
       this.isTimingOut = true;
     }
     return this.isTimingOut;
@@ -886,7 +886,8 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
     Boolean isAllowedToContinue = this.rollupControl.MaxRollupRetries__c >= stackDepth;
     this.logger.log(
-      'Number of deferred rollups: ' +
+      this.getTypeName() +
+      ': number of deferred rollups: ' +
       this.deferredRollups.size() +
       ', still allowed to re-queue?: ' +
       isAllowedToContinue +
@@ -904,10 +905,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     this.isTimingOut = false;
 
     if (isDeferralAllowed) {
-      this.logger.log('deferred rollups remaining:', this.rollups, LoggingLevel.INFO);
+      this.logger.log(this.getTypeName() + ': deferred rollups remaining:', this.rollups, LoggingLevel.INFO);
       this.getAsyncRollup()?.beginAsyncRollup();
     } else if (this.rollups.isEmpty() == false) {
-      this.logger.log('deferral was explicitly disallowed for rollups:', this.rollups, LoggingLevel.ERROR);
+      this.logger.log(this.getTypeName() + ': deferral was explicitly disallowed for rollups:', this.rollups, LoggingLevel.ERROR);
     }
   }
 
@@ -1300,7 +1301,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         }
 
         oldLookupsRollup.calcItems = reparentedCalcItems;
-        this.logger.log('reparenting operation:', oldLookupsRollup, LoggingLevel.DEBUG);
+        this.logger.log(this.getTypeName() + ': reparenting operation', oldLookupsRollup, LoggingLevel.DEBUG);
         calc = this.getCalculator(calc, oldLookupsRollup, reparentedCalcItems, lookupRecord, priorVal, key, roll.lookupFieldOnCalcItem);
         this.conditionallyPerformUpdate(priorVal, calc, lookupRecord, roll, recordsToUpdate, updater, ParentUpdateType.REPARENTED, reparentedCalcItems);
       }
@@ -1318,18 +1319,18 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     List<SObject> localCalcItems
   ) {
     String logKey = parentUpdateType.name().toLowerCase();
-    this.logger.log(logKey + ' record prior to rolling up:', lookupRecord, LoggingLevel.DEBUG);
+    this.logger.log(this.getTypeName() + ': ' + logKey + ' record prior to rolling up:', lookupRecord, LoggingLevel.DEBUG);
     Object newVal = calc.getReturnValue();
     if (this.rollupControl.ShouldSkipResettingParentFields__c == true && ((localCalcItems.isEmpty() == false && newVal == null) || localCalcItems.isEmpty())) {
       newVal = priorVal;
     }
     if (priorVal != newVal) {
       String key = (String) lookupRecord.get(roll.lookupFieldOnLookupObject);
-      this.logger.log('updating record ...', LoggingLevel.FINE);
+      this.logger.log(this.getTypeName() + ': updating record ...', LoggingLevel.FINE);
       updater.updateField(lookupRecord, newVal);
       recordsToUpdate.put(key, lookupRecord);
     }
     this.storeParentResetField(roll, lookupRecord);
-    this.logger.log(logKey + ' record after rolling up:', lookupRecord, LoggingLevel.DEBUG);
+    this.logger.log(this.getTypeName() + ': ' + logKey + ' record after rolling up:', lookupRecord, LoggingLevel.DEBUG);
   }
 }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -352,7 +352,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       } else {
         roll = this;
       }
-    } else if (canEnqueue && (this instanceof QueueableProcessor) == false && (System.isQueueable() == false || hasAlreadyAsyncEnqueued == false)) {
+    } else if (canEnqueue && (System.isQueueable() == false || hasAlreadyAsyncEnqueued == false)) {
       roll = new QueueableProcessor(this);
     } else if (canEnqueue) {
       roll = this.rollupControl.IsDevEdOrTrialOrg__c && this.stackDepth >= 4 ? new RollupAsyncProcessor(this) : this;

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -211,11 +211,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
      * trying to use Database.Stateful on the top-level class ** in addition to Batchable ** results in the dreaded:
      * "System.AsyncException: Queueable cannot be implemented with other system interfaces" exception
      */
-    Set<String> objIds = new Set<String>();
-    String query = this.preStart(objIds);
-    this.logger.log('starting batch with query: ' + query, context, LoggingLevel.INFO);
+    RollupRepository repo = this.preStart();
+    this.logger.log('starting batch with query: ' + repo, context, LoggingLevel.INFO);
     this.logger.save();
-    return Database.getQueryLocator(query);
+    return repo.getLocator();
   }
 
   public virtual void execute(Database.BatchableContext context, List<SObject> scope) {
@@ -300,19 +299,21 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     return rollupProcessId;
   }
 
-  protected virtual String preStart(Set<String> objIds) {
+  protected virtual RollupRepository preStart() {
     this.winnowRollups(this.rollups);
     this.populateObjectFields(this.rollups);
     String query = 'SELECT Id FROM Organization WHERE Name != \'' + UserInfo.getOrganizationName() + '\'';
+    RollupRepository repo = new RollupRepository(this.accessLevel);
     if (this.rollups.isEmpty() == false) {
       RollupAsyncProcessor firstRollup = this.rollups.get(0);
       SObjectType sObjectType = firstRollup.lookupObj;
       String lookupFieldForLookupObject = firstRollup.lookupFieldOnLookupObject.getDescribe().getName();
       Set<String> uniqueLookupObjectFields = this.lookupObjectToUniqueFieldNames.get(sObjectType);
-      objIds.addAll(this.getCalcItemsByLookupField(firstRollup, uniqueLookupObjectFields).keySet());
+      repo.setArg(this.getCalcItemsByLookupField(firstRollup, uniqueLookupObjectFields).keySet());
       query = RollupQueryBuilder.Current.getQuery(sObjectType, new List<String>(uniqueLookupObjectFields), lookupFieldForLookupObject, '=');
     }
-    return query;
+    repo.setQuery(query);
+    return repo;
   }
 
   protected virtual override String getTypeName() {
@@ -462,8 +463,8 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     return Database.executeBatch(this, this.rollupControl.BatchChunkSize__c.intValue());
   }
 
-  protected List<SObject> getExistingLookupItems(Set<String> objIds, RollupAsyncProcessor rollup, Set<String> uniqueQueryFieldNames) {
-    if (objIds.isEmpty()) {
+  protected List<SObject> getExistingLookupItems(Set<String> lookupKeys, RollupAsyncProcessor rollup, Set<String> uniqueQueryFieldNames) {
+    if (lookupKeys.isEmpty()) {
       this.lookupItems = new List<SObject>();
     } else if (stubParentRecords != null) {
       this.lookupItems = stubParentRecords;
@@ -480,7 +481,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         RollupQueryBuilder.Current.getQuery(rollup.lookupObj, new List<String>(uniqueQueryFieldNames), String.valueOf(rollup.lookupFieldOnLookupObject), '=') +
         (this.isSingleRecordSyncUpdate(rollup) ? '\nFOR UPDATE' : '');
 
-      localLookupItems = new RollupRepository(rollup.accessLevel).get(queryString, objIds);
+      localLookupItems = new RollupRepository(rollup.accessLevel).setQuery(queryString).setArg(lookupKeys).get();
     }
     List<SObject> recordsToReset = new List<SObject>();
     for (SObject lookupItem : localLookupItems) {
@@ -551,14 +552,13 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       additionalCalcItems = this.cachedQueryToAdditionalCalcItems.get(query);
     } else {
       Set<String> recordIds = lookupToCalcItems.keySet();
-      RollupRepository repo = new RollupRepository(rollup.accessLevel);
       String countQuery = RollupQueryBuilder.Current.getQuery(rollup.calcItemType, new List<String>(), 'Id', '!=', whereClause);
-      Map<String, Object> queryBinds = new Map<String, Object>{ RollupQueryBuilder.BIND_VAR => objIds, 'recordIds' => recordIds };
+      RollupRepository repo = new RollupRepository(rollup.accessLevel).setQuery(countQuery).setArg(objIds).setArg('recordIds', recordIds);
       if (additionalCalcItemCount != null) {
         outstandingItemCount = additionalCalcItemCount;
         additionalCalcItemCount = null;
       } else {
-        outstandingItemCount = repo.getCount(countQuery, queryBinds);
+        outstandingItemCount = repo.getCount();
       }
       remainingQueryRowsLeft = new RollupLimits.Tester(rollup.rollupControl, this.getIsRunningAsync()).getRemainingQueryRows();
       shouldLimitCalcItemQuery = outstandingItemCount >= remainingQueryRowsLeft;
@@ -602,7 +602,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       }
       if (outstandingItemCount > 0) {
         this.logger.log('gathering additional calc items with query:', query, LoggingLevel.DEBUG);
-        additionalCalcItems = repo.get(query, queryBinds);
+        additionalCalcItems = repo.setQuery(query).get();
 
         if (hasAlreadyBeenQueried) {
           this.cachedQueryToAdditionalCalcItems.get(cachedQueryKey).addAll(additionalCalcItems);
@@ -1115,7 +1115,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
     RollupRepository repo = new RollupRepository(localAccessLevel);
     for (String countQuery : queryCountsToLookupIds.keySet()) {
-      Integer countForSObject = repo.getCount(countQuery, queryCountsToLookupIds.get(countQuery));
+      Integer countForSObject = repo.setQuery(countQuery).setArg(queryCountsToLookupIds.get(countQuery)).getCount();
       if (countForSObject == RollupRepository.SENTINEL_COUNT_VALUE) {
         totalCountOfRecords = this.rollupControl.MaxLookupRowsBeforeBatching__c.intValue() - 1;
         break;

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -312,8 +312,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       repo.setArg(this.getCalcItemsByLookupField(firstRollup, uniqueLookupObjectFields).keySet());
       query = RollupQueryBuilder.Current.getQuery(sObjectType, new List<String>(uniqueLookupObjectFields), lookupFieldForLookupObject, '=');
     }
-    repo.setQuery(query);
-    return repo;
+    return repo.setQuery(query);
   }
 
   protected virtual override String getTypeName() {
@@ -477,11 +476,17 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     if (rollup.traversal != null) {
       localLookupItems = rollup.traversal.getAllParents();
     } else {
-      String queryString =
-        RollupQueryBuilder.Current.getQuery(rollup.lookupObj, new List<String>(uniqueQueryFieldNames), String.valueOf(rollup.lookupFieldOnLookupObject), '=') +
-        (this.isSingleRecordSyncUpdate(rollup) ? '\nFOR UPDATE' : '');
-
-      localLookupItems = new RollupRepository(rollup.accessLevel).setQuery(queryString).setArg(lookupKeys).get();
+      localLookupItems = new RollupRepository(rollup.accessLevel)
+        .setQuery(
+          RollupQueryBuilder.Current.getQuery(
+            rollup.lookupObj,
+            new List<String>(uniqueQueryFieldNames),
+            String.valueOf(rollup.lookupFieldOnLookupObject),
+            '='
+          ) + (this.isSingleRecordSyncUpdate(rollup) ? '\nFOR UPDATE' : '')
+        )
+        .setArg(lookupKeys)
+        .get();
     }
     List<SObject> recordsToReset = new List<SObject>();
     for (SObject lookupItem : localLookupItems) {
@@ -503,11 +508,11 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       return;
     }
 
-    Set<String> objIds = new Set<String>();
+    Set<String> lookupKeys = new Set<String>();
     for (CalcItemBag bag : lookupToCalcItems.values()) {
       if (bag.hasQueriedForAdditionalItems == false) {
         bag.hasQueriedForAdditionalItems = true;
-        objIds.addAll(bag.getAllIds());
+        lookupKeys.addAll(bag.getAllIds());
       }
       // calling clear in a loop here might look interesting - and it would be a massive problem if not for the
       // bag only responding to the very first clear() invocation. everything after that is a no-op (so, any rollup with more
@@ -517,7 +522,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       }
     }
 
-    if (objIds.isEmpty()) {
+    if (lookupKeys.isEmpty()) {
       return;
     }
 
@@ -526,7 +531,8 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       ? rollup.calcObjectToUniqueFieldNames
       : this.calcObjectToUniqueFieldNames;
 
-    String whereClause = '' + rollup.lookupFieldOnCalcItem + ' = :recordIds';
+    String recordBindVar = 'recordIds';
+    String whereClause = '' + rollup.lookupFieldOnCalcItem + ' = :' + recordBindVar;
     String query = RollupQueryBuilder.Current.getQuery(
       rollup.calcItemType,
       new List<String>(localCalcToUniqueFieldNames.get(rollup.calcItemType)),
@@ -552,8 +558,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       additionalCalcItems = this.cachedQueryToAdditionalCalcItems.get(query);
     } else {
       Set<String> recordIds = lookupToCalcItems.keySet();
-      String countQuery = RollupQueryBuilder.Current.getQuery(rollup.calcItemType, new List<String>(), 'Id', '!=', whereClause);
-      RollupRepository repo = new RollupRepository(rollup.accessLevel).setQuery(countQuery).setArg(objIds).setArg('recordIds', recordIds);
+      RollupRepository repo = new RollupRepository(rollup.accessLevel).setQuery(query).setArg(lookupKeys).setArg(recordBindVar, recordIds);
       if (additionalCalcItemCount != null) {
         outstandingItemCount = additionalCalcItemCount;
         additionalCalcItemCount = null;
@@ -582,13 +587,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         } else {
           this.logger.log('Populating unexpected full recalc for ' + outstandingItemCount + ' items', LoggingLevel.INFO);
           RollupFullRecalcProcessor fullBatchProcessor = new RollupFullBatchRecalculator(
-            RollupQueryBuilder.Current.getQuery(
-              rollup.calcItemType,
-              new List<String>(localCalcToUniqueFieldNames.get(rollup.calcItemType)),
-              'Id',
-              '!=',
-              whereClause
-            ),
+            query.substringBeforeLast('\nLIMIT'),
             this.invokePoint,
             new List<Rollup__mdt>{ rollup.metadata },
             rollup.calcItemType,

--- a/rollup/core/classes/RollupCalcItemReplacer.cls
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls
@@ -123,7 +123,7 @@ public without sharing class RollupCalcItemReplacer {
       }
       String queryString = RollupQueryBuilder.Current.getQuery(firstItem.getSObjectType(), new List<String>(baseFields), 'Id', '=');
       RollupLogger.Instance.log('replacing calc items with missing base fields using query string:', queryString, LoggingLevel.DEBUG);
-      List<SObject> calcItemsWithReplacement = this.repo.get(queryString, calcItems);
+      List<SObject> calcItemsWithReplacement = this.repo.setQuery(queryString).setArg(calcItems).get();
       Map<String, Schema.SObjectField> fieldNameToDescribe = firstItem.getSObjectType().getDescribe().fields.getMap();
       for (SObject calcItemWithReplacement : calcItemsWithReplacement) {
         if (idToCalcItem.containsKey(calcItemWithReplacement.Id)) {
@@ -200,7 +200,7 @@ public without sharing class RollupCalcItemReplacer {
     );
 
     RollupLogger.Instance.log('replacing calc items with polymorphic where clause using query string:', queryString, LoggingLevel.FINE);
-    calcItems = this.repo.get(queryString, calcItems);
+    calcItems = this.repo.setQuery(queryString).setArg(calcItems).get();
     return calcItems;
   }
 
@@ -246,7 +246,7 @@ public without sharing class RollupCalcItemReplacer {
     if (hasUnqueriedParentFields) {
       String queryString = RollupQueryBuilder.Current.getQuery(calcItemType, new List<String>(parentQueryFields), 'Id', '=');
       RollupLogger.Instance.log('replacing calc items with parent-level where clause using query string:', queryString, LoggingLevel.FINE);
-      Map<Id, SObject> idToCalcItemsWithParentFields = new Map<Id, SObject>(this.repo.get(queryString, calcItems));
+      Map<Id, SObject> idToCalcItemsWithParentFields = new Map<Id, SObject>(this.repo.setQuery(queryString).setArg(calcItems).get());
       this.appendUpdatedParentFields(calcItems, idToCalcItemsWithParentFields);
     }
   }

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -1022,14 +1022,17 @@ public without sharing abstract class RollupCalculator {
       // we have to wait till it's the last iteration; this is what ensures that all of the deleted
       // items are accounted for in concatDistinctIds (for proper exclusion)
       if (this.isLastItem) {
-        String query = RollupQueryBuilder.Current.getQuery(
-          calcItem.getSObjectType(),
-          new List<String>{ this.opFieldOnCalcItem.getDescribe().getName() },
-          'Id',
-          '!=',
-          this.lookupKeyQuery
-        );
-        List<SObject> relatedItems = this.repo.setArg(this.concatDistinctIds).setQuery(query).get();
+        List<SObject> relatedItems = this.repo.setArg(this.concatDistinctIds)
+          .setQuery(
+            RollupQueryBuilder.Current.getQuery(
+              calcItem.getSObjectType(),
+              new List<String>{ this.opFieldOnCalcItem.getDescribe().getName() },
+              'Id',
+              '!=',
+              this.lookupKeyQuery
+            )
+          )
+          .get();
         for (SObject relatedItem : relatedItems) {
           this.handleConcat(relatedItem);
         }

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -386,13 +386,13 @@ public without sharing abstract class RollupCalculator {
   }
 
   private List<SObject> tryQuery(SObjectType sObjectType, Set<String> queryFields, Object objIds) {
-    String query = RollupQueryBuilder.Current.getQuery(sObjectType, new List<String>(queryFields), 'Id', '!=', this.lookupKeyQuery);
     List<SObject> results;
     try {
-      results = this.repo.get(query, objIds);
+      results = this.repo.setQuery(RollupQueryBuilder.Current.getQuery(sObjectType, new List<String>(queryFields), 'Id', '!=', this.lookupKeyQuery))
+        .setArg(objIds)
+        .get();
     } catch (System.QueryException qex) {
-      query = RollupQueryBuilder.Current.getQuery(sObjectType, new List<String>(queryFields), 'Id', '!=');
-      results = this.repo.get(query, objIds);
+      results = this.repo.setQuery(RollupQueryBuilder.Current.getQuery(sObjectType, new List<String>(queryFields), 'Id', '!=')).get();
     }
     return results;
   }
@@ -468,17 +468,19 @@ public without sharing abstract class RollupCalculator {
         queryFields.add('COUNT(' + (this.isIdCount ? '' : 'Id') + ')');
       }
 
-      String query =
-        RollupQueryBuilder.Current.getQuery(sObjectType, queryFields, 'Id', '!=', this.lookupKeyQuery + ('\nAND ' + this.opFieldOnCalcItem + '!= null')) +
-        (isGroupable && this.isIdCount == false ? ('\nGROUP BY ' + this.opFieldOnCalcItem) : '');
+      this.repo.setQuery(
+          RollupQueryBuilder.Current.getQuery(sObjectType, queryFields, 'Id', '!=', this.lookupKeyQuery + ('\nAND ' + this.opFieldOnCalcItem + '!= null')) +
+          (isGroupable && this.isIdCount == false ? ('\nGROUP BY ' + this.opFieldOnCalcItem) : '')
+        )
+        .setArg(objIds);
 
       if (this.isIdCount) {
-        Integer result = this.repo.getCount(query, objIds);
+        Integer result = this.repo.getCount();
         for (Integer index = 0; index < result; index++) {
           this.distinctValues.add(index);
         }
       } else {
-        List<SObject> results = this.repo.get(query, objIds);
+        List<SObject> results = this.repo.get();
         String calcItemOpField = this.opFieldOnCalcItem.getDescribe().getName();
         for (SObject res : results) {
           // have to use the String representation of the this.opFieldOnCalcItem to avoid:
@@ -1027,7 +1029,7 @@ public without sharing abstract class RollupCalculator {
           '!=',
           this.lookupKeyQuery
         );
-        List<SObject> relatedItems = this.repo.get(query, this.concatDistinctIds);
+        List<SObject> relatedItems = this.repo.setArg(this.concatDistinctIds).setQuery(query).get();
         for (SObject relatedItem : relatedItems) {
           this.handleConcat(relatedItem);
         }
@@ -1109,8 +1111,9 @@ public without sharing abstract class RollupCalculator {
       Decimal oldSum;
       Decimal denominator = Decimal.valueOf(applicableCalcItems.size());
       if (this.isFullRecalc == false) {
-        String query = RollupQueryBuilder.Current.getQuery(this.calcItemSObjectType, new List<String>(), 'Id', '!=', this.lookupKeyQuery);
-        denominator += this.repo.getCount(query, calcItems);
+        denominator += this.repo.setQuery(RollupQueryBuilder.Current.getQuery(this.calcItemSObjectType, new List<String>(), 'Id', '!=', this.lookupKeyQuery))
+          .setArg(calcItems)
+          .getCount();
         oldSum = (Decimal) this.calculateNewAggregateValue(Rollup.Op.SUM, calcItems, this.calcItemSObjectType);
       }
 
@@ -1157,9 +1160,12 @@ public without sharing abstract class RollupCalculator {
       if (this.isFullRecalc == false) {
         Set<String> queryFields = this.getQueryFields();
         // a full-recalc is always necessary because we don't retain the information about the order by field
-        String queryString = RollupQueryBuilder.Current.getQuery(this.calcItemSObjectType, new List<String>(queryFields), 'Id', '!=', this.lookupKeyQuery);
         // we have to exclude the current items on delete, otherwise they'll be incorrectly considered
-        List<SObject> additionalItems = this.repo.get(queryString, calcItems);
+        List<SObject> additionalItems = this.repo.setQuery(
+            RollupQueryBuilder.Current.getQuery(this.calcItemSObjectType, new List<String>(queryFields), 'Id', '!=', this.lookupKeyQuery)
+          )
+          .setArg(calcItems)
+          .get();
         switch on this.op {
           when DELETE_FIRST, DELETE_LAST {
             calcItems = additionalItems;

--- a/rollup/core/classes/RollupDateLiteral.cls
+++ b/rollup/core/classes/RollupDateLiteral.cls
@@ -420,8 +420,8 @@ public without sharing abstract class RollupDateLiteral {
   private class LastNDaysLiteral extends RollupDateLiteral {
     protected override void setDynamicValue(String num) {
       Integer dateRange = Integer.valueOf(num);
-      this.bound = getRelativeDatetime(START_OF_TODAY.date(), END_TIME); // includes all of today
-      this.ref = getRelativeDatetime(START_OF_TODAY.addDays(-(dateRange + 1)).date(), END_TIME);
+      this.bound = getRelativeDatetime(START_OF_TODAY.dateGmt(), END_TIME); // includes all of today
+      this.ref = getRelativeDatetime(START_OF_TODAY.addDays(-(dateRange + 1)).dateGmt(), END_TIME);
     }
   }
 
@@ -431,8 +431,8 @@ public without sharing abstract class RollupDateLiteral {
   private class NDaysAgoLiteral extends RollupDateLiteral {
     protected override void setDynamicValue(String num) {
       Integer dateRange = Integer.valueOf(num);
-      this.ref = getRelativeDatetime(START_OF_TODAY.addDays(-dateRange).date(), START_TIME);
-      this.bound = getRelativeDatetime(this.ref.date(), END_TIME);
+      this.ref = getRelativeDatetime(START_OF_TODAY.addDays(-dateRange).dateGmt(), START_TIME);
+      this.bound = getRelativeDatetime(this.ref.dateGmt(), END_TIME);
     }
   }
 

--- a/rollup/core/classes/RollupDeferredFullRecalcProcessor.cls
+++ b/rollup/core/classes/RollupDeferredFullRecalcProcessor.cls
@@ -25,7 +25,7 @@ public without sharing virtual class RollupDeferredFullRecalcProcessor extends R
       this.logger.log('returning pre-queried records from cache', LoggingLevel.FINE);
       return QUERY_TO_CALC_ITEMS.get(this.queryString);
     }
-    List<SObject> localCalcItems = new RollupRepository(this.accessLevel).get(this.queryString, this.bindVars);
+    List<SObject> localCalcItems = this.preStart().get();
     QUERY_TO_CALC_ITEMS.put(this.queryString, localCalcItems);
     return localCalcItems;
   }

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -16,10 +16,6 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupF
     this.process(this.getDelegatedFullRecalcRollups(this.calcItems));
   }
 
-  protected override String preStart(Set<String> objIds) {
-    return this.queryString;
-  }
-
   protected override Map<String, String> customizeToStringEntries(Map<String, String> props) {
     props = super.customizeToStringEntries(props);
     this.addToMap(props, 'Stateful Previously Reset Parents', this.statefulPreviouslyResetParents);

--- a/rollup/core/classes/RollupFullRecalcProcessor.cls
+++ b/rollup/core/classes/RollupFullRecalcProcessor.cls
@@ -1,7 +1,6 @@
 public abstract without sharing class RollupFullRecalcProcessor extends RollupAsyncProcessor.QueueableProcessor {
   protected final List<Rollup__mdt> rollupMetas;
   protected final Set<String> objIds = new Set<String>();
-  protected final Map<String, Object> bindVars;
   private final RollupFullRecalcProcessor postProcessor;
   private final Map<Id, SObject> parentRecordsToClear = new Map<Id, SObject>();
 
@@ -23,7 +22,6 @@ public abstract without sharing class RollupFullRecalcProcessor extends RollupAs
     this.rollupMetas = rollupMetas;
     this.recordIds = recordIds;
     this.postProcessor = postProcessor;
-    this.bindVars = new Map<String, Object>{ RollupQueryBuilder.BIND_VAR => this.objIds, 'recordIds' => this.recordIds };
     this.processMetadata();
   }
 
@@ -100,6 +98,10 @@ public abstract without sharing class RollupFullRecalcProcessor extends RollupAs
     relatedParentRecords.clear();
     relatedParentRecords.addAll(relatedParentRecordsMap.values());
     this.parentRecordsToClear.clear();
+  }
+
+  protected override RollupRepository preStart() {
+    return new RollupRepository(this.accessLevel).setArg(this.objIds).setArg('recordIds', this.recordIds).setQuery(this.queryString);
   }
 
   protected List<RollupAsyncProcessor> getDelegatedFullRecalcRollups(List<SObject> calcItems) {

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,4 +1,4 @@
-public without sharing virtual class RollupLogger implements ILogger {
+global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
   private static final String CURRENT_VERSION_NUMBER = 'v1.5.54-beta';

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.54-beta';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.54';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 public without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.53';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.54-beta';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupParentResetProcessor.cls
+++ b/rollup/core/classes/RollupParentResetProcessor.cls
@@ -90,13 +90,13 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
 
   private Integer getNumberOfItems() {
     if (this.countOfItems == null) {
-      this.countOfItems = new RollupRepository(this.accessLevel).getCount(this.queryString, this.bindVars);
+      this.countOfItems = this.preStart().getCount();
     }
     return this.countOfItems;
   }
 
   private void runSync() {
-    List<SObject> parentItems = new RollupRepository(this.accessLevel).get(this.queryString, this.bindVars);
+    List<SObject> parentItems = this.preStart().get();
     this.execute(null, parentItems);
     this.finish(null);
   }

--- a/rollup/core/classes/RollupRelationshipFieldFinder.cls
+++ b/rollup/core/classes/RollupRelationshipFieldFinder.cls
@@ -367,15 +367,18 @@ public without sharing class RollupRelationshipFieldFinder {
     }
 
     // NB - we only support one route through polymorphic fields such as Task.WhoId and Task.WhatId for this sort of thing
-    String query = this.appendAdditionalWhereClauses(
-      RollupQueryBuilder.Current.getQuery(baseSObjectType, new List<String>(fieldNames), 'Id', '='),
-      currentRelationshipName,
-      fieldMap
-    );
+    this.repo.setQuery(
+        this.appendAdditionalWhereClauses(
+          RollupQueryBuilder.Current.getQuery(baseSObjectType, new List<String>(fieldNames), 'Id', '='),
+          currentRelationshipName,
+          fieldMap
+        )
+      )
+      .setArg(objIds);
     this.setFirstRunFlags(records);
 
     // recurse through till we get to the top/bottom of the chain
-    return this.getParents(this.repo.get(query, objIds));
+    return this.getParents(this.repo.get());
   }
 
   private String getCurrentRelationshipName(SObjectType baseSObjectType) {
@@ -540,10 +543,12 @@ public without sharing class RollupRelationshipFieldFinder {
         this.trackTraversalIds(otherMatchingParent.Id, (Id) otherMatchingParent.get(this.metadata.UltimateParentLookup__c), null, objIds);
       }
     }
-    List<SObject> otherPotentialParents = this.repo.get(
-      RollupQueryBuilder.Current.getQuery(this.ultimateParent, queryFields, this.metadata.UltimateParentLookup__c, '=', whereClause),
-      objIds
-    );
+    List<SObject> otherPotentialParents = this.repo.setQuery(
+        RollupQueryBuilder.Current.getQuery(this.ultimateParent, queryFields, this.metadata.UltimateParentLookup__c, '=', whereClause)
+      )
+      .setArg(objIds)
+      .get();
+
     if (otherPotentialParents.isEmpty()) {
       this.retrieveAdditionalCalcItems();
     } else {
@@ -612,10 +617,7 @@ public without sharing class RollupRelationshipFieldFinder {
         '\nAND Id != :records'
       );
       try {
-        List<SObject> additionalCalcItems = this.repo.get(
-          query,
-          new Map<String, Object>{ RollupQueryBuilder.BIND_VAR => inclusiveIds, 'records' => this.records }
-        );
+        List<SObject> additionalCalcItems = this.repo.setQuery(query).setArg(inclusiveIds).setArg('records', this.records).get();
         this.records.addAll(additionalCalcItems);
         return additionalCalcItems;
       } catch (Exception ex) {
@@ -665,7 +667,7 @@ public without sharing class RollupRelationshipFieldFinder {
       priorLookup = record.getPopulatedFieldsAsMap().containsKey(priorLookup) ? priorLookup : 'Id';
       objIds.add((Id) record.get(priorLookup));
     }
-    records = this.repo.get(query, objIds);
+    records = this.repo.setQuery(query).setArg(objIds).get();
 
     Map<String, SObjectField> fieldMap = sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).fields.getMap();
     SObjectField field = this.getField(fieldMap, this.currentRelationshipName);

--- a/rollup/core/classes/RollupRelationshipFieldFinder.cls
+++ b/rollup/core/classes/RollupRelationshipFieldFinder.cls
@@ -611,13 +611,19 @@ public without sharing class RollupRelationshipFieldFinder {
       if (childType == this.ultimateParent && this.metadata.RollupToUltimateParent__c == true) {
         queryFields.add(this.metadata.UltimateParentLookup__c);
       }
-      String query = RollupQueryBuilder.Current.getAllRowSafeQuery(
-        childType,
-        RollupQueryBuilder.Current.getQuery(childType, new List<String>(queryFields), relationshipPath, '=', this.metadata.CalcItemWhereClause__c) +
-        '\nAND Id != :records'
-      );
+      String bindVar = 'records';
       try {
-        List<SObject> additionalCalcItems = this.repo.setQuery(query).setArg(inclusiveIds).setArg('records', this.records).get();
+        List<SObject> additionalCalcItems = this.repo.setQuery(
+            RollupQueryBuilder.Current.getAllRowSafeQuery(
+              childType,
+              RollupQueryBuilder.Current.getQuery(childType, new List<String>(queryFields), relationshipPath, '=', this.metadata.CalcItemWhereClause__c)
+            ) +
+            '\nAND Id != :' +
+            bindVar
+          )
+          .setArg(inclusiveIds)
+          .setArg(bindVar, this.records)
+          .get();
         this.records.addAll(additionalCalcItems);
         return additionalCalcItems;
       } catch (Exception ex) {
@@ -652,22 +658,25 @@ public without sharing class RollupRelationshipFieldFinder {
     this.oneToManyParts.remove(junctionObjectName);
     Schema.SObjectType sObjectType = RollupFieldInitializer.Current.getDescribeFromName(junctionObjectName).getSObjectType();
     this.currentRelationshipName = this.getCurrentRelationshipName(sObjectType);
-    String query = RollupQueryBuilder.Current.getQuery(
-      sObjectType,
-      new List<String>{
-        'Id',
-        oneToManyFieldName,
-        this.currentRelationshipName.endsWith('__r') ? this.currentRelationshipName.replace('__r', '__c') : this.currentRelationshipName + 'Id'
-      },
-      oneToManyFieldName,
-      '='
-    );
-    Set<Id> objIds = new Set<Id>();
+    Set<Id> junctionRecordIds = new Set<Id>();
     for (SObject record : records) {
       priorLookup = record.getPopulatedFieldsAsMap().containsKey(priorLookup) ? priorLookup : 'Id';
-      objIds.add((Id) record.get(priorLookup));
+      junctionRecordIds.add((Id) record.get(priorLookup));
     }
-    records = this.repo.setQuery(query).setArg(objIds).get();
+    records = this.repo.setQuery(
+        RollupQueryBuilder.Current.getQuery(
+          sObjectType,
+          new List<String>{
+            'Id',
+            oneToManyFieldName,
+            this.currentRelationshipName.endsWith('__r') ? this.currentRelationshipName.replace('__r', '__c') : this.currentRelationshipName + 'Id'
+          },
+          oneToManyFieldName,
+          '='
+        )
+      )
+      .setArg(junctionRecordIds)
+      .get();
 
     Map<String, SObjectField> fieldMap = sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).fields.getMap();
     SObjectField field = this.getField(fieldMap, this.currentRelationshipName);

--- a/rollup/core/classes/RollupRepository.cls
+++ b/rollup/core/classes/RollupRepository.cls
@@ -1,35 +1,52 @@
 public without sharing class RollupRepository {
   public static final Integer SENTINEL_COUNT_VALUE = -1;
 
+  private final Args args = new Args();
   private final System.AccessLevel accessLevel;
+
+  private class Args {
+    public final Map<String, Object> bindVars = new Map<String, Object>();
+    public String query;
+  }
 
   public RollupRepository(System.AccessLevel accessLevel) {
     this.accessLevel = accessLevel;
   }
 
-  public List<SObject> get(String queryString, Object objIds) {
-    return this.get(queryString, new Map<String, Object>{ RollupQueryBuilder.BIND_VAR => objIds });
+  public RollupRepository setQuery(String query) {
+    this.args.query = query;
+    return this;
   }
 
-  public List<SObject> get(String queryString, Map<String, Object> queryBinds) {
-    return this.query(queryString, queryBinds);
+  public RollupRepository setArg(Object value) {
+    this.args.bindVars.put(RollupQueryBuilder.BIND_VAR, value);
+    return this;
   }
 
-  public Integer getCount(String queryString, Object objIds) {
-    return this.getCount(queryString, new Map<String, Object>{ RollupQueryBuilder.BIND_VAR => objIds });
+  public RollupRepository setArg(String key, Object value) {
+    this.args.bindVars.put(key, value);
+    return this;
   }
 
-  public Integer getCount(String queryString, Map<String, Object> queryBinds) {
-    if (queryString.contains(RollupQueryBuilder.ALL_ROWS)) {
-      queryString = queryString.replace(RollupQueryBuilder.ALL_ROWS, '');
+  public Database.QueryLocator getLocator() {
+    return Database.getQueryLocatorWithBinds(this.args.query, this.args.bindVars, this.accessLevel);
+  }
+
+  public List<SObject> get() {
+    return Database.queryWithBinds(this.args.query, this.args.bindVars, this.accessLevel);
+  }
+
+  public Integer getCount() {
+    if (this.args.query.contains(RollupQueryBuilder.ALL_ROWS)) {
+      this.args.query = this.args.query.replace(RollupQueryBuilder.ALL_ROWS, '');
     }
-    queryString = queryString.replaceFirst('SELECT.+\n', 'SELECT Count()\n');
+    this.args.query = this.args.query.replaceFirst('SELECT.+\n', 'SELECT Count()\n');
 
     Integer countAmount;
     try {
-      countAmount = Database.countQueryWithBinds(queryString, queryBinds, this.accessLevel);
+      countAmount = Database.countQueryWithBinds(this.args.query, this.args.bindVars, this.accessLevel);
     } catch (Exception ex) {
-      RollupLogger.Instance.log('an error occurred while trying to get count query:\n' + queryString, ex, LoggingLevel.WARN);
+      RollupLogger.Instance.log('an error occurred while trying to get count query:\n' + this.args.query, ex, LoggingLevel.WARN);
       // not all count queries are valid, particularly those with polymorphic fields referencing parent fields
       // return a sentinel value instead, to be checked for downstream
       countAmount = SENTINEL_COUNT_VALUE;
@@ -37,7 +54,7 @@ public without sharing class RollupRepository {
     return countAmount;
   }
 
-  private List<SObject> query(String queryString, Map<String, Object> queryBinds) {
-    return Database.queryWithBinds(queryString, queryBinds, this.accessLevel);
+  public override String toString() {
+    return this.args.query + '\n' + 'with bind var keys: ' + this.args.bindVars.keySet();
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Quality of life updates as far as how rollup queries are performed",
+            "versionName": "Quality of life updates as far as how rollup queries are performed, updated RollupLogger to global visibility",
             "versionNumber": "1.5.54.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -102,6 +102,7 @@
         "apex-rollup@1.5.50-0": "04t6g000008fjeGAAQ",
         "apex-rollup@1.5.51-0": "04t6g000008fjepAAA",
         "apex-rollup@1.5.52-0": "04t6g000008fjfYAAQ",
-        "apex-rollup@1.5.53-0": "04t6g000008fjg2AAA"
+        "apex-rollup@1.5.53-0": "04t6g000008fjg2AAA",
+        "apex-rollup@1.5.54-0": "04t6g000008fjhPAAQ"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Add extra type safety when multiple children types are being rolled up to the same grandparent",
-            "versionNumber": "1.5.53.0",
+            "versionName": "Quality of life updates as far as how rollup queries are performed",
+            "versionNumber": "1.5.54.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
* Refactored `RollupRepository` allowing for less coupling between query bind variables and query locators (batch start) to run in user mode
* Promoted `RollupLogger` to global so that it can be overridden for consumers of the namespaced package
* Decorated logging messages in `RollupAsyncProcessor` which may help address an issue raised in #414 if it's not fixed by ...
* Tweaked `RollupAsyncProcessor.getAsyncRollup()` method to disallow fast-tracking full batch rollups if they're trying to restart from within a batch context (which would otherwise throw)
* Classic date literal updates to prevent cross-DST issues