### PR TITLE
v1.5.55 - CPU time optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjhZAAQ">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjihAAA">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjhZAAQ">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjihAAA">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.54",
+  "version": "1.5.55",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -74,7 +74,7 @@ global without sharing virtual class Rollup {
   }
 
   @TestVisible
-  private static final List<Rollup> CACHED_ROLLUPS {
+  private static List<Rollup> CACHED_ROLLUPS {
     get {
       if (CACHED_ROLLUPS == null) {
         CACHED_ROLLUPS = new List<Rollup>();
@@ -251,7 +251,7 @@ global without sharing virtual class Rollup {
   }
 
   public class CalcItemBag {
-    private final Map<String, SObject> idToCalcItem = new Map<String, SObject>();
+    private Map<String, SObject> idToCalcItem = new Map<String, SObject>();
     private Boolean hasBeenCleared = false;
     public Boolean hasQueriedForAdditionalItems = false;
     public CalcItemBag(List<SObject> calcItems) {
@@ -270,7 +270,7 @@ global without sharing virtual class Rollup {
 
     public void clear() {
       if (this.hasBeenCleared == false) {
-        this.idToCalcItem.clear();
+        this.idToCalcItem = new Map<String, SObject>();
         this.hasBeenCleared = true;
       }
     }
@@ -1628,7 +1628,7 @@ global without sharing virtual class Rollup {
   global static Rollup runFromApex(List<Rollup__mdt> localMetas, Evaluator eval, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
     Rollup rollupConductor = RollupAsyncProcessor.getConductor(InvocationPoint.FROM_APEX, calcItems, oldCalcItems);
     if (shouldRunFromTrigger() == false || localMetas.isEmpty()) {
-      rollupConductor.calcItems?.clear();
+      rollupConductor.calcItems = new List<SObject>();
       return rollupConductor;
     }
 
@@ -1728,7 +1728,7 @@ global without sharing virtual class Rollup {
   public static void processStoredFlowRollups() {
     flatten(CACHED_ROLLUPS);
     List<Rollup> rollupsToProcess = new List<Rollup>(CACHED_ROLLUPS);
-    CACHED_ROLLUPS.clear();
+    CACHED_ROLLUPS = null;
     batch(rollupsToProcess, InvocationPoint.FROM_INVOCABLE);
   }
 
@@ -2222,6 +2222,7 @@ global without sharing virtual class Rollup {
       Integer currentCount = new RollupRepository(RollupMetaPicklists.getAccessLevel(meta))
         .setQuery(RollupQueryBuilder.Current.getQuery(childType, new List<String>(), meta.LookupFieldOnLookupObject__c, '!=', whereClause))
         .setArg(new Set<String>())
+        .setArg('recordIds', metaWrapper.recordIds)
         .getCount();
       metaWrapper.recordCount = currentCount == RollupRepository.SENTINEL_COUNT_VALUE ? currentCount : metaWrapper.recordCount + currentCount;
     }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -664,6 +664,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     if (this.isTimingOut) {
       this.getDML().forceSyncUpdate();
     }
+    RollupEvaluator.clearConditionCache();
     this.getDML().doUpdate(updatedLookupRecords.values());
     this.populateOtherDeferredRollups();
     this.processDeferredRollups();
@@ -745,9 +746,9 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   private Boolean isValidAdditionalCalcItemRetrieval(RollupAsyncProcessor roll) {
-    if (this.fullRecalcProcessor != null) {
+    if (roll.fullRecalcProcessor != null) {
       // if we aren't batching, safe to assume a full recalc has already pulled the rest of the records back
-      return this.fullRecalcProcessor.isBatch() != true;
+      return roll.fullRecalcProcessor.isBatch() != true;
     } else {
       return roll.isFullRecalc || roll.metadata.IsFullRecordSet__c == true;
     }

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -290,9 +290,8 @@ public without sharing abstract class RollupCalculator {
   }
 
   protected List<SObject> winnowItems(List<SObject> items, Map<Id, SObject> oldCalcItems) {
-    List<SObject> temporaryItems = new List<SObject>(items);
-    items.clear(); // the List may not be strongly typed, but this is a good way to keep it typed if it is
-    this.transformForMultiCurrencyOrgs(temporaryItems);
+    List<SObject> temporaryItems = new List<SObject>();
+    this.transformForMultiCurrencyOrgs(items);
     if (oldCalcItems.isEmpty() == false && this.isMultiCurrencyRollup) {
       List<SObject> tempOldCalcItems = oldCalcItems.values();
       this.transformForMultiCurrencyOrgs(tempOldCalcItems);
@@ -300,7 +299,7 @@ public without sharing abstract class RollupCalculator {
         oldCalcItems.put(oldCalcItem.Id, this.getTransformedCalcItem(oldCalcItem));
       }
     }
-    for (SObject item : temporaryItems) {
+    for (SObject item : items) {
       Boolean currentItemMatches = this.eval?.matches(item) != false;
       if (currentItemMatches == false) {
         switch on this.op {
@@ -314,7 +313,7 @@ public without sharing abstract class RollupCalculator {
         }
       }
       if (currentItemMatches) {
-        items.add(this.getTransformedCalcItem(item));
+        temporaryItems.add(this.getTransformedCalcItem(item));
         if (this.op == Rollup.Op.SOME) {
           break;
         }
@@ -324,12 +323,12 @@ public without sharing abstract class RollupCalculator {
       ? new List<RollupOrderBy__mdt>{ new RollupOrderBy__mdt(FieldName__c = 'Id', Ranking__c = 0) }
       : this.metadata.RollupOrderBys__r;
     if (orderBys.isEmpty() == false) {
-      new RollupCalcItemSorter(orderBys).sort(items);
+      new RollupCalcItemSorter(orderBys).sort(temporaryItems);
     }
     if (this.metadata?.LimitAmount__c != null) {
       // we can only safely remove the items after sorting
-      while (items.size() > this.metadata.LimitAmount__c && items.isEmpty() == false) {
-        items.remove(items.size() - 1);
+      while (temporaryItems.size() > this.metadata.LimitAmount__c && temporaryItems.isEmpty() == false) {
+        temporaryItems.remove(items.size() - 1);
       }
       // Limit-based rollups always reset the field's value, and always act as a fresh start
       if (this.metadata.RollupOperation__c.contains('DELETE_') || this.metadata.RollupOperation__c.contains('UPDATE_')) {
@@ -337,7 +336,7 @@ public without sharing abstract class RollupCalculator {
       }
     }
 
-    return items;
+    return temporaryItems;
   }
 
   protected virtual Object calculateNewAggregateValue(Rollup.Op op, List<Object> objIds, SObjectType sObjectType) {
@@ -408,7 +407,7 @@ public without sharing abstract class RollupCalculator {
   }
 
   private without sharing class CountDistinctRollupCalculator extends RollupCalculator {
-    private final Set<Object> distinctValues = new Set<Object>();
+    private Set<Object> distinctValues = new Set<Object>();
     private Boolean isIdCount;
     public CountDistinctRollupCalculator(
       Rollup.Op op,
@@ -422,7 +421,7 @@ public without sharing abstract class RollupCalculator {
 
     public override void setDefaultValues(String lookupRecordKey, Object priorVal) {
       super.setDefaultValues(lookupRecordKey, priorVal);
-      this.distinctValues.clear();
+      this.distinctValues = new Set<Object>();
       this.isIdCount = this.opFieldOnCalcItem.getDescribe().getName() == 'Id';
       Object defaultVal = RollupFieldInitializer.Current.getDefaultValue(opFieldOnLookupObject);
       if (defaultVal != 0 && this.returnVal != defaultVal && this.isIdCount == false) {
@@ -446,7 +445,7 @@ public without sharing abstract class RollupCalculator {
       if (this.op != Rollup.Op.DELETE_COUNT_DISTINCT && potentiallyNullValue != null) {
         this.distinctValues.add(potentiallyNullValue);
       } else if (this.op == Rollup.Op.DELETE_COUNT_DISTINCT) {
-        this.distinctValues.clear();
+        this.distinctValues = new Set<Object>();
         this.calculateNewAggregateValue(this.op, new List<Id>{ calcItem.Id }, calcItem.getSObjectType());
       }
       this.shouldShortCircuit = true;
@@ -459,7 +458,7 @@ public without sharing abstract class RollupCalculator {
 
     protected override Object calculateNewAggregateValue(Rollup.Op op, List<Object> objIds, SObjectType sObjectType) {
       if (this.shouldTriggerFullRecalc == true) {
-        this.distinctValues.clear();
+        this.distinctValues = new Set<Object>();
       }
       Boolean isArchivable = sObjectType == Task.SObjectType || sObjectType == Event.SObjectType;
       Boolean isGroupable = isArchivable == false && this.opFieldOnCalcItem.getDescribe().isGroupable();
@@ -1196,7 +1195,7 @@ public without sharing abstract class RollupCalculator {
   }
 
   private without sharing class MostRollupCalculator extends RollupCalculator {
-    private final Map<Object, Integer> occurrenceToCount = new Map<Object, Integer>();
+    private Map<Object, Integer> occurrenceToCount = new Map<Object, Integer>();
     private Integer largestCountPointer;
     public MostRollupCalculator(
       Rollup.Op op,
@@ -1209,7 +1208,7 @@ public without sharing abstract class RollupCalculator {
     }
 
     public override void performRollup(List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
-      this.occurrenceToCount.clear();
+      this.occurrenceToCount = new Map<Object, Integer>();
       this.largestCountPointer = -1;
       this.returnVal = this.defaultVal;
       List<SObject> localCalcItems = this.winnowItems(calcItems, oldCalcItems);

--- a/rollup/core/classes/RollupCurrencyInfo.cls
+++ b/rollup/core/classes/RollupCurrencyInfo.cls
@@ -19,6 +19,8 @@ public without sharing virtual class RollupCurrencyInfo {
     'OpportunitySplit' => new List<String>{ 'OpportunityId', 'CloseDate' } // yikes
   };
 
+  private static final Map<String, RollupCurrencyInfo> CURRENCY_ISO_CODE_TO_CURRENCY = getCurrencyMap();
+
   @TestVisible
   private static Boolean IS_MULTICURRENCY {
     get {
@@ -49,16 +51,6 @@ public without sharing virtual class RollupCurrencyInfo {
         FALLBACK_INFO.ConversionRate = 1;
       }
       return FALLBACK_INFO;
-    }
-    set;
-  }
-
-  private static final Map<String, RollupCurrencyInfo> CURRENCY_ISO_CODE_TO_CURRENCY {
-    get {
-      if (CURRENCY_ISO_CODE_TO_CURRENCY == null) {
-        CURRENCY_ISO_CODE_TO_CURRENCY = getCurrencyMap();
-      }
-      return CURRENCY_ISO_CODE_TO_CURRENCY;
     }
     set;
   }

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -8,6 +8,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
   static String stubRequestId;
 
   private static final Map<String, WhereFieldEvaluator> CACHED_WHERE_EVALS = new Map<String, WhereFieldEvaluator>();
+  private static Map<String, Boolean> CACHED_WHERE_DECISIONS = new Map<String, Boolean>();
 
   // totally not obvious ranking going on here - it's absolutely imperative that
   // the two-word conditions go first; otherwise replacing will fail on the whole string
@@ -70,6 +71,10 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
     }
 
     return getCombinedEvals(evals);
+  }
+
+  public static void clearConditionCache() {
+    CACHED_WHERE_DECISIONS = new Map<String, Boolean>();
   }
 
   private static Rollup.Evaluator getCombinedEvals(List<Rollup.Evaluator> evals) {
@@ -599,6 +604,11 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
 
     @SuppressWarnings('PMD.OverrideBothEqualsAndHashCode, PMD.EmptyCatchBlock')
     public Boolean equals(Object o) {
+      String decisionKey = this.fieldName + this.criteria + this.originalValues + o.hashCode();
+      if (CACHED_WHERE_DECISIONS.containsKey(decisionKey)) {
+        return CACHED_WHERE_DECISIONS.get(decisionKey);
+      }
+
       SObject item = (SObject) o;
       Boolean isEqual = true;
       Boolean hasOnlyOneValue = this.originalValues.size() == 1;
@@ -609,79 +619,82 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       String storedValue = originalValue == null ? (String) originalValue : String.valueOf(originalValue);
 
       if (hasOnlyOneValue && isDateFunction) {
-        return RollupDateLiteral.getFunction(this.fieldName, this.originalValues[0]).matches(originalValue, this.criteria);
+        isEqual = RollupDateLiteral.getFunction(this.fieldName, this.originalValues[0]).matches(originalValue, this.criteria);
       } else if (hasOnlyOneValue && RollupDateLiteral.isDateLiteral(this.originalValues[0])) {
-        return RollupDateLiteral.get(this.originalValues[0]).matches(originalValue, this.criteria);
-      } else if (originalValue instanceof Decimal) {
-        for (Integer index = 0; index < this.values.size(); index++) {
-          Object val = this.values[index];
-          try {
-            String stringVal = String.valueOf(val);
-            Decimal decimalVal = Decimal.valueOf(stringVal);
-            if (decimalVal == originalValue) {
-              originalValue = decimalVal;
-              storedValue = stringVal;
-              break;
+        isEqual = RollupDateLiteral.get(this.originalValues[0]).matches(originalValue, this.criteria);
+      } else {
+        if (originalValue instanceof Decimal) {
+          for (Integer index = 0; index < this.values.size(); index++) {
+            Object val = this.values[index];
+            try {
+              String stringVal = String.valueOf(val);
+              Decimal decimalVal = Decimal.valueOf(stringVal);
+              if (decimalVal == originalValue) {
+                originalValue = decimalVal;
+                storedValue = stringVal;
+                break;
+              }
+            } catch (Exception ex) {
+              // do nothing
             }
-          } catch (Exception ex) {
-            // do nothing
           }
         }
-      }
 
-      switch on this.criteria {
-        when '=', '!=', '<>' {
-          if (this.hasValues == false) {
-            isEqual = String.isBlank(storedValue);
-          } else {
-            for (String value : this.values) {
-              isEqual = value?.equalsIgnoreCase(storedValue) == true || value == null && storedValue == null;
-              if (isEqual) {
-                break;
+        switch on this.criteria {
+          when '=', '!=', '<>' {
+            if (this.hasValues == false) {
+              isEqual = String.isBlank(storedValue);
+            } else {
+              for (String value : this.values) {
+                isEqual = value?.equalsIgnoreCase(storedValue) == true || value == null && storedValue == null;
+                if (isEqual) {
+                  break;
+                }
               }
             }
+            isEqual = this.criteria == '=' ? isEqual : !isEqual;
           }
-          isEqual = this.criteria == '=' ? isEqual : !isEqual;
-        }
-        when 'like', '!like' {
-          // like/not like have to be handled separately because it's the storedValue
-          // that gets tested against, not the other way around
-          isEqual = false;
-          if (storedValue != null) {
-            for (String val : this.values) {
-              isEqual = storedValue.containsIgnoreCase(val);
-              if (isEqual) {
-                break;
-              }
-            }
-            isEqual = this.criteria == 'like' ? isEqual : isEqual == false;
-          }
-        }
-        // then there's this whole paradigm; it really shouldn't be possible to have multiple values for either
-        // greater than / less than routes, but we test for it first just to be triple-sure
-        when '>', '>=', '<', '<=' {
-          if (this.values.size() != 1) {
-            throw new IllegalArgumentException('Comparison not valid with multiple arguments: ' + JSON.serialize(this.values));
-          } else if (storedValue == null) {
+          when 'like', '!like' {
+            // like/not like have to be handled separately because it's the storedValue
+            // that gets tested against, not the other way around
             isEqual = false;
-          } else {
-            isEqual = this.getGreaterOrLessThan(this.values[0], originalValue);
-          }
-        }
-        when 'includes', '!includes' {
-          isEqual = false;
-          for (String value : this.values) {
-            List<String> splitValues = value.split(';');
-            for (String splitValue : splitValues) {
-              isEqual = storedValue.contains(splitValue);
-              if (isEqual == false) {
-                break;
+            if (storedValue != null) {
+              for (String val : this.values) {
+                isEqual = storedValue.containsIgnoreCase(val);
+                if (isEqual) {
+                  break;
+                }
               }
+              isEqual = this.criteria == 'like' ? isEqual : isEqual == false;
             }
           }
-          isEqual = this.criteria == 'includes' ? isEqual : isEqual == false;
+          // then there's this whole paradigm; it really shouldn't be possible to have multiple values for either
+          // greater than / less than routes, but we test for it first just to be triple-sure
+          when '>', '>=', '<', '<=' {
+            if (this.values.size() != 1) {
+              throw new IllegalArgumentException('Comparison not valid with multiple arguments: ' + JSON.serialize(this.values));
+            } else if (storedValue == null) {
+              isEqual = false;
+            } else {
+              isEqual = this.getGreaterOrLessThan(this.values[0], originalValue);
+            }
+          }
+          when 'includes', '!includes' {
+            isEqual = false;
+            for (String value : this.values) {
+              List<String> splitValues = value.split(';');
+              for (String splitValue : splitValues) {
+                isEqual = storedValue.contains(splitValue);
+                if (isEqual == false) {
+                  break;
+                }
+              }
+            }
+            isEqual = this.criteria == 'includes' ? isEqual : isEqual == false;
+          }
         }
       }
+      CACHED_WHERE_DECISIONS.put(decisionKey, isEqual);
       return isEqual;
     }
 

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.54';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.55';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Quality of life updates as far as how rollup queries are performed, updated RollupLogger to global visibility",
-            "versionNumber": "1.5.54.0",
+            "versionName": "Optimizations to reduce CPU time",
+            "versionNumber": "1.5.55.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -103,6 +103,7 @@
         "apex-rollup@1.5.51-0": "04t6g000008fjepAAA",
         "apex-rollup@1.5.52-0": "04t6g000008fjfYAAQ",
         "apex-rollup@1.5.53-0": "04t6g000008fjg2AAA",
-        "apex-rollup@1.5.54-0": "04t6g000008fjhZAAQ"
+        "apex-rollup@1.5.54-0": "04t6g000008fjhZAAQ",
+        "apex-rollup@1.5.55-0": "04t6g000008fjihAAA"
     }
 }


### PR DESCRIPTION
* Pushing pressure on some long-running operations from CPU-intensive to GC-intensive which should help with larger rollup runs. Using a sample set of 14 rollups with 4000 records (twice the theoretical max that could be done in a batch full recalc with chunk size of 2000), the rollup evaluator where clause cache ended up taking up nearly 1 MB of heap size. For smaller operations (6 rollups on 400 records), that same cached map took up 41 KB instead. We'll call this a heap size experiment and adjust/remove the functionality if it isn't helping larger rollup operations