### PR TITLE
v1.5.56 - ACM bugfix, further optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjiwAAA">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjnnAAA">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjiwAAA">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjnnAAA">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -4,5 +4,10 @@
   "country": "US",
   "language": "en_US",
   "features": ["MultiCurrency"],
-  "hasSampleData": true
+  "hasSampleData": true,
+  "settings": {
+    "deploymentSettings": {
+      "doesSkipAsyncApexValidation": true
+    }
+  }
 }

--- a/extra-tests/classes/RollupCalculatorTests.cls
+++ b/extra-tests/classes/RollupCalculatorTests.cls
@@ -1209,6 +1209,21 @@ private class RollupCalculatorTests {
   // MIN / MAX
 
   @IsTest
+  static void supportsMaxFromPicklists() {
+    RollupCalculator calc = getCalculator(
+      '',
+      Rollup.Op.MAX,
+      ContactPointAddress.Name,
+      Account.Industry,
+      new Rollup__mdt(),
+      RollupTestUtils.createId(Account.SObjectType),
+      Account.Id
+    );
+
+    Assert.isNotNull(calc);
+  }
+
+  @IsTest
   static void shouldDefaultToNullIfCurrentItemExcludedAndNoOtherMatchingItemsTime() {
     Time max = Time.newInstance(11, 11, 11, 11);
     Rollup__mdt metadata = new Rollup__mdt(CalcItem__c = 'ContactPointAddress', CalcItemWhereClause__c = 'BestTimeToContactEndTime != ' + String.valueOf(max));

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -1244,6 +1244,53 @@ private class RollupTests {
   }
 
   @IsTest
+  static void shouldRemoveTextOnConcatDistinctDelete() {
+    Account acc = [SELECT Id, Name, Description FROM Account];
+    String originalAccountName = acc.Name;
+    String somethingElse = 'Something else';
+    acc.Name = acc.Name + ', ' + somethingElse;
+    RollupAsyncProcessor.stubParentRecords = new List<SObject>{ acc };
+
+    ContactPointAddress originalName = new ContactPointAddress(Name = originalAccountName, ParentId = acc.Id, PreferenceRank = 0);
+    ContactPointAddress somethingElseName = new ContactPointAddress(Name = somethingElse, ParentId = acc.Id, PreferenceRank = 1);
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{ originalName, somethingElseName };
+    insert cpas;
+
+    RollupTestUtils.DMLMock mock = RollupTestUtils.loadMock(new List<ContactPointAddress>{ somethingElseName });
+    Rollup.oldRecordsMap = new Map<Id, SObject>{ somethingElseName.Id => somethingElseName };
+    Rollup.apexContext = TriggerOperation.BEFORE_DELETE;
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        RollupFieldOnCalcItem__c = 'Name',
+        LookupObject__c = 'Account',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'Name',
+        RollupOperation__c = 'CONCAT_DISTINCT'
+      ),
+      new Rollup__mdt(
+        CalcItem__c = 'ContactPointAddress',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        RollupFieldOnCalcItem__c = 'Name',
+        LookupObject__c = 'Account',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'Description',
+        RollupOperation__c = 'CONCAT_DISTINCT',
+        CalcItemWhereClause__c = 'Parent.Type = \'Account\'',
+        GrandparentRelationshipFieldPath__c = 'Parent.Description'
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    System.assertEquals(1, mock.Records.size(), 'Account should be updated CONCAT_DISTINCT delete');
+    System.assertEquals(originalAccountName, acc.Name);
+  }
+
+  @IsTest
   static void shouldMaxOnStringsOnInsert() {
     List<ContactPointAddress> testCpas = new List<ContactPointAddress>{ new ContactPointAddress(Name = 'A'), new ContactPointAddress(Name = 'Z') };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.55",
+  "version": "1.5.56",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjj1AAA">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjnsAAA">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjj1AAA">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjnsAAA">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Optimizations to reduce CPU time",
-            "versionNumber": "1.0.28.0",
+            "versionName": "ACM correctly includes all query fields for full recalcs, further optimizations",
+            "versionNumber": "1.0.29.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -49,6 +49,7 @@
         "apex-rollup-namespaced@1.0.25-0": "04t6g000008fjfdAAA",
         "apex-rollup-namespaced@1.0.26-0": "04t6g000008fjg7AAA",
         "apex-rollup-namespaced@1.0.27-0": "04t6g000008fjheAAA",
-        "apex-rollup-namespaced@1.0.28-0": "04t6g000008fjj1AAA"
+        "apex-rollup-namespaced@1.0.28-0": "04t6g000008fjj1AAA",
+        "apex-rollup-namespaced@1.0.29-0": "04t6g000008fjnsAAA"
     }
 }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1816,6 +1816,8 @@ global without sharing virtual class Rollup {
     RollupLimits.Tester limitTester = new RollupLimits.Tester(control, isContextAsync());
     Boolean hasExceededLimits = limitTester.hasExceededLimits && isDeferralAllowed;
     if (hasExceededLimits) {
+      control.IsRollupLoggingEnabled__c = true;
+      RollupLogger.Instance.updateRollupControl(control);
       RollupLogger.Instance.log('exceeded limits:', limitTester, LoggingLevel.WARN);
     }
     return hasExceededLimits;
@@ -2068,7 +2070,7 @@ global without sharing virtual class Rollup {
       SObjectType calcItemType = calcItems[0].getSObjectType();
       RollupEvaluator.WhereFieldEvaluator eval = RollupEvaluator.getWhereEval(meta.CalcItemWhereClause__c, calcItemType);
       Boolean matches = false;
-      FilterResults filter = filter(calcItems, oldCalcItems, eval, meta, calcItemType, CALC_ITEM_REPLACER);
+      FilterResults filter = filter(calcItems, oldCalcItems, eval, meta, calcItemType, matches);
       for (SObject calcItem : calcItems) {
         matches = matches || filter.matchingItemIds.contains(calcItem.Id);
         if (matches) {
@@ -2632,6 +2634,9 @@ global without sharing virtual class Rollup {
     if (sObjectType == null) {
       sObjectType = calcItems[0].getSObjectType();
     }
+
+    Boolean shouldFilterCalcItems = CALC_ITEM_REPLACER.hasProcessedMetadata(rollupOperations, calcItems);
+
     /**
      * We have rollup operations to perform. That's great!
      * Let's get ready to rollup!
@@ -2670,7 +2675,7 @@ global without sharing virtual class Rollup {
         rollupConductor.rollupControl.IsRollupLoggingEnabled__c = localControl.IsRollupLoggingEnabled__c;
       }
 
-      FilterResults filterResults = filter(calcItems, oldCalcItems, eval, rollupMetadata, sObjectType, rollupConductor.calcItemReplacer);
+      FilterResults filterResults = filter(calcItems, oldCalcItems, eval, rollupMetadata, sObjectType, shouldFilterCalcItems);
 
       loadRollups(
         rollupFieldOnCalcItem,
@@ -2961,7 +2966,7 @@ global without sharing virtual class Rollup {
     Evaluator eval,
     Rollup__mdt metadata,
     SObjectType calcItemType,
-    RollupCalcItemReplacer calcItemReplacer
+    Boolean shouldFilterCalcItems
   ) {
     FilterResults results = new FilterResults();
     results.eval = RollupEvaluator.getEvaluator(eval, metadata, oldCalcItems, calcItemType);
@@ -2970,7 +2975,7 @@ global without sharing virtual class Rollup {
     // mean inadvertently filtering the items for other rollups on the same child SObject type. Instead, we track the matching Ids
     // to avoid unintended side-effects
     for (SObject item : calcItems) {
-      if (results.eval.matches(item) || calcItemReplacer.hasProcessedMetadata(new List<Rollup__mdt>{ metadata }, calcItems) == false) {
+      if (results.eval.matches(item) || shouldFilterCalcItems == false) {
         results.matchingItemIds.add(item.Id);
       } else if (oldCalcItems?.containsKey(item.Id) == true && results.eval.matches(oldCalcItems.get(item.Id))) {
         // if the where clause would exclude something, but we're in an update

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -821,7 +821,7 @@ global without sharing virtual class Rollup {
   global static Id schedule(String jobName, String cronExp, String query, String rollupObjectName, Evaluator eval) {
     List<SObject> localCalcItems;
     try {
-      localCalcItems = Database.query(query);
+      localCalcItems = new RollupRepository(System.AccessLevel.SYSTEM_MODE).setQuery(query).get();
     } catch (QueryException ex) {
       throw new QueryException('There\'s a problem with your query: ' + ex.getMessage() + '\n' + ex.getStackTraceString());
     }
@@ -2560,7 +2560,7 @@ global without sharing virtual class Rollup {
   }
 
   private static List<Rollup__mdt> getRollupMetadataBySObject(SObjectType sObjectType) {
-    String sObjectName = sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getName();
+    String sObjectName = '' + sObjectType;
     List<Rollup__mdt> rollupMetadatas = getMetadataFromCache(Rollup__mdt.SObjectType);
     for (Integer index = rollupMetadatas.size() - 1; index >= 0; index--) {
       Rollup__mdt meta = rollupMetadatas[index];
@@ -2975,7 +2975,7 @@ global without sharing virtual class Rollup {
     // mean inadvertently filtering the items for other rollups on the same child SObject type. Instead, we track the matching Ids
     // to avoid unintended side-effects
     for (SObject item : calcItems) {
-      if (results.eval.matches(item) || shouldFilterCalcItems == false) {
+      if (shouldFilterCalcItems == false || results.eval.matches(item)) {
         results.matchingItemIds.add(item.Id);
       } else if (oldCalcItems?.containsKey(item.Id) == true && results.eval.matches(oldCalcItems.get(item.Id))) {
         // if the where clause would exclude something, but we're in an update

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -973,38 +973,42 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       } else {
         this.calcObjectToUniqueFieldNames.put(roll.calcItemType, whereFields);
       }
-      if (this.calcItemReplacer?.hasProcessedMetadata(combinedMeta, roll.calcItems) == false) {
-        Integer oldHashCode = roll.calcItems?.hashCode();
-        roll.calcItems = this.calcItemReplacer.replace(roll.calcItems, combinedMeta);
-        this.replaceCalcItems(oldHashCode, roll.calcItems, roll, CollectionType.ITERABLE);
-      }
-      if (this.calcItemReplacer?.hasProcessedMetadata(combinedMeta, roll.oldCalcItems?.values()) == false) {
-        Integer oldHashCode = roll.oldCalcItems?.hashCode();
-        Map<Id, SObject> oldCalcItemsWithUpdatedFields = new Map<Id, SObject>();
-        for (SObject oldCalcItem : this.calcItemReplacer.replace(roll.oldCalcItems?.values(), combinedMeta)) {
-          oldCalcItemsWithUpdatedFields.put(oldCalcItem.Id, oldCalcItem);
-        }
-        roll.oldCalcItems = oldCalcItemsWithUpdatedFields;
-        this.replaceCalcItems(oldHashCode, roll.oldCalcItems, roll, CollectionType.DICTIONARY);
-      }
       if (this.fullRecalcProcessor != null) {
         this.fullRecalcProcessor.calcObjectToUniqueFieldNames = this.calcObjectToUniqueFieldNames;
         this.fullRecalcProcessor.lookupObjectToUniqueFieldNames = this.lookupObjectToUniqueFieldNames;
       }
     }
+
+    if (this.calcItems != null && this.calcItemReplacer?.hasProcessedMetadata(combinedMeta, this.calcItems) == false) {
+      Integer oldHashCode = this.calcItems?.hashCode();
+      this.calcItems = this.calcItemReplacer.replace(this.calcItems, combinedMeta);
+      this.replaceCalcItems(oldHashCode, this.calcItems, rollups, CollectionType.ITERABLE);
+    }
+    if (this.oldCalcItems != null && this.calcItemReplacer?.hasProcessedMetadata(combinedMeta, this.oldCalcItems.values()) == false) {
+      Integer oldHashCode = this.oldCalcItems?.hashCode();
+      Map<Id, SObject> oldCalcItemsWithUpdatedFields = new Map<Id, SObject>();
+      for (SObject oldCalcItem : this.calcItemReplacer.replace(this.oldCalcItems.values(), combinedMeta)) {
+        oldCalcItemsWithUpdatedFields.put(oldCalcItem.Id, oldCalcItem);
+      }
+      this.oldCalcItems = oldCalcItemsWithUpdatedFields;
+      this.replaceCalcItems(oldHashCode, this.oldCalcItems, rollups, CollectionType.DICTIONARY);
+    }
   }
 
-  private void replaceCalcItems(Integer oldHashCode, Object updatedRecords, Rollup innerRollup, CollectionType collectionType) {
+  private void replaceCalcItems(Integer oldHashCode, Object updatedRecords, List<Rollup> innerRollups, CollectionType type) {
     // this unfortunate statement wouldn't be nearly so bad if the collections were passed by reference - but they're not,
     // they're passed by value, which means the reassignments below would not cascade back up to the innerRollup's
     // calcItems / oldCalcItems properties without explicitly being re-set.
-    if (innerRollup.calcItems?.hashCode() == oldHashCode) {
-      switch on collectionType {
-        when ITERABLE {
-          innerRollup.calcItems = (List<SObject>) updatedRecords;
-        }
-        when DICTIONARY {
-          innerRollup.oldCalcItems = (Map<Id, SObject>) updatedRecords;
+    for (Rollup innerRollup : innerRollups) {
+      Boolean isMatch = (type == CollectionType.ITERABLE ? innerRollup.calcItems?.hashCode() : innerRollup.oldCalcItems?.hashCode()) == oldHashCode;
+      if (isMatch) {
+        switch on type {
+          when ITERABLE {
+            innerRollup.calcItems = (List<SObject>) updatedRecords;
+          }
+          when DICTIONARY {
+            innerRollup.oldCalcItems = (Map<Id, SObject>) updatedRecords;
+          }
         }
       }
     }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -80,6 +80,16 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     set;
   }
 
+  private static Map<Integer, Map<String, CalcItemBag>> CACHED_CALC_ITEM_LOOKUPS {
+    get {
+      if (CACHED_CALC_ITEM_LOOKUPS == null) {
+        CACHED_CALC_ITEM_LOOKUPS = new Map<Integer, Map<String, CalcItemBag>>();
+      }
+      return CACHED_CALC_ITEM_LOOKUPS;
+    }
+    set;
+  }
+
   public static RollupAsyncProcessor getConductor(InvocationPoint invokePoint, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
     return new QueueableProcessor(invokePoint, calcItems, oldCalcItems);
   }
@@ -204,7 +214,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     return numberToReturn;
   }
 
-  public virtual Database.QueryLocator start(Database.BatchableContext context) {
+  public Database.QueryLocator start(Database.BatchableContext context) {
     /**
      * for batch, we know 100% for sure there's only 1 SObjectType / Set<String> in the map.
      * NB: we have to call "populateObjectFields" in both the "start" and "execute" methods because
@@ -212,7 +222,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
      * "System.AsyncException: Queueable cannot be implemented with other system interfaces" exception
      */
     RollupRepository repo = this.preStart();
-    this.logger.log('starting batch with query: ' + repo, context, LoggingLevel.INFO);
     this.logger.save();
     return repo.getLocator();
   }
@@ -600,7 +609,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         return;
       }
       if (outstandingItemCount > 0) {
-        this.logger.log(this.getTypeName() + ': gathering additional calc items with query:', query, LoggingLevel.DEBUG);
         additionalCalcItems = repo.setQuery(query).get();
 
         if (hasAlreadyBeenQueried) {
@@ -639,7 +647,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       }
 
       String grandparentKey = '' + roll.lookupObj + roll.calcItemType;
-      if (grandparentRollups.containsKey(grandparentKey)) {
+      if (String.isNotBlank(roll.metadata.GrandparentRelationshipFieldPath__c) && grandparentRollups.containsKey(grandparentKey)) {
         roll.traversal = grandparentRollups.get(grandparentKey);
       }
 
@@ -664,7 +672,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     if (this.isTimingOut) {
       this.getDML().forceSyncUpdate();
     }
-    RollupEvaluator.clearConditionCache();
+    this.cleanup();
     this.getDML().doUpdate(updatedLookupRecords.values());
     this.populateOtherDeferredRollups();
     this.processDeferredRollups();
@@ -818,6 +826,17 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       }
       return roll.traversal.getIsFinished() ? roll.traversal.getParentLookupToRecords() : lookupFieldToCalcItems;
     }
+
+    Integer cacheKey = roll.calcItems.hashCode();
+    switch on this.invokePoint {
+      when FROM_FULL_RECALC_LWC, FROM_SINGULAR_PARENT_RECALC_LWC, FROM_FULL_RECALC_FLOW {
+        Map<String, CalcItemBag> possiblyCachedItems = CACHED_CALC_ITEM_LOOKUPS.get(cacheKey);
+        if (possiblyCachedItems != null) {
+          return possiblyCachedItems;
+        }
+      }
+    }
+
     for (SObject calcItem : roll.calcItems) {
       if (roll.matchingCalcItemIds.contains(calcItem.Id) == false) {
         continue;
@@ -853,6 +872,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         }
       }
     }
+    CACHED_CALC_ITEM_LOOKUPS.put(cacheKey, lookupFieldToCalcItems);
     return lookupFieldToCalcItems;
   }
 
@@ -1333,5 +1353,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
     this.storeParentResetField(roll, lookupRecord);
     this.logger.log(this.getTypeName() + ': ' + logKey + ' record after rolling up:', lookupRecord, LoggingLevel.DEBUG);
+  }
+
+  private void cleanup() {
+    RollupEvaluator.clearConditionCache();
+    CACHED_CALC_ITEM_LOOKUPS = null;
   }
 }

--- a/rollup/core/classes/RollupCalcItemReplacer.cls
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls
@@ -122,7 +122,6 @@ public without sharing class RollupCalcItemReplacer {
         return calcItems;
       }
       String queryString = RollupQueryBuilder.Current.getQuery(firstItem.getSObjectType(), new List<String>(baseFields), 'Id', '=');
-      RollupLogger.Instance.log('replacing calc items with missing base fields using query string:', queryString, LoggingLevel.DEBUG);
       List<SObject> calcItemsWithReplacement = this.repo.setQuery(queryString).setArg(calcItems).get();
       Map<String, Schema.SObjectField> fieldNameToDescribe = firstItem.getSObjectType().getDescribe().fields.getMap();
       for (SObject calcItemWithReplacement : calcItemsWithReplacement) {
@@ -199,7 +198,6 @@ public without sharing class RollupCalcItemReplacer {
       String.join(optionalWhereClauses, ' AND ')
     );
 
-    RollupLogger.Instance.log('replacing calc items with polymorphic where clause using query string:', queryString, LoggingLevel.FINE);
     calcItems = this.repo.setQuery(queryString).setArg(calcItems).get();
     return calcItems;
   }
@@ -245,7 +243,6 @@ public without sharing class RollupCalcItemReplacer {
 
     if (hasUnqueriedParentFields) {
       String queryString = RollupQueryBuilder.Current.getQuery(calcItemType, new List<String>(parentQueryFields), 'Id', '=');
-      RollupLogger.Instance.log('replacing calc items with parent-level where clause using query string:', queryString, LoggingLevel.FINE);
       Map<Id, SObject> idToCalcItemsWithParentFields = new Map<Id, SObject>(this.repo.setQuery(queryString).setArg(calcItems).get());
       this.appendUpdatedParentFields(calcItems, idToCalcItemsWithParentFields);
     }

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -74,7 +74,7 @@ public without sharing abstract class RollupCalculator {
             when Currency, Double, Integer, Long, Percent {
               calc = new DecimalRollupCalculator(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField);
             }
-            when Combobox, Email, EncryptedString, Id, MultiPicklist, Phone, Reference, String, TextArea, URL {
+            when Combobox, Email, EncryptedString, Id, MultiPicklist, Phone, Picklist, Reference, String, TextArea, URL {
               calc = new PicklistRollupCalculator(op, opFieldOnCalcItem, opFieldOnLookupObject, metadata, lookupKeyField);
             }
             when Date {

--- a/rollup/core/classes/RollupCurrencyInfo.cls
+++ b/rollup/core/classes/RollupCurrencyInfo.cls
@@ -77,6 +77,14 @@ public without sharing virtual class RollupCurrencyInfo {
   protected virtual void addInfo(RollupCurrencyInfo info) {
   }
 
+  public static List<String> getMultiCurrencyFields(Schema.DescribeSObjectResult objectToken) {
+    List<String> fields = new List<String>{ CURRENCY_ISO_CODE_FIELD_NAME };
+    if (CURRENCY_ISO_CODE_TO_CURRENCY != null && IS_DATED_MULTICURRENCY && DATED_MULTICURRENCY_SUPPORTED_OBJECTS.containsKey(objectToken.getName())) {
+      fields.addAll(DATED_MULTICURRENCY_SUPPORTED_OBJECTS.get(objectToken.getName()));
+    }
+    return fields;
+  }
+
   public static void transform(List<SObject> calcItems, Schema.SObjectField opFieldOnCalcItem, String parentIsoCode, List<RollupOrderBy__mdt> orderBys) {
     if (IS_MULTICURRENCY) {
       loadProperMinMaxDates(calcItems);

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -254,9 +254,10 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
           ConditionalGrouping conditionalGrouping = this.conditionalGroupings[index];
           Boolean hasInnerMatch = conditionalGrouping.equals(calcItem);
           addLog(conditionalGrouping, hasInnerMatch, calcItem, LoggingLevel.FINEST);
-          if (conditionalGrouping.isOrConditional()) {
+          Boolean isOrConditional = conditionalGrouping.isOrConditional();
+          if (isOrConditional) {
             matches = index == 0 ? hasInnerMatch : hasInnerMatch || matches;
-          } else if (conditionalGrouping.isOrConditional() == false) {
+          } else if (isOrConditional == false) {
             matches = matches && hasInnerMatch;
           }
         }
@@ -566,6 +567,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
   private class WhereFieldCondition {
     private final SObjectType sObjectType;
     private final String fieldName;
+    private final Map<String, Schema.SObjectField> fieldNameToTokens;
     private final String criteria;
     private final List<String> originalValues;
     private final List<String> values;
@@ -579,6 +581,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       this.criteria = criteria;
       this.originalValues = values;
       this.sObjectType = sObjectType;
+      this.fieldNameToTokens = this.sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).fields.getMap();
       this.values = new List<String>();
 
       for (String val : values) {
@@ -615,7 +618,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       Boolean isDateFunction = RollupDateLiteral.isSoqlDateFunction(this.fieldName);
 
       String fieldNameToUse = isDateFunction ? getDateFunctionField(this.fieldName) : this.fieldName;
-      Object originalValue = this.getFieldValue(item, fieldNameToUse, this.sObjectType);
+      Object originalValue = this.getFieldValue(item, fieldNameToUse, this.fieldNameToTokens);
       String storedValue = originalValue == null ? (String) originalValue : String.valueOf(originalValue);
 
       if (hasOnlyOneValue && isDateFunction) {
@@ -698,21 +701,21 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       return isEqual;
     }
 
-    private Object getFieldValue(SObject item, String fieldPath, SObjectType sObjectType) {
+    private Object getFieldValue(SObject item, String fieldPath, Map<String, Schema.SObjectField> localFieldNameToTokens) {
       if (item == null) {
         return null;
       }
       // handle compound fields separately
-      Boolean hasField = sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).fields.getMap().containsKey(fieldPath);
+      Boolean hasField = localFieldNameToTokens.containsKey(fieldPath);
       if (fieldPath.contains('.') && hasField == false) {
-        return this.getRelationshipFieldValue(item, fieldPath, sObjectType);
+        return this.getRelationshipFieldValue(item, fieldPath, localFieldNameToTokens);
       } else if ((hasField && item.getPopulatedFieldsAsMap().containsKey(fieldPath)) || (hasField && item.get(fieldPath) == null)) {
         return item.get(fieldPath);
       }
       return null;
     }
 
-    private Object getRelationshipFieldValue(SObject item, String fieldPath, SObjectType sObjectType) {
+    private Object getRelationshipFieldValue(SObject item, String fieldPath, Map<String, Schema.SObjectField> localFieldNameToTokens) {
       List<String> fieldNameParts = fieldPath.split(RELATIONSHIP_FIELD_DELIMITER);
       // here, we pop fields off the front of the list because for tertiary+ object relationships (eg Owner.Profile.Name)
       // we need to recurse till the value itself can be captured
@@ -720,7 +723,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       String originalName = relationshipName;
       relationshipName = getRelationshipNameFromField(relationshipName);
 
-      SObjectField fieldToken = sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).fields.getMap().get(relationshipName);
+      SObjectField fieldToken = localFieldNameToTokens.get(relationshipName);
       if (fieldToken == null) {
         // it could be a rollup started from the parent using a parent-level where clause
         try {
@@ -746,7 +749,11 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       if (fieldNameParts.size() == 1 && fieldNameParts[0] == 'Type' && parentSObject?.getPopulatedFieldsAsMap().containsKey('Type') == true) {
         return parentSObject.get(fieldNameParts[0]);
       } else if (fieldNameParts.isEmpty() == false) {
-        return this.getFieldValue(parentSObject, String.join(fieldNameParts, '.'), parentSObjectType);
+        return this.getFieldValue(
+          parentSObject,
+          String.join(fieldNameParts, '.'),
+          parentSObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).fields.getMap()
+        );
       } else {
         return parentSObject?.get(originalName);
       }
@@ -877,7 +884,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
   }
 
   private static void addLog(Object clazz, Boolean matches, Object item, LoggingLevel logLevel) {
-    RollupLogger.Instance.log(clazz + '\nMatches? ' + matches + ' for: ' + item, logLevel);
+    RollupLogger.Instance.log('Evaluator matches? ' + matches, item, logLevel);
   }
 
   private static String getCurrentTransactionId() {

--- a/rollup/core/classes/RollupLimits.cls
+++ b/rollup/core/classes/RollupLimits.cls
@@ -5,6 +5,9 @@ public without sharing class RollupLimits {
   private static final Integer SYNC_TIMEOUT_INTERVAL_MS = 3000;
   private static final Integer ASYNC_TIMEOUT_INTERVAL_MS = 13000;
 
+  private static final Integer LIMIT_HEAP_SIZE = Limits.getLimitHeapSize();
+  private static final Integer LIMIT_QUERY_ROWS = 50000;
+
   public class Tester {
     private final transient RollupControl__mdt control;
     private final transient Boolean isRunningAsync;
@@ -25,7 +28,7 @@ public without sharing class RollupLimits {
     }
     public Boolean hasExceededHeapSizeLimit {
       get {
-        return (Limits.getLimitHeapSize() - 2000) < Limits.getHeapSize();
+        return (LIMIT_HEAP_SIZE - 2000) < Limits.getHeapSize();
       }
     }
     public Boolean hasExceededDMLRowLimit {
@@ -53,7 +56,7 @@ public without sharing class RollupLimits {
     public Integer getRemainingQueryRows() {
       Integer queryRowsUsed = stubbedQueryRows != null ? stubbedQueryRows : Limits.getQueryRows();
       if (this.control?.MaxQueryRows__c == null) {
-        return Limits.getLimitQueryRows() - queryRowsUsed;
+        return LIMIT_QUERY_ROWS - queryRowsUsed;
       }
       Integer remainingQueryRows = this.control.MaxQueryRows__c?.intValue() - queryRowsUsed;
       return remainingQueryRows > 0 ? remainingQueryRows : 0;

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.55';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.56';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupQueryBuilder.cls
+++ b/rollup/core/classes/RollupQueryBuilder.cls
@@ -22,7 +22,7 @@ public without sharing class RollupQueryBuilder {
     fieldNames.clear();
     fieldNames.addAll(lowerCaseFieldNames);
 
-    this.addCurrencyIsoCodeForMultiCurrencyOrgs(fieldNames, lowerCaseFieldNames, sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED));
+    this.addMultiCurrencyFields(fieldNames, lowerCaseFieldNames, sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED));
 
     String originalWhereClause = optionalWhereClause;
     Boolean isBlank = String.isBlank(originalWhereClause);
@@ -117,15 +117,17 @@ public without sharing class RollupQueryBuilder {
     return hasPolymorphicField;
   }
 
-  private void addCurrencyIsoCodeForMultiCurrencyOrgs(List<String> fieldNames, Set<String> uniqueLowercaseFields, Schema.DescribeSObjectResult objectToken) {
-    if (
-      RollupCurrencyInfo.isMultiCurrency() &&
-      uniqueLowercaseFields.contains(RollupCurrencyInfo.CURRENCY_ISO_CODE_FIELD_NAME.toLowerCase()) == false &&
-      objectToken.fields.getMap().containsKey(RollupCurrencyInfo.CURRENCY_ISO_CODE_FIELD_NAME)
-    ) {
+  private void addMultiCurrencyFields(List<String> fieldNames, Set<String> uniqueLowercaseFields, Schema.DescribeSObjectResult objectToken) {
+    if (RollupCurrencyInfo.isMultiCurrency() && objectToken.fields.getMap().containsKey(RollupCurrencyInfo.CURRENCY_ISO_CODE_FIELD_NAME)) {
       Boolean hasAggregateFunction = AGGREGATE_QUERY_REGEX.matcher(String.join(fieldNames, ',')).find();
       if (hasAggregateFunction == false) {
-        fieldNames.add(RollupCurrencyInfo.CURRENCY_ISO_CODE_FIELD_NAME);
+        List<String> multiCurrencyFields = RollupCurrencyInfo.getMultiCurrencyFields(objectToken);
+        for (String multiCurrencyField : multiCurrencyFields) {
+          if (uniqueLowercaseFields.contains(multiCurrencyField.toLowerCase()) == false) {
+            fieldNames.add(multiCurrencyField);
+          }
+        }
+        uniqueLowercaseFields.addAll(multiCurrencyFields);
       }
     }
   }

--- a/rollup/core/classes/RollupRepository.cls
+++ b/rollup/core/classes/RollupRepository.cls
@@ -29,10 +29,12 @@ public without sharing class RollupRepository {
   }
 
   public Database.QueryLocator getLocator() {
+    RollupLogger.Instance.log('Getting query locator for', this.args.query, LoggingLevel.DEBUG);
     return Database.getQueryLocatorWithBinds(this.args.query, this.args.bindVars, this.accessLevel);
   }
 
   public List<SObject> get() {
+    RollupLogger.Instance.log('Querying...', this.args.query, LoggingLevel.DEBUG);
     return Database.queryWithBinds(this.args.query, this.args.bindVars, this.accessLevel);
   }
 

--- a/scripts/extra-metadata/Rollup.Opp_Eight.md-meta.xml
+++ b/scripts/extra-metadata/Rollup.Opp_Eight.md-meta.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Opp Eight</label>
+    <protected>false</protected>
+    <values>
+        <field>CalcItemWhereClause__c</field>
+        <value xsi:type="xsd:string">StageName != &apos;One&apos;</value>
+    </values>
+    <values>
+        <field>CalcItem__c</field>
+        <value xsi:type="xsd:string">Opportunity</value>
+    </values>
+    <values>
+        <field>ChangedFieldsOnCalcItem__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ConcatDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Description__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultNumberValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultStringValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GrandparentRelationshipFieldPath__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByFields__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByRowEndDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByRowStartDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>IsFullRecordSet__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsRollupStartedFromParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsTableFormatted__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>LimitAmount__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>LookupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">AccountId</value>
+    </values>
+    <values>
+        <field>LookupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">Id</value>
+    </values>
+    <values>
+        <field>LookupObject__c</field>
+        <value xsi:type="xsd:string">Account</value>
+    </values>
+    <values>
+        <field>OneToManyGrandparentFields__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>OrderByFirstLast__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>RollupControl__c</field>
+        <value xsi:type="xsd:string">Org_Defaults</value>
+    </values>
+    <values>
+        <field>RollupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">Name</value>
+    </values>
+    <values>
+        <field>RollupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">Active__c</value>
+    </values>
+    <values>
+        <field>RollupOperation__c</field>
+        <value xsi:type="xsd:string">FIRST</value>
+    </values>
+    <values>
+        <field>RollupToUltimateParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>SharingMode__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ShouldRunWithoutCustomSettingEnabled__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>SplitConcatDelimiterOnCalcItem__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>UltimateParentLookup__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/scripts/extra-metadata/Rollup.Opp_Five.md-meta.xml
+++ b/scripts/extra-metadata/Rollup.Opp_Five.md-meta.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Opp Five</label>
+    <protected>false</protected>
+    <values>
+        <field>CalcItemWhereClause__c</field>
+        <value xsi:type="xsd:string">StageName IN (&apos;One&apos;, &apos;Two&apos;)</value>
+    </values>
+    <values>
+        <field>CalcItem__c</field>
+        <value xsi:type="xsd:string">Opportunity</value>
+    </values>
+    <values>
+        <field>ChangedFieldsOnCalcItem__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ConcatDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Description__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultNumberValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultStringValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GrandparentRelationshipFieldPath__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByFields__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByRowEndDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByRowStartDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>IsFullRecordSet__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsRollupStartedFromParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsTableFormatted__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>LimitAmount__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>LookupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">AccountId</value>
+    </values>
+    <values>
+        <field>LookupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">Id</value>
+    </values>
+    <values>
+        <field>LookupObject__c</field>
+        <value xsi:type="xsd:string">Account</value>
+    </values>
+    <values>
+        <field>OneToManyGrandparentFields__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>OrderByFirstLast__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>RollupControl__c</field>
+        <value xsi:type="xsd:string">Org_Defaults</value>
+    </values>
+    <values>
+        <field>RollupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">Name</value>
+    </values>
+    <values>
+        <field>RollupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">Description</value>
+    </values>
+    <values>
+        <field>RollupOperation__c</field>
+        <value xsi:type="xsd:string">CONCAT</value>
+    </values>
+    <values>
+        <field>RollupToUltimateParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>SharingMode__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ShouldRunWithoutCustomSettingEnabled__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>SplitConcatDelimiterOnCalcItem__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>UltimateParentLookup__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/scripts/extra-metadata/Rollup.Opp_Four.md-meta.xml
+++ b/scripts/extra-metadata/Rollup.Opp_Four.md-meta.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Opp Four</label>
+    <protected>false</protected>
+    <values>
+        <field>CalcItemWhereClause__c</field>
+        <value xsi:type="xsd:string">StageName != &apos;One&apos;</value>
+    </values>
+    <values>
+        <field>CalcItem__c</field>
+        <value xsi:type="xsd:string">Opportunity</value>
+    </values>
+    <values>
+        <field>ChangedFieldsOnCalcItem__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ConcatDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Description__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultNumberValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultStringValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GrandparentRelationshipFieldPath__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByFields__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByRowEndDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByRowStartDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>IsFullRecordSet__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsRollupStartedFromParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsTableFormatted__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>LimitAmount__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>LookupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">AccountId</value>
+    </values>
+    <values>
+        <field>LookupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">Id</value>
+    </values>
+    <values>
+        <field>LookupObject__c</field>
+        <value xsi:type="xsd:string">Account</value>
+    </values>
+    <values>
+        <field>OneToManyGrandparentFields__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>OrderByFirstLast__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>RollupControl__c</field>
+        <value xsi:type="xsd:string">Org_Defaults</value>
+    </values>
+    <values>
+        <field>RollupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">Id</value>
+    </values>
+    <values>
+        <field>RollupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">NumberOfEmployees</value>
+    </values>
+    <values>
+        <field>RollupOperation__c</field>
+        <value xsi:type="xsd:string">COUNT</value>
+    </values>
+    <values>
+        <field>RollupToUltimateParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>SharingMode__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ShouldRunWithoutCustomSettingEnabled__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>SplitConcatDelimiterOnCalcItem__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>UltimateParentLookup__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/scripts/extra-metadata/Rollup.Opp_Nine.md-meta.xml
+++ b/scripts/extra-metadata/Rollup.Opp_Nine.md-meta.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Opp Nine</label>
+    <protected>false</protected>
+    <values>
+        <field>CalcItemWhereClause__c</field>
+        <value xsi:type="xsd:string">StageName = &apos;One&apos;</value>
+    </values>
+    <values>
+        <field>CalcItem__c</field>
+        <value xsi:type="xsd:string">Opportunity</value>
+    </values>
+    <values>
+        <field>ChangedFieldsOnCalcItem__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ConcatDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Description__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultNumberValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultStringValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GrandparentRelationshipFieldPath__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByFields__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByRowEndDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByRowStartDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>IsFullRecordSet__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsRollupStartedFromParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsTableFormatted__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>LimitAmount__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>LookupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">AccountId</value>
+    </values>
+    <values>
+        <field>LookupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">Id</value>
+    </values>
+    <values>
+        <field>LookupObject__c</field>
+        <value xsi:type="xsd:string">Account</value>
+    </values>
+    <values>
+        <field>OneToManyGrandparentFields__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>OrderByFirstLast__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>RollupControl__c</field>
+        <value xsi:type="xsd:string">Org_Defaults</value>
+    </values>
+    <values>
+        <field>RollupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">StageName</value>
+    </values>
+    <values>
+        <field>RollupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">Rollup_To_Checkbox__c</value>
+    </values>
+    <values>
+        <field>RollupOperation__c</field>
+        <value xsi:type="xsd:string">NONE</value>
+    </values>
+    <values>
+        <field>RollupToUltimateParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>SharingMode__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ShouldRunWithoutCustomSettingEnabled__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>SplitConcatDelimiterOnCalcItem__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>UltimateParentLookup__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/scripts/extra-metadata/Rollup.Opp_One.md-meta.xml
+++ b/scripts/extra-metadata/Rollup.Opp_One.md-meta.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Opp One</label>
+    <protected>false</protected>
+    <values>
+        <field>CalcItemWhereClause__c</field>
+        <value xsi:type="xsd:string">StageName = &apos;One&apos; AND Amount &lt; 3</value>
+    </values>
+    <values>
+        <field>CalcItem__c</field>
+        <value xsi:type="xsd:string">Opportunity</value>
+    </values>
+    <values>
+        <field>ChangedFieldsOnCalcItem__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ConcatDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Description__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultNumberValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultStringValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GrandparentRelationshipFieldPath__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByFields__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByRowEndDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByRowStartDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>IsFullRecordSet__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsRollupStartedFromParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsTableFormatted__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>LimitAmount__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>LookupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">AccountId</value>
+    </values>
+    <values>
+        <field>LookupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">Id</value>
+    </values>
+    <values>
+        <field>LookupObject__c</field>
+        <value xsi:type="xsd:string">Account</value>
+    </values>
+    <values>
+        <field>OneToManyGrandparentFields__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>OrderByFirstLast__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>RollupControl__c</field>
+        <value xsi:type="xsd:string">Org_Defaults</value>
+    </values>
+    <values>
+        <field>RollupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">Name</value>
+    </values>
+    <values>
+        <field>RollupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">Site</value>
+    </values>
+    <values>
+        <field>RollupOperation__c</field>
+        <value xsi:type="xsd:string">MIN</value>
+    </values>
+    <values>
+        <field>RollupToUltimateParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>SharingMode__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ShouldRunWithoutCustomSettingEnabled__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>SplitConcatDelimiterOnCalcItem__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>UltimateParentLookup__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/scripts/extra-metadata/Rollup.Opp_Seven.md-meta.xml
+++ b/scripts/extra-metadata/Rollup.Opp_Seven.md-meta.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Opp Seven</label>
+    <protected>false</protected>
+    <values>
+        <field>CalcItemWhereClause__c</field>
+        <value xsi:type="xsd:string">StageName IN (&apos;One&apos;, &apos;Two&apos;)</value>
+    </values>
+    <values>
+        <field>CalcItem__c</field>
+        <value xsi:type="xsd:string">Opportunity</value>
+    </values>
+    <values>
+        <field>ChangedFieldsOnCalcItem__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ConcatDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Description__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultNumberValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultStringValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GrandparentRelationshipFieldPath__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByFields__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByRowEndDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByRowStartDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>IsFullRecordSet__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsRollupStartedFromParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsTableFormatted__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>LimitAmount__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>LookupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">AccountId</value>
+    </values>
+    <values>
+        <field>LookupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">Id</value>
+    </values>
+    <values>
+        <field>LookupObject__c</field>
+        <value xsi:type="xsd:string">Account</value>
+    </values>
+    <values>
+        <field>OneToManyGrandparentFields__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>OrderByFirstLast__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>RollupControl__c</field>
+        <value xsi:type="xsd:string">Org_Defaults</value>
+    </values>
+    <values>
+        <field>RollupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">StageName</value>
+    </values>
+    <values>
+        <field>RollupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">Industry</value>
+    </values>
+    <values>
+        <field>RollupOperation__c</field>
+        <value xsi:type="xsd:string">MAX</value>
+    </values>
+    <values>
+        <field>RollupToUltimateParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>SharingMode__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ShouldRunWithoutCustomSettingEnabled__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>SplitConcatDelimiterOnCalcItem__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>UltimateParentLookup__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/scripts/extra-metadata/Rollup.Opp_Six.md-meta.xml
+++ b/scripts/extra-metadata/Rollup.Opp_Six.md-meta.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Opp Six</label>
+    <protected>false</protected>
+    <values>
+        <field>CalcItemWhereClause__c</field>
+        <value xsi:type="xsd:string">StageName IN (&apos;One&apos;, &apos;Two&apos;)</value>
+    </values>
+    <values>
+        <field>CalcItem__c</field>
+        <value xsi:type="xsd:string">Opportunity</value>
+    </values>
+    <values>
+        <field>ChangedFieldsOnCalcItem__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ConcatDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Description__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultNumberValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultStringValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GrandparentRelationshipFieldPath__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByFields__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByRowEndDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByRowStartDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>IsFullRecordSet__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsRollupStartedFromParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsTableFormatted__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>LimitAmount__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>LookupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">AccountId</value>
+    </values>
+    <values>
+        <field>LookupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">Id</value>
+    </values>
+    <values>
+        <field>LookupObject__c</field>
+        <value xsi:type="xsd:string">Account</value>
+    </values>
+    <values>
+        <field>OneToManyGrandparentFields__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>OrderByFirstLast__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>RollupControl__c</field>
+        <value xsi:type="xsd:string">Org_Defaults</value>
+    </values>
+    <values>
+        <field>RollupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">Name</value>
+    </values>
+    <values>
+        <field>RollupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">NumberofLocations__c</value>
+    </values>
+    <values>
+        <field>RollupOperation__c</field>
+        <value xsi:type="xsd:string">COUNT_DISTINCT</value>
+    </values>
+    <values>
+        <field>RollupToUltimateParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>SharingMode__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ShouldRunWithoutCustomSettingEnabled__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>SplitConcatDelimiterOnCalcItem__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>UltimateParentLookup__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/scripts/extra-metadata/Rollup.Opp_Three.md-meta.xml
+++ b/scripts/extra-metadata/Rollup.Opp_Three.md-meta.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Opp Three</label>
+    <protected>false</protected>
+    <values>
+        <field>CalcItemWhereClause__c</field>
+        <value xsi:type="xsd:string">StageName = &apos;One&apos; AND Amount &gt; 3</value>
+    </values>
+    <values>
+        <field>CalcItem__c</field>
+        <value xsi:type="xsd:string">Opportunity</value>
+    </values>
+    <values>
+        <field>ChangedFieldsOnCalcItem__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ConcatDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Description__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultNumberValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultStringValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GrandparentRelationshipFieldPath__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByFields__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByRowEndDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByRowStartDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>IsFullRecordSet__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsRollupStartedFromParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsTableFormatted__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>LimitAmount__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>LookupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">AccountId</value>
+    </values>
+    <values>
+        <field>LookupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">Id</value>
+    </values>
+    <values>
+        <field>LookupObject__c</field>
+        <value xsi:type="xsd:string">Account</value>
+    </values>
+    <values>
+        <field>OneToManyGrandparentFields__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>OrderByFirstLast__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>RollupControl__c</field>
+        <value xsi:type="xsd:string">Org_Defaults</value>
+    </values>
+    <values>
+        <field>RollupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">AccountIdText__c</value>
+    </values>
+    <values>
+        <field>RollupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">AnnualRevenue</value>
+    </values>
+    <values>
+        <field>RollupOperation__c</field>
+        <value xsi:type="xsd:string">SUM</value>
+    </values>
+    <values>
+        <field>RollupToUltimateParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>SharingMode__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ShouldRunWithoutCustomSettingEnabled__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>SplitConcatDelimiterOnCalcItem__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>UltimateParentLookup__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/scripts/extra-metadata/Rollup.Opp_Two.md-meta.xml
+++ b/scripts/extra-metadata/Rollup.Opp_Two.md-meta.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Opp Two</label>
+    <protected>false</protected>
+    <values>
+        <field>CalcItemWhereClause__c</field>
+        <value xsi:type="xsd:string">StageName = &apos;One&apos; AND Amount &gt; 3</value>
+    </values>
+    <values>
+        <field>CalcItem__c</field>
+        <value xsi:type="xsd:string">Opportunity</value>
+    </values>
+    <values>
+        <field>ChangedFieldsOnCalcItem__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ConcatDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Description__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultNumberValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>FullRecalculationDefaultStringValue__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GrandparentRelationshipFieldPath__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByFields__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByRowEndDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>GroupByRowStartDelimiter__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>IsFullRecordSet__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsRollupStartedFromParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsTableFormatted__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>LimitAmount__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>LookupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">AccountId</value>
+    </values>
+    <values>
+        <field>LookupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">Id</value>
+    </values>
+    <values>
+        <field>LookupObject__c</field>
+        <value xsi:type="xsd:string">Account</value>
+    </values>
+    <values>
+        <field>OneToManyGrandparentFields__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>OrderByFirstLast__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>RollupControl__c</field>
+        <value xsi:type="xsd:string">Org_Defaults</value>
+    </values>
+    <values>
+        <field>RollupFieldOnCalcItem__c</field>
+        <value xsi:type="xsd:string">Name</value>
+    </values>
+    <values>
+        <field>RollupFieldOnLookupObject__c</field>
+        <value xsi:type="xsd:string">NaicsDesc</value>
+    </values>
+    <values>
+        <field>RollupOperation__c</field>
+        <value xsi:type="xsd:string">MAX</value>
+    </values>
+    <values>
+        <field>RollupToUltimateParent__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>SharingMode__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ShouldRunWithoutCustomSettingEnabled__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>SplitConcatDelimiterOnCalcItem__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>UltimateParentLookup__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Optimizations to reduce CPU time",
-            "versionNumber": "1.5.55.0",
+            "versionName": "ACM correctly includes all query fields for full recalcs, further optimizations",
+            "versionNumber": "1.5.56.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -104,6 +104,7 @@
         "apex-rollup@1.5.52-0": "04t6g000008fjfYAAQ",
         "apex-rollup@1.5.53-0": "04t6g000008fjg2AAA",
         "apex-rollup@1.5.54-0": "04t6g000008fjhZAAQ",
-        "apex-rollup@1.5.55-0": "04t6g000008fjiwAAA"
+        "apex-rollup@1.5.55-0": "04t6g000008fjiwAAA",
+        "apex-rollup@1.5.56-0": "04t6g000008fjnnAAA"
     }
 }


### PR DESCRIPTION
* fixed a bug with ACM where a full recalc could fail for Opportunity-related items
* massive deep dive on CPU time for full recalcs with @jongpie and friends. This resulted in a number of optimizations for full recalcs, specifically:
  * evaluating the result of where clauses - added some optimistic caching in here when parts of where clauses are shared between different rollups
  * prevented an _extremely_ expensive `toString()` call that was being used even when rollup logging was disabled in `RollupEvaluator`
  * added caching in a few other hot code spots related to full recalcs - particularly when mapping calc items to their corresponding parent keys
  * prevented `RollupEvaluator` from being called in a full recalc if it was just going to be called later anyway. On a non-full recalc this double call is nice because it allows us to stop the async part of Apex Rollup if there aren't any matching children, but on the full recalc code path it's an expensive operation being performed twice for no reason
  * optimized when the `RollupCalcItemReplacer` is being called, as well as how many _times_ it was being called. 
  * optimized how rollup limits were being calculated. There were a few calls to the `Limits` class - part of the standard Apex library - that were really burning through CPU time (for whatever reason)
  * optimized a _really_ hot code path through `RollupEvaluator` which was using the `getDescribe().fields.getMap()` property repeatedly for no reason

All of these optimizations were measured and benchmarked across a variety of different batch sizes, ranging from 200 - 500. Some of these individual batches (with 9 rollups) were taking an average of 40 seconds to run, which didn't leave a ton of room for error. At the end of optimizing, most batches were finishing in an average of 11 seconds - an improvement of over 100% in processing time! I'm confident that these improvements will put an end to issues with full recalculations.