### PR TITLE
v1.5.58 - RollupRepository log message updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjoMAAQ">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008nzupAAA">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjoMAAQ">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008nzupAAA">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.57",
+  "version": "1.5.58",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjogAAA">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008nzuuAAA">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008fjogAAA">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008nzuuAAA">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -5,7 +5,7 @@
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
             "versionName": "Adding marker interface for log objects to provide more information, added caboose concept to full batch recalcs",
-            "versionNumber": "1.0.30.0",
+            "versionNumber": "1.0.31.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -24,6 +24,7 @@
         "apex-rollup-namespaced@1.0.27-0": "04t6g000008fjheAAA",
         "apex-rollup-namespaced@1.0.28-0": "04t6g000008fjj1AAA",
         "apex-rollup-namespaced@1.0.29-0": "04t6g000008fjnsAAA",
-        "apex-rollup-namespaced@1.0.30-0": "04t6g000008fjogAAA"
+        "apex-rollup-namespaced@1.0.30-0": "04t6g000008fjogAAA",
+        "apex-rollup-namespaced@1.0.31-0": "04t6g000008nzuuAAA"
     }
 }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -505,7 +505,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       }
     }
     this.lookupItems = localLookupItems;
-    this.fullRecalcProcessor?.processParentFieldsToReset(this.lookupItems);
+    this.fullRecalcProcessor?.processParentFieldsToReset(recordsToReset);
     return this.lookupItems;
   }
 

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.57';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.58';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupRepository.cls
+++ b/rollup/core/classes/RollupRepository.cls
@@ -60,10 +60,10 @@ public without sharing class RollupRepository implements RollupLogger.ToStringOb
   }
 
   public override String toString() {
-    return this.args.query + '\n' + 'with bind var keys: ' + this.args.bindVars.keySet();
+    return this.args.query + '\nBind keys: ' + this.args.bindVars.keySet()  + '\nAccess level: ' + this.accessLevelName;
   }
 
   private void createQueryLog(String message) {
-    RollupLogger.Instance.Log(message, 'Query: ' + this.args.query + '\nAccess level: ' + this.accessLevelName, LoggingLevel.DEBUG);
+    RollupLogger.Instance.Log(message, this, LoggingLevel.DEBUG);
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,7 +5,7 @@
             "package": "apex-rollup",
             "path": "rollup",
             "versionName": "Adding marker interface for log objects to provide more information, added caboose concept to full batch recalcs",
-            "versionNumber": "1.5.57.0",
+            "versionNumber": "1.5.58.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -106,6 +106,7 @@
         "apex-rollup@1.5.54-0": "04t6g000008fjhZAAQ",
         "apex-rollup@1.5.55-0": "04t6g000008fjiwAAA",
         "apex-rollup@1.5.56-0": "04t6g000008fjnnAAA",
-        "apex-rollup@1.5.57-0": "04t6g000008fjoMAAQ"
+        "apex-rollup@1.5.57-0": "04t6g000008fjoMAAQ",
+        "apex-rollup@1.5.58-0": "04t6g000008nzupAAA"
     }
 }


### PR DESCRIPTION
* Updates `RollupRepository.toString()` to be used properly in log messages
* Updated `RollupAsyncProcessor` to use the right record collection when resetting parent fields for full recalcs