### PR TITLE
v1.5.64 - Grandparent Rollup Optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008o0DaAAI">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnWCAA0">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008o0DaAAI">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnWCAA0">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnWCAA0">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnX0AAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnWCAA0">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnX0AAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupCalcItemReplacerTests.cls
+++ b/extra-tests/classes/RollupCalcItemReplacerTests.cls
@@ -146,7 +146,7 @@ private class RollupCalcItemReplacerTests {
       new RollupControl__mdt(IsRollupLoggingEnabled__c = true, ReplaceCalcItemsAsyncWhenOverCount__c = 1)
     );
     Account updatedAccount = (Account) replacer.replace(
-      new List<Account>{ new Account(Id = acc.Id) },
+      new List<Account>{ acc },
       new List<Rollup__mdt>{ new Rollup__mdt(CalcItemWhereClause__c = 'CreatedDate != null', CalcItem__c = 'Account') }
     )[0];
 

--- a/extra-tests/classes/RollupEvaluatorTests.cls
+++ b/extra-tests/classes/RollupEvaluatorTests.cls
@@ -1029,6 +1029,15 @@ private class RollupEvaluatorTests {
   }
 
   @IsTest
+  static void supportsTypeFieldWhenOnlyPresentOnParent() {
+    String whereClause = 'Account.Type != \'Something\'';
+    RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, Contact.SObjectType);
+    List<String> queryFields = eval.getQueryFields();
+    System.assertEquals(1, queryFields.size(), queryFields);
+    System.assertEquals('Account.Type', queryFields[0]);
+  }
+
+  @IsTest
   static void gracefullyHandlesFieldNotExistingForDateLiteral() {
     String whereClause = 'SomeFieldThatDoesNotExist = THIS_YEAR';
     RollupEvaluator.WhereFieldEvaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, Opportunity.SObjectType);

--- a/extra-tests/classes/RollupFlowBulkProcessorTests.cls
+++ b/extra-tests/classes/RollupFlowBulkProcessorTests.cls
@@ -379,4 +379,49 @@ private class RollupFlowBulkProcessorTests {
     Account acc = [SELECT AnnualRevenue, NumberOfEmployees FROM Account];
     System.assertEquals(10, acc.AnnualRevenue, 'Account annual revenue should have summed properly');
   }
+
+  @IsTest
+  static void rollupOrderBysAreHandledProperlyForParentRollups() {
+    Rollup.onlyUseMockMetadata = true;
+    List<Account> accs = [SELECT Id, AnnualRevenue FROM Account];
+    insert new List<SObject>{
+      new Opportunity(Amount = 5, AccountId = accs[0].Id, StageName = 'A', CloseDate = System.today().addDays(5), Name = 'Amount 1'),
+      new Opportunity(Amount = 10, AccountId = accs[0].Id, StageName = 'A', CloseDate = System.today(), Name = 'Amount 2')
+    };
+
+    RollupFlowBulkProcessor.FlowInput input = new RollupFlowBulkProcessor.FlowInput();
+    input.recordsToRollup = accs;
+    input.rollupContext = 'UPSERT';
+    input.oldRecordsToRollup = new List<SObject>{ null, null };
+    input.deferProcessing = false;
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      Rollup.appendOrderByMetadata(
+        new Rollup__mdt(
+          RollupOperation__c = 'FIRST',
+          CalcItem__c = 'Opportunity',
+          LookupObject__c = 'Account',
+          RollupFieldOnCalcItem__c = 'Amount',
+          LookupFieldOnCalcItem__c = 'AccountId',
+          LookupFieldOnLookupObject__c = 'Id',
+          RollupFieldOnLookupObject__c = 'AnnualRevenue',
+          IsRollupStartedFromParent__c = true
+        ),
+        new List<RollupOrderBy__mdt>{ new RollupOrderBy__mdt(FieldName__c = 'CloseDate', Ranking__c = 0) }
+      )
+    };
+
+    Exception ex;
+    Test.startTest();
+    try {
+      RollupFlowBulkProcessor.addRollup(new List<RollupFlowBulkProcessor.FlowInput>{ input });
+    } catch (Exception e) {
+      ex = e;
+    }
+    Test.stopTest();
+
+    System.assertEquals(null, ex, 'Exception should not be thrown when child object info can be inferred from CMDT');
+    Account acc = [SELECT AnnualRevenue, NumberOfEmployees FROM Account];
+    System.assertEquals(10, acc.AnnualRevenue, 'Account annual revenue should have ordered properly');
+  }
 }

--- a/extra-tests/classes/RollupFlowBulkProcessorTests.cls
+++ b/extra-tests/classes/RollupFlowBulkProcessorTests.cls
@@ -326,12 +326,13 @@ private class RollupFlowBulkProcessorTests {
     };
 
     Test.startTest();
-    RollupFlowBulkProcessor.addRollup(new List<RollupFlowBulkProcessor.FlowInput>{ input });
+    List<Rollup.FlowOutput> flowOutputs = RollupFlowBulkProcessor.addRollup(new List<RollupFlowBulkProcessor.FlowInput>{ input });
     Test.stopTest();
 
     acc = [SELECT AnnualRevenue, NumberOfEmployees FROM Account];
     System.assertEquals(10, acc.AnnualRevenue, 'Account annual revenue should have summed properly');
     System.assertEquals(2, acc.NumberOfEmployees, 'Account number of employees should have counted properly');
+    System.assertEquals(1, flowOutputs.size(), 'Output size should be the same as input size');
   }
 
   @IsTest

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -879,7 +879,6 @@ private class RollupFullRecalcTests {
 
   @IsTest
   static void shouldAllowGrandparentRollupsFromParent() {
-    // TODO - WIP
     // also an integration test for having an ORDER BY statement
     // in RollupFullBatchRecalculator
     Account acc = [SELECT Id, OwnerId FROM Account];
@@ -920,7 +919,6 @@ private class RollupFullRecalcTests {
 
   @IsTest
   static void shouldAllowGrandparentRollupFromParentWithPolymorphicFields() {
-    // TODO - WIP
     // technically shouldAllowGrandparentRollupsFromParent also tests polymorphic fields
     // this test does that in conjunction with a more complicated where clause
     Account acc = [SELECT Id, OwnerId FROM Account];

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -879,6 +879,7 @@ private class RollupFullRecalcTests {
 
   @IsTest
   static void shouldAllowGrandparentRollupsFromParent() {
+    // TODO - WIP
     // also an integration test for having an ORDER BY statement
     // in RollupFullBatchRecalculator
     Account acc = [SELECT Id, OwnerId FROM Account];
@@ -919,6 +920,7 @@ private class RollupFullRecalcTests {
 
   @IsTest
   static void shouldAllowGrandparentRollupFromParentWithPolymorphicFields() {
+    // TODO - WIP
     // technically shouldAllowGrandparentRollupsFromParent also tests polymorphic fields
     // this test does that in conjunction with a more complicated where clause
     Account acc = [SELECT Id, OwnerId FROM Account];

--- a/extra-tests/classes/RollupRelationshipFieldFinderTests.cls
+++ b/extra-tests/classes/RollupRelationshipFieldFinderTests.cls
@@ -91,7 +91,6 @@ private class RollupRelationshipFieldFinderTests {
     // same as above except this one should succeed since everything should be fetched in one go
     Account acc = [SELECT Id, OwnerId, Owner.Name FROM Account];
 
-    // TODO - would be nice to also support something like Parent.Owner.Name from ContactPointAddress (polymorphic lookups, in general)
     Contact con = new Contact(AccountId = acc.Id, LastName = 'Child con');
     insert con;
     control.MaxNumberOfQueries__c = 1;

--- a/extra-tests/classes/RollupRelationshipFieldFinderTests.cls
+++ b/extra-tests/classes/RollupRelationshipFieldFinderTests.cls
@@ -87,6 +87,32 @@ private class RollupRelationshipFieldFinderTests {
   }
 
   @IsTest
+  static void skipsIntermediateRelationshipFetchesForFullRecalc() {
+    // same as above except this one should succeed since everything should be fetched in one go
+    Account acc = [SELECT Id, OwnerId, Owner.Name FROM Account];
+
+    // TODO - would be nice to also support something like Parent.Owner.Name from ContactPointAddress (polymorphic lookups, in general)
+    Contact con = new Contact(AccountId = acc.Id, LastName = 'Child con');
+    insert con;
+    control.MaxNumberOfQueries__c = 1;
+
+    RollupRelationshipFieldFinder finder = new RollupRelationshipFieldFinder(
+      control,
+      new Rollup__mdt(GrandparentRelationshipFieldPath__c = 'Account.Owner.Name'),
+      uniqueFieldNames,
+      uniqueFieldNames,
+      User.SObjectType,
+      new Map<Id, SObject>()
+    );
+    finder.setIsFullRecalc(true);
+    RollupRelationshipFieldFinder.Traversal traversal = finder.getParents(new List<Contact>{ con });
+
+    System.assertEquals(true, traversal.getParentLookupToRecords().containsKey(acc.OwnerId));
+    System.assertEquals(acc.Owner.Name, traversal.retrieveParents(con.Id)[0].get('Name'));
+    System.assertEquals(true, traversal.getIsFinished());
+  }
+
+  @IsTest
   static void shouldNotReportFalsePositiveIfUltimateParentStaysTheSame() {
     Account intermediateOne = new Account(Name = 'Intermediate 1');
     Account intermediateTwo = new Account(Name = 'Intermediate 2');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.63",
+  "version": "1.5.64",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008o0DfAAI">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnWHAA0">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008o0DfAAI">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnWHAA0">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnWHAA0">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnX5AAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnWHAA0">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnX5AAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Fixes The number of results does not match the number of interviews that were executed in a single bulk execution request issue in RollupFlowBulkProcessor",
-            "versionNumber": "1.0.36.0",
+            "versionName": "Grandparent full recalc rollup optimizations",
+            "versionNumber": "1.0.37.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -30,6 +30,7 @@
         "apex-rollup-namespaced@1.0.33-0": "04t6g000008o01cAAA",
         "apex-rollup-namespaced@1.0.34-0": "04t6g000008o021AAA",
         "apex-rollup-namespaced@1.0.35-0": "04t6g000008o0DVAAY",
-        "apex-rollup-namespaced@1.0.36-0": "04t6g000008o0DfAAI"
+        "apex-rollup-namespaced@1.0.36-0": "04t6g000008o0DfAAI",
+        "apex-rollup-namespaced@1.0.37-0": "04t6g000008SnWHAA0"
     }
 }

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -31,6 +31,6 @@
         "apex-rollup-namespaced@1.0.34-0": "04t6g000008o021AAA",
         "apex-rollup-namespaced@1.0.35-0": "04t6g000008o0DVAAY",
         "apex-rollup-namespaced@1.0.36-0": "04t6g000008o0DfAAI",
-        "apex-rollup-namespaced@1.0.37-0": "04t6g000008SnWHAA0"
+        "apex-rollup-namespaced@1.0.37-0": "04t6g000008SnX5AAK"
     }
 }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -2212,6 +2212,9 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
     wrappedMeta.metadata.add(innerMeta);
     RollupEvaluator.WhereFieldEvaluator eval = String.isBlank(whereClause) ? null : RollupEvaluator.getWhereEval(whereClause, childType);
     wrappedMeta.queryFields.addAll(getQueryFieldsFromMetadata(innerMeta, eval));
+    if (innerMeta.IsRollupStartedFromParent__c && innerMeta.GrandparentRelationshipFieldPath__c != null) {
+      wrappedMeta.queryFields.add(innerMeta.GrandparentRelationshipFieldPath__c);
+    }
     return wrappedMeta;
   }
 

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -809,7 +809,10 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
       List<Rollup__mdt> metas = new List<Rollup__mdt>(wrapper.rollupMetadata);
       wrapper.flowInput.recordsToRollup = replaceFlowInputCalcItemsIfNecessary(hashCodeToCalcItems, wrapper.flowInput.recordsToRollup, metas);
       wrapper.flowInput.oldRecordsToRollup = replaceFlowInputCalcItemsIfNecessary(hashCodeToCalcItems, wrapper.flowInput.oldRecordsToRollup, metas);
-      Map<Id, SObject> oldFlowRecords = new Map<Id, SObject>(wrapper.flowInput.oldRecordsToRollup);
+      Map<Id, SObject> oldFlowRecords = new Map<Id, SObject>();
+      for (SObject oldFlowRecord : wrapper.flowInput.oldRecordsToRollup) {
+        oldFlowRecords.put(oldFlowRecord.Id, oldFlowRecord);
+      }
       processCustomMetadata(
         localRollups,
         metas,

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -752,10 +752,11 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
     // Flow bulkifies things, but poorly. It's possible to get multiple FlowInputs with the same metadata, but different calc items (for example)
     // let's head that off at the pass by bulkifying here
     Map<Rollup__mdt, FlowInputWrapper> metaToInputWrapper = new Map<Rollup__mdt, FlowInputWrapper>();
+    RollupSettings__c settings = RollupSettings__c.getInstance();
     for (FlowInput flowInput : flowInputs) {
       FlowOutput flowOutput = new FlowOutput();
       flowOutputs.add(flowOutput);
-      if (RollupSettings__c.getInstance().IsEnabled__c == false) {
+      if (settings.IsEnabled__c == false) {
         continue;
       }
 
@@ -1868,36 +1869,38 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
   }
 
   private static Rollup__mdt transformFlowInputToRollupMetadata(FlowInput flowInput, String rollupContext, SObjectType sObjectType) {
-    return new Rollup__mdt(
-      CalcItem__c = flowInput.isRollupStartedFromParent || String.isNotBlank(flowInput.calcItemTypeWhenRollupStartedFromParent)
-        ? flowInput.calcItemTypeWhenRollupStartedFromParent
-        : String.valueOf(sObjectType),
-      CalcItemWhereClause__c = flowInput.calcItemWhereClause,
-      ChangedFieldsOnCalcItem__c = flowInput.calcItemChangedFields,
-      ConcatDelimiter__c = flowInput.concatDelimiter,
-      CurrencyFieldMapping__c = flowInput.currencyFieldMapping,
-      FullRecalculationDefaultNumberValue__c = flowInput.fullRecalculationDefaultNumberValue,
-      FullRecalculationDefaultStringValue__c = flowInput.fullRecalculationDefaultStringValue,
-      GrandparentRelationshipFieldPath__c = flowInput.grandparentRelationshipFieldPath,
-      GroupByFields__c = flowInput.groupByFields,
-      GroupByRowEndDelimiter__c = flowInput.groupByRowEndDelimiter,
-      GroupByRowStartDelimiter__c = flowInput.groupByRowStartDelimiter,
-      IsFullRecordSet__c = flowInput.isFullRecordSet,
-      IsRollupStartedFromParent__c = flowInput.isRollupStartedFromParent,
-      IsTableFormatted__c = flowInput.isTableFormatted,
-      LookupFieldOnCalcItem__c = flowInput.lookupFieldOnCalcItem,
-      LookupFieldOnLookupObject__c = flowInput.lookupFieldOnOpObject,
-      LookupObject__c = flowInput.rollupSObjectName,
-      OneToManyGrandparentFields__c = flowInput.oneToManyGrandparentFields,
-      OrderByFirstLast__c = flowInput.orderByFirstLast,
-      RollupControl__r = getSingleControlOrDefault(RollupControl__mdt.Id, flowInput.rollupControlId, defaultControl),
-      RollupFieldOnCalcItem__c = flowInput.rollupFieldOnCalcItem,
-      RollupFieldOnLookupObject__c = flowInput.rollupFieldOnOpObject,
-      RollupOperation__c = rollupContext + flowInput.rollupOperation,
-      RollupToUltimateParent__c = flowInput.rollupToUltimateParent,
-      SharingMode__c = flowInput.sharingMode,
-      SplitConcatDelimiterOnCalcItem__c = flowInput.splitConcatDelimiterOnCalcItem,
-      UltimateParentLookup__c = flowInput.ultimateParentLookup
+    return getFirstLastMetadata(
+      new Rollup__mdt(
+        CalcItem__c = flowInput.isRollupStartedFromParent || String.isNotBlank(flowInput.calcItemTypeWhenRollupStartedFromParent)
+          ? flowInput.calcItemTypeWhenRollupStartedFromParent
+          : String.valueOf(sObjectType),
+        CalcItemWhereClause__c = flowInput.calcItemWhereClause,
+        ChangedFieldsOnCalcItem__c = flowInput.calcItemChangedFields,
+        ConcatDelimiter__c = flowInput.concatDelimiter,
+        CurrencyFieldMapping__c = flowInput.currencyFieldMapping,
+        FullRecalculationDefaultNumberValue__c = flowInput.fullRecalculationDefaultNumberValue,
+        FullRecalculationDefaultStringValue__c = flowInput.fullRecalculationDefaultStringValue,
+        GrandparentRelationshipFieldPath__c = flowInput.grandparentRelationshipFieldPath,
+        GroupByFields__c = flowInput.groupByFields,
+        GroupByRowEndDelimiter__c = flowInput.groupByRowEndDelimiter,
+        GroupByRowStartDelimiter__c = flowInput.groupByRowStartDelimiter,
+        IsFullRecordSet__c = flowInput.isFullRecordSet,
+        IsRollupStartedFromParent__c = flowInput.isRollupStartedFromParent,
+        IsTableFormatted__c = flowInput.isTableFormatted,
+        LookupFieldOnCalcItem__c = flowInput.lookupFieldOnCalcItem,
+        LookupFieldOnLookupObject__c = flowInput.lookupFieldOnOpObject,
+        LookupObject__c = flowInput.rollupSObjectName,
+        OneToManyGrandparentFields__c = flowInput.oneToManyGrandparentFields,
+        OrderByFirstLast__c = flowInput.orderByFirstLast,
+        RollupControl__r = getSingleControlOrDefault(RollupControl__mdt.Id, flowInput.rollupControlId, defaultControl),
+        RollupFieldOnCalcItem__c = flowInput.rollupFieldOnCalcItem,
+        RollupFieldOnLookupObject__c = flowInput.rollupFieldOnOpObject,
+        RollupOperation__c = rollupContext + flowInput.rollupOperation,
+        RollupToUltimateParent__c = flowInput.rollupToUltimateParent,
+        SharingMode__c = flowInput.sharingMode,
+        SplitConcatDelimiterOnCalcItem__c = flowInput.splitConcatDelimiterOnCalcItem,
+        UltimateParentLookup__c = flowInput.ultimateParentLookup
+      )
     );
   }
 

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -2183,7 +2183,7 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
       }
     }
     for (RollupOrderBy__mdt orderByInfo : meta.RollupOrderBys__r) {
-      queryFields.add(orderByInfo.FieldName__c);
+      queryFields.add(orderByInfo.FieldName__c.trim());
     }
     return queryFields;
   }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1900,7 +1900,8 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
         SharingMode__c = flowInput.sharingMode,
         SplitConcatDelimiterOnCalcItem__c = flowInput.splitConcatDelimiterOnCalcItem,
         UltimateParentLookup__c = flowInput.ultimateParentLookup
-      )
+      ),
+      flowInput.rollupOperation
     );
   }
 
@@ -2711,9 +2712,7 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
       if (isFullRecalcOp(getBaseOperationName(rollupMetadata.RollupOperation__c)) || rollupMetadata.GroupByFields__c != null) {
         rollupMetadata.IsFullRecordSet__c = true;
       }
-      if (rollupOp.name().contains(Op.FIRST.name()) || rollupOp.name().contains(Op.LAST.name())) {
-        rollupMetadata = getFirstLastMetadata(rollupMetadata);
-      }
+      rollupMetadata = getFirstLastMetadata(rollupMetadata, rollupOp.name());
 
       RollupControl__mdt localControl;
       if (rollupMetadata.RollupControl__c != null) {
@@ -2749,7 +2748,7 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
     return rollupConductor;
   }
 
-  private static Rollup__mdt getFirstLastMetadata(Rollup__mdt meta) {
+  private static Rollup__mdt getFirstLastMetadata(Rollup__mdt meta, String rollupOpName) {
     List<RollupOrderBy__mdt> replacementOrderBys;
     if (meta.RollupOrderBys__r.isEmpty() && String.isNotBlank(meta.OrderByFirstLast__c)) {
       List<String> unparsedOrderBys = meta.OrderByFirstLast__c.split(',');
@@ -2768,7 +2767,9 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
         }
         replacementOrderBys.add(orderBy);
       }
-    } else if (meta.RollupOrderBys__r.isEmpty()) {
+    } else if (
+      meta.RollupOrderBys__r.isEmpty() && (rollupOpName.contains(Op.FIRST.name()) || rollupOpName.contains(Op.LAST.name())) || meta.LimitAmount__c != null
+    ) {
       replacementOrderBys = new List<RollupOrderBy__mdt>{ new RollupOrderBy__mdt(Ranking__c = 0, FieldName__c = meta.RollupFieldOnCalcItem__c) };
     }
     return appendOrderByMetadata(meta, replacementOrderBys);

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -828,6 +828,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
             roll.lookupObj,
             roll.oldCalcItems
           )
+          .setIsFullRecalc(this.isFullRecalc)
           .getParents(roll.calcItems);
       } else if (roll.traversal?.getIsFinished() == false) {
         roll.traversal.recommence();

--- a/rollup/core/classes/RollupCalcItemReplacer.cls
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls
@@ -87,7 +87,6 @@ public without sharing class RollupCalcItemReplacer {
       if (mightNeedReplacement && isPresentInMapAlready == false) {
         localNeedsReplacement = true;
         RollupEvaluator.WhereFieldEvaluator whereEval = RollupEvaluator.getWhereEval(meta.CalcItemWhereClause__c, calcType);
-        this.metaToEval.put(meta, whereEval);
         Set<String> parentQueryFieldSet = this.parentQueryFields.containsKey(calcType) ? this.parentQueryFields.get(calcType) : new Set<String>();
         Set<String> baseQueryFieldSet = this.baseQueryFields.containsKey(calcType) ? this.baseQueryFields.get(calcType) : new Set<String>();
         for (RollupOrderBy__mdt orderBy : meta.RollupOrderBys__r) {
@@ -98,7 +97,9 @@ public without sharing class RollupCalcItemReplacer {
         }
         this.parentQueryFields.put(calcType, parentQueryFieldSet);
         this.baseQueryFields.put(calcType, baseQueryFieldSet);
-      } else if (isPresentInMapAlready) {
+        localNeedsReplacement = this.parentQueryFields.isEmpty() == false || this.baseQueryFields.isEmpty() == false;
+        this.metaToEval.put(meta, localNeedsReplacement ? whereEval : null);
+      } else if (isPresentInMapAlready && this.metaToEval.get(meta) != null) {
         localNeedsReplacement = true;
       }
     }

--- a/rollup/core/classes/RollupCalcItemReplacer.cls
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls
@@ -112,9 +112,7 @@ public without sharing class RollupCalcItemReplacer {
       // it'd be great to only calcItem.isSet(fieldName) here, but that returns false for null values
       // instead, we also test against a very unlikely to be found value
       try {
-        if (calcItem.isSet(fieldName) == false && calcItem.get(fieldName) != '<<<improbable test value>>>') {
-          baseQueryFieldSet.add(fieldName);
-        }
+        calcItem.get(fieldName);
       } catch (Exception ex) {
         baseQueryFieldSet.add(fieldName);
       }

--- a/rollup/core/classes/RollupCalcItemReplacer.cls
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls
@@ -73,10 +73,8 @@ public without sharing class RollupCalcItemReplacer {
     }
     SObjectType calcType = calcItems[0].getSObjectType();
     for (Rollup__mdt meta : metadata) {
-      if (meta.IsRollupStartedFromParent__c && meta.LookupObject__c == calcType.getDescribe().getName()) {
-        return localNeedsReplacement;
-      } else if (meta.CalcItem__c != calcType.getDescribe().getName()) {
-        return localNeedsReplacement;
+      if (meta.CalcItem__c != calcType.getDescribe().getName()) {
+        continue;
       }
       if (this.repo == null) {
         this.repo = new RollupRepository(RollupMetaPicklists.getAccessLevel(meta));
@@ -90,7 +88,7 @@ public without sharing class RollupCalcItemReplacer {
         Set<String> parentQueryFieldSet = this.parentQueryFields.containsKey(calcType) ? this.parentQueryFields.get(calcType) : new Set<String>();
         Set<String> baseQueryFieldSet = this.baseQueryFields.containsKey(calcType) ? this.baseQueryFields.get(calcType) : new Set<String>();
         for (RollupOrderBy__mdt orderBy : meta.RollupOrderBys__r) {
-          this.addQueryableFields(orderBy.FieldName__c, parentQueryFieldSet, baseQueryFieldSet, calcItems[0]);
+          this.addQueryableFields(orderBy.FieldName__c.trim(), parentQueryFieldSet, baseQueryFieldSet, calcItems[0]);
         }
         for (String queryField : whereEval.getQueryFields()) {
           this.addQueryableFields(queryField, parentQueryFieldSet, baseQueryFieldSet, calcItems[0]);
@@ -107,6 +105,7 @@ public without sharing class RollupCalcItemReplacer {
   }
 
   private void addQueryableFields(String fieldName, Set<String> parentQueryFieldSet, Set<String> baseQueryFieldSet, SObject calcItem) {
+    // TODO - only add parent fields when the calc item doesn't already have the parent-level field populated
     if (fieldName.contains('.')) {
       parentQueryFieldSet.add(fieldName);
     } else {
@@ -177,7 +176,9 @@ public without sharing class RollupCalcItemReplacer {
     Set<String> additionalQueryFields = new Set<String>();
     if (this.metaToEval.containsKey(metadata)) {
       RollupEvaluator.WhereFieldEvaluator eval = this.metaToEval.get(metadata);
-      this.processWhereClauseForDownstreamEvals(optionalWhereClauses, additionalQueryFields, sObjectType, typeField, owner, metadata, eval);
+      if (eval != null) {
+        this.processWhereClauseForDownstreamEvals(optionalWhereClauses, additionalQueryFields, sObjectType, typeField, owner, metadata, eval);
+      }
     }
 
     Boolean hasOwnerPrepolulated = populatedFields.containsKey('Owner');
@@ -192,10 +193,15 @@ public without sharing class RollupCalcItemReplacer {
     } else if (hasTypeClause && hasTypePrepopulated && hasOwnerClause && hasOwnerPrepolulated) {
       return calcItems;
     } else if (hasTypeClause && hasTypePrepopulated == false && hasOwnerClause == false) {
+      Boolean hasAllSoughtFields = true;
       for (String whereClause : optionalWhereClauses) {
-        if (this.hasSoughtField(typeField, whereClause, firstItem)) {
-          return calcItems;
+        hasAllSoughtFields = hasAllSoughtFields && this.hasSoughtField(typeField, whereClause, firstItem);
+        if (hasAllSoughtFields == false) {
+          break;
         }
+      }
+      if (hasAllSoughtFields) {
+        return calcItems;
       }
     }
 

--- a/rollup/core/classes/RollupCalcItemReplacer.cls
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls
@@ -161,9 +161,9 @@ public without sharing class RollupCalcItemReplacer {
     Boolean hasTypeClause = metadata.CalcItemWhereClause__c?.contains(typeField) == true;
     SObjectType sObjectType = firstItem.getSObjectType();
     Map<String, Schema.SObjectField> fieldMap = sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).fields.getMap();
-    Boolean hasPolyMorphicFields = hasOwnerClause || hasTypeClause || fieldMap.get(metadata.LookupFieldOnCalcItem__c)?.getDescribe().isNamePointing() == true;
+    Boolean hasPolymorphicFields = hasOwnerClause || hasTypeClause || fieldMap.get(metadata.LookupFieldOnCalcItem__c)?.getDescribe().isNamePointing() == true;
 
-    if (hasPolyMorphicFields == false) {
+    if (hasPolymorphicFields == false) {
       return calcItems;
     }
     if (hasTypeClause == false && hasOwnerClause == false) {
@@ -190,6 +190,12 @@ public without sharing class RollupCalcItemReplacer {
       return calcItems;
     } else if (hasTypeClause && hasTypePrepopulated && hasOwnerClause && hasOwnerPrepolulated) {
       return calcItems;
+    } else if (hasTypeClause && hasTypePrepopulated == false && hasOwnerClause == false) {
+      for (String whereClause : optionalWhereClauses) {
+        if (this.hasSoughtField(typeField, whereClause, firstItem)) {
+          return calcItems;
+        }
+      }
     }
 
     for (String fieldName : populatedFields.keySet()) {
@@ -330,6 +336,19 @@ public without sharing class RollupCalcItemReplacer {
         }
       }
     }
+  }
+
+  @SuppressWarnings('PMD.EmptyCatchBlock')
+  private Boolean hasSoughtField(String fieldName, String whereClause, SObject item) {
+    if (whereClause.containsIgnoreCase(fieldName)) {
+      try {
+        String possibleSoughtField = whereClause.substringBefore(fieldName);
+        return item.getPopulatedFieldsAsMap().get(possibleSoughtField) != null;
+      } catch (Exception ex) {
+        // the field isn't populated, so we SHOULD re-query it
+      }
+    }
+    return false;
   }
 
   private static SObject serializeReplace(SObject calcItem, String fieldName, Object value) {

--- a/rollup/core/classes/RollupCalcItemReplacer.cls
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls
@@ -105,12 +105,24 @@ public without sharing class RollupCalcItemReplacer {
   }
 
   private void addQueryableFields(String fieldName, Set<String> parentQueryFieldSet, Set<String> baseQueryFieldSet, SObject calcItem) {
-    // TODO - only add parent fields when the calc item doesn't already have the parent-level field populated
     if (fieldName.contains('.')) {
-      parentQueryFieldSet.add(fieldName);
+      List<String> relationshipFields = fieldName.split('\\.');
+      String actualField = relationshipFields.remove(relationshipFields.size() - 1);
+      SObject relativeObject = calcItem;
+      while (relationshipFields.isEmpty() == false) {
+        try {
+          relativeObject = relativeObject.getSObject(relationshipFields.remove(0));
+        } catch (Exception ex) {
+          parentQueryFieldSet.add(fieldName);
+        }
+      }
+      try {
+        relativeObject.get(actualField);
+      } catch (Exception ex) {
+        parentQueryFieldSet.add(fieldName);
+      }
     } else {
-      // it'd be great to only calcItem.isSet(fieldName) here, but that returns false for null values
-      // instead, we also test against a very unlikely to be found value
+      // it'd be great to use calcItem.isSet(fieldName) here, but that returns false for null values
       try {
         calcItem.get(fieldName);
       } catch (Exception ex) {
@@ -318,7 +330,12 @@ public without sharing class RollupCalcItemReplacer {
           Boolean isAcceptableField = fieldToken.getReferenceTo().isEmpty() == false && fieldToken.getName() != 'Id';
           if (isAcceptableField && fieldToken.isNamePointing() == false) {
             try {
-              calcItem.putSObject(fieldToken.getRelationshipName(), calcItemWIthUpdatedParentField.getSObject(fieldToken.getRelationshipName()));
+              SObject parent = calcItem.getSObject(fieldToken.getRelationshipName());
+              if (parent == null) {
+                calcItem.putSObject(fieldToken.getRelationshipName(), calcItemWIthUpdatedParentField.getSObject(fieldToken.getRelationshipName()));
+              } else {
+                parent.put(fieldName, calcItemWIthUpdatedParentField.getPopulatedFieldsAsMap().get(fieldName));
+              }
             } catch (SObjectException ex) {
               // avoids "System.SObjectException: Relationship { relationship name } is not editable"
               if (calcItemWIthUpdatedParentField.getPopulatedFieldsAsMap().containsKey(fieldToken.getRelationshipName())) {

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -275,6 +275,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       return matches;
     }
 
+    @SuppressWarnings('PMD.EagerlyLoadedDescribeSObjectResult')
     private Set<String> getValidRelationshipNames(SObjectType sObjectType) {
       Set<String> localRelationshipNames = new Set<String>();
       List<SObjectField> fields = sObjectType.getDescribe(Schema.SObjectDescribeOptions.DEFERRED).fields.getMap().values();

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -165,6 +165,16 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
 
     private List<String> queryFields;
 
+    private final Map<String, Schema.SObjectField> fieldNameToField {
+      get {
+        if (this.fieldNameToField == null) {
+          this.fieldNameToField = this.calcItemType.getDescribe(Schema.SObjectDescribeOptions.DEFERRED).fields.getMap();
+        }
+        return this.fieldNameToField;
+      }
+      set;
+    }
+
     public WhereFieldEvaluator(String whereClause, SObjectType calcItemSObjectType) {
       whereClause = whereClause == null ? '' : whereClause.replaceAll('(\n|\r|\t)', '');
       this.originalWhereClause = whereClause;
@@ -267,7 +277,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
 
     private Set<String> getValidRelationshipNames(SObjectType sObjectType) {
       Set<String> localRelationshipNames = new Set<String>();
-      List<SObjectField> fields = sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).fields.getMap().values();
+      List<SObjectField> fields = sObjectType.getDescribe(Schema.SObjectDescribeOptions.DEFERRED).fields.getMap().values();
       for (SObjectField field : fields) {
         String relationshipName = field.getDescribe().getRelationshipName();
         // filter out polymorphic relationship fields that can't be queried
@@ -475,17 +485,19 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
     }
 
     private Boolean isValidRelationshipField(String fieldName) {
-      Map<String, SObjectField> fieldNameToField = this.calcItemType.getDescribe().fields.getMap();
+      if (fieldName.contains('.') == false) {
+        return false;
+      }
+      List<String> fieldParts = fieldName.split(RELATIONSHIP_FIELD_DELIMITER);
       if (fieldName.contains('Owner.')) {
-        List<String> fieldParts = fieldName.split(RELATIONSHIP_FIELD_DELIMITER);
         Integer ownerIndex = fieldParts.indexOf('Owner');
-        SObjectType ownerType;
+        Schema.SObjectType ownerType;
         if (ownerIndex > 0) {
           Integer index = 0;
           while (index < ownerIndex) {
             String relationshipName = fieldParts[index];
             String fieldRef = getRelationshipNameFromField(relationshipName);
-            SObjectField fieldToken = fieldNameToField.get(fieldRef);
+            SObjectField fieldToken = this.fieldNameToField.get(fieldRef);
             if (fieldToken.getDescribe().isNamePointing()) {
               return false;
             }
@@ -495,12 +507,20 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
         } else {
           ownerType = this.calcItemType;
         }
-        return ownerType.getDescribe().fields.getMap().get('OwnerId').getDescribe().isNamePointing() == false;
+        return (ownerType == this.calcItemType ? this.fieldNameToField : ownerType.getDescribe().fields.getMap())
+            .get('OwnerId')
+            .getDescribe()
+            .isNamePointing() == false;
       } else {
-        String endPart = fieldName.substringAfter('.');
-        return fieldNameToField.containsKey(endPart) ||
-          (POLYMORPHIC_FIELDS.contains(fieldName.substringBetween('.')) == false &&
-          POLYMORPHIC_FIELDS.contains(endPart) == false);
+        Map<String, Schema.SObjectField> localFieldNameToField = this.fieldNameToField;
+        while (fieldParts.size() > 1) {
+          String relationshipPart = fieldParts.remove(0);
+          relationshipPart = relationshipPart.endsWith('__r') ? relationshipPart.replace('__r', '__c') : relationshipPart + 'Id';
+          Schema.SObjectField relationField = localFieldNameToField.get(relationshipPart);
+          localFieldNameToField = relationField.getDescribe().getReferenceTo()[0].getDescribe(Schema.SObjectDescribeOptions.DEFERRED).fields.getMap();
+        }
+        String endPart = fieldParts[0];
+        return localFieldNameToField.containsKey(endPart);
       }
     }
   }

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -518,7 +518,12 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
           String relationshipPart = fieldParts.remove(0);
           relationshipPart = relationshipPart.endsWith('__r') ? relationshipPart.replace('__r', '__c') : relationshipPart + 'Id';
           Schema.SObjectField relationField = localFieldNameToField.get(relationshipPart);
-          localFieldNameToField = relationField.getDescribe().getReferenceTo()[0].getDescribe(Schema.SObjectDescribeOptions.DEFERRED).fields.getMap();
+          Schema.DescribeFieldResult fieldDescribe = relationField.getDescribe();
+          if (fieldDescribe.isFilterable() == false) {
+            return false;
+          } else {
+            localFieldNameToField = fieldDescribe.getReferenceTo()[0].getDescribe(Schema.SObjectDescribeOptions.DEFERRED).fields.getMap();
+          }
         }
         String endPart = fieldParts[0];
         return localFieldNameToField.containsKey(endPart);

--- a/rollup/core/classes/RollupFlowBulkProcessor.cls
+++ b/rollup/core/classes/RollupFlowBulkProcessor.cls
@@ -117,7 +117,14 @@ global without sharing class RollupFlowBulkProcessor {
             input.orderByFirstLast = flowInput.orderByFirstLast != null ? flowInput.orderByFirstLast : '';
             if (input.orderByFirstLast == '') {
               for (RollupOrderBy__mdt orderBy : meta.RollupOrderBys__r) {
-                input.orderByFirstLast += orderBy.FieldName__c + ' ' + orderBy.NullSortOrder__c + ' ' + orderBy.SortOrder__c + ',';
+                input.orderByFirstLast += orderBy.FieldName__c;
+                if (orderBy.NullSortOrder__c != null) {
+                  input.orderByFirstLast += ' ' + orderBy.NullSortOrder__c;
+                }
+                if (orderBy.SortOrder__c != null) {
+                  input.orderByFirstLast += ' ' + orderBy.SortOrder__c;
+                }
+                input.orderByFirstLast += ',';
               }
             }
             input.orderByFirstLast = input.orderByFirstLast.removeEnd(',');

--- a/rollup/core/classes/RollupFlowBulkProcessor.cls
+++ b/rollup/core/classes/RollupFlowBulkProcessor.cls
@@ -115,8 +115,10 @@ global without sharing class RollupFlowBulkProcessor {
             input.sharingMode = flowInput.sharingMode != null ? flowInput.sharingMode : meta.SharingMode__c;
             // fixup order by children records
             input.orderByFirstLast = flowInput.orderByFirstLast != null ? flowInput.orderByFirstLast : '';
-            for (RollupOrderBy__mdt orderBy : meta.RollupOrderBys__r) {
-              input.orderByFirstLast += orderBy.FieldName__c + ' ' + orderBy.NullSortOrder__c + ' ' + orderBy.SortOrder__c + ',';
+            if (input.orderByFirstLast == '') {
+              for (RollupOrderBy__mdt orderBy : meta.RollupOrderBys__r) {
+                input.orderByFirstLast += orderBy.FieldName__c + ' ' + orderBy.NullSortOrder__c + ' ' + orderBy.SortOrder__c + ',';
+              }
             }
             input.orderByFirstLast = input.orderByFirstLast.removeEnd(',');
             // metadata values that don't get overridden

--- a/rollup/core/classes/RollupFlowBulkProcessor.cls
+++ b/rollup/core/classes/RollupFlowBulkProcessor.cls
@@ -69,16 +69,16 @@ global without sharing class RollupFlowBulkProcessor {
   @InvocableMethod(category='Rollups' label='Perform Rollup__mdt-based rollup')
   global static List<Rollup.FlowOutput> addRollup(List<FlowInput> flowInputs) {
     List<Rollup.FlowOutput> outputs = new List<Rollup.FlowOutput>();
-
+    List<Rollup.FlowInput> validInputs = new List<Rollup.FlowInput>();
     for (FlowInput flowInput : flowInputs) {
       Rollup.FlowOutput output = new Rollup.FlowOutput();
       if (flowInput.recordsToRollup?.isEmpty() != false) {
         output.message = 'No records';
+        outputs.add(output);
       } else {
         List<Rollup__mdt> rollupMetadata = Rollup.getMetadataFromCache(Rollup__mdt.SObjectType);
         // for some reason, lists passed from Flow to Apex report their SObjectType as null. womp.
         String sObjectName = flowInput.recordsToRollup == null ? '' : flowInput.recordsToRollup[0].getSObjectType().getDescribe().getName();
-        List<Rollup.FlowInput> rollupFlowInputs = new List<Rollup.FlowInput>();
         for (Rollup__mdt meta : rollupMetadata) {
           if (meta.IsRollupStartedFromParent__c) {
             flowInput.calcItemTypeWhenRollupStartedFromParent = flowInput.calcItemTypeWhenRollupStartedFromParent != null
@@ -87,6 +87,7 @@ global without sharing class RollupFlowBulkProcessor {
           }
           if (flowInput.recordsToRollup == null || meta.CalcItem__c == sObjectName || flowInput.calcItemTypeWhenRollupStartedFromParent == meta.CalcItem__c) {
             Rollup.FlowInput input = new Rollup.FlowInput();
+            validInputs.add(input);
             // pertinent fields from CMDT (can be overridden by optional flow properties)
             input.calcItemChangedFields = flowInput.calcItemChangedFields != null ? flowInput.calcItemChangedFields : meta.ChangedFieldsOnCalcItem__c;
             input.calcItemTypeWhenRollupStartedFromParent = flowInput.calcItemTypeWhenRollupStartedFromParent;
@@ -137,23 +138,15 @@ global without sharing class RollupFlowBulkProcessor {
             input.recordsToRollup = flowInput.recordsToRollup;
             input.rollupContext = flowInput.rollupContext;
             input.shouldRunSync = flowInput.shouldRunSync != null ? flowInput.shouldRunSync : false;
-            rollupFlowInputs.add(input);
-
-            output.message = 'Rollup queued for context: ' + meta.RollupOperation__c;
-          }
-        }
-
-        List<Rollup.FlowOutput> innerOutputs = Rollup.performRollup(rollupFlowInputs);
-        for (Rollup.FlowOutput innerOutput : innerOutputs) {
-          if (innerOutput.isSuccess == false) {
-            output.isSuccess = false;
-            output.message = innerOutput.message;
           }
         }
       }
-      outputs.add(output);
     }
 
+    outputs.addAll(Rollup.performRollup(validInputs));
+    while (outputs.size() > flowInputs.size()) {
+      outputs.remove(0);
+    }
     return outputs;
   }
 }

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.63';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.64';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupQueryBuilder.cls
+++ b/rollup/core/classes/RollupQueryBuilder.cls
@@ -97,9 +97,16 @@ public without sharing class RollupQueryBuilder {
         String whoOrWhat = fieldParts.remove(0);
         String indexer = whoOrWhat + '.Type = \'';
         String relationshipName = optionalWhereClause.substring(optionalWhereClause.indexOf(indexer) + indexer.length()).substringBefore('\'');
-        String typeOfField = String.join(fieldParts, '.');
+        Set<String> typeOfFields = new Set<String>{ String.join(fieldParts, '.').toLowerCase() };
+        for (Integer reverseIndex = fieldNames.size() - 1; reverseIndex >= 0; reverseIndex--) {
+          String possiblyRelatedField = fieldNames[reverseIndex];
+          if (possiblyRelatedField.containsIgnoreCase(whoOrWhat + '.')) {
+            fieldNames.remove(reverseIndex);
+            typeOfFields.add(possiblyRelatedField.substringAfter('.'));
+          }
+        }
 
-        fieldNames.add('TYPEOF ' + whoOrWhat + ' WHEN ' + relationshipName + ' THEN ' + typeOfField + ' END');
+        fieldNames.add('TYPEOF ' + whoOrWhat + ' WHEN ' + relationshipName + ' THEN ' + String.join(new List<String>(typeOfFields), ',') + ' END');
 
         optionalWhereClause = optionalWhereClause.replace(indexer + relationshipName + '\'', '').replace(whereClause, '');
       }

--- a/rollup/core/classes/RollupRelationshipFieldFinder.cls
+++ b/rollup/core/classes/RollupRelationshipFieldFinder.cls
@@ -23,6 +23,7 @@ public without sharing class RollupRelationshipFieldFinder {
   private List<String> relationshipParts;
   private Boolean isFirstRun = true;
   private String currentRelationshipName;
+  private Boolean isFullRecalc = false;
 
   private static final Integer MAX_FOREIGN_KEY_RELATIONSHIP_HOPS = 5;
 
@@ -176,8 +177,18 @@ public without sharing class RollupRelationshipFieldFinder {
     }
   }
 
+  public RollupRelationshipFieldFinder setIsFullRecalc(Boolean isFullRecalc) {
+    this.isFullRecalc = isFullRecalc;
+    return this;
+  }
+
   public Traversal getParents(List<SObject> records) {
-    if (records.isEmpty() || (this.relationshipParts.isEmpty() && this.metadata.RollupToUltimateParent__c == false)) {
+    if (this.isFullRecalc && this.metadata.OneToManyGrandparentFields__c == null && this.metadata.RollupToUltimateParent__c == false) {
+      // go "straight to the top" since all children will be part of the calculation
+      // the only awkward part here is we then need to do the mapping ("trackTraversalIds") all at once
+      this.getFullRecalcParents(records);
+      return this.traversal;
+    } else if (records.isEmpty() || (this.relationshipParts.isEmpty() && this.metadata.RollupToUltimateParent__c == false)) {
       this.traversal.isFinished = true;
       return this.traversal;
     } else if (Rollup.hasExceededCurrentRollupLimits(this.rollupControl) && this.isFirstRun == false) {
@@ -267,15 +278,16 @@ public without sharing class RollupRelationshipFieldFinder {
   }
 
   private Boolean isFinishedWithHierarchyTraversal(List<SObject> records) {
-    if (this.metadata.RollupToUltimateParent__c != true) {
+    if (this.metadata.RollupToUltimateParent__c != true || records.isEmpty()) {
       return true;
     }
 
     Boolean allRecordsAreTopOfHierarchy = true;
     List<SObject> finishedRecords = new List<SObject>();
+    Map<String, Schema.SObjectField> fieldMap = records.get(0).getSObjectType().getDescribe(SObjectDescribeOptions.DEFERRED).fields.getMap();
     for (Integer index = records.size() - 1; index >= 0; index--) {
       SObject record = records[index];
-      SObject parentRecord = this.getPotentialUltimateParent(record);
+      SObject parentRecord = this.getPotentialUltimateParent(record, fieldMap);
 
       if (parentRecord.get(this.metadata.UltimateParentLookup__c) == null) {
         finishedRecords.add(parentRecord);
@@ -291,8 +303,7 @@ public without sharing class RollupRelationshipFieldFinder {
     return allRecordsAreTopOfHierarchy;
   }
 
-  private SObject getPotentialUltimateParent(SObject childRecord) {
-    Map<String, Schema.SObjectField> fieldMap = childRecord.getSObjectType().getDescribe().fields.getMap();
+  private SObject getPotentialUltimateParent(SObject childRecord, Map<String, Schema.SObjectField> fieldMap) {
     this.currentRelationshipName = this.relationshipParts.size() == 1 ? this.relationshipParts[0] : this.currentRelationshipName;
     if (childRecord.getSObjectType() == this.ultimateParent) {
       this.currentRelationshipName = this.relationshipParts[this.relationshipParts.size() - 1];
@@ -302,7 +313,10 @@ public without sharing class RollupRelationshipFieldFinder {
     if (childRecord.get(this.metadata.UltimateParentLookup__c) != null && childRecord.getPopulatedFieldsAsMap().containsKey(relationshipName)) {
       SObject intermediateParent = childRecord.getSObject(relationshipName);
       this.trackTraversalIds(childRecord.Id, intermediateParent.Id, lookupField, null);
-      return this.getPotentialUltimateParent(intermediateParent);
+      return this.getPotentialUltimateParent(
+        intermediateParent,
+        intermediateParent.getSObjectType().getDescribe(SObjectDescribeOptions.DEFERRED).fields.getMap()
+      );
     }
     return childRecord;
   }
@@ -484,7 +498,7 @@ public without sharing class RollupRelationshipFieldFinder {
         if (this.oldRecords.containsKey(recordId)) {
           Id oldLookupId = (Id) this.oldRecords.get(recordId).get(field);
           if (String.isNotBlank(oldLookupId) && oldLookupId != lookupId) {
-            lookupIds.add(oldLookupId);
+            lookupIds?.add(oldLookupId);
             this.traversal.hierarchy.put(oldLookupId, new List<Id>{ oldLookupId });
           }
         }
@@ -694,6 +708,57 @@ public without sharing class RollupRelationshipFieldFinder {
       }
     }
     return null;
+  }
+
+  private void getFullRecalcParents(List<SObject> children) {
+    this.setFirstRunFlags(children);
+    if (children.isEmpty() == false) {
+      Set<String> parentFieldNames = new Set<String>{ this.metadata.GrandparentRelationshipFieldPath__c };
+      String baseGrandparentPath = this.metadata.GrandparentRelationshipFieldPath__c.substringBeforeLast('.');
+      for (String parentField : this.uniqueFinalParentFieldNames) {
+        parentFieldNames.add(baseGrandparentPath + '.' + parentField);
+      }
+      String query = RollupQueryBuilder.Current.getQuery(
+        children[0].getSObjectType(),
+        new List<String>(parentFieldNames),
+        'Id',
+        '=',
+        this.metadata.CalcItemWhereClause__c
+      );
+      List<String> splitRelationshipNames = baseGrandparentPath.split('\\.');
+      List<SObject> requeriedChildren = this.areParentFieldsAlreadySet(splitRelationshipNames, children[0])
+        ? children
+        : this.repo.setQuery(query).setArg(children).get();
+      List<SObject> finalParents = new List<SObject>();
+      for (SObject requeriedChild : requeriedChildren) {
+        List<String> copiedRelationshipNames = new List<String>(splitRelationshipNames);
+        SObject priorRelationship = requeriedChild;
+        while (copiedRelationshipNames.isEmpty() == false) {
+          SObject nextParent = priorRelationship.getSObject(copiedRelationshipNames.remove(0));
+          this.trackTraversalIds(priorRelationship.Id, nextParent.Id, null, null);
+          priorRelationship = nextParent;
+        }
+        finalParents.add(priorRelationship);
+      }
+      this.prepFinishedObject(finalParents);
+    }
+  }
+
+  private Boolean areParentFieldsAlreadySet(List<String> splitRelationshipNames, SObject firstChild) {
+    Boolean isAlreadySet = false;
+    List<String> copiedRelationshipNames = new List<String>(splitRelationshipNames);
+    SObject ref = firstChild;
+    while (copiedRelationshipNames.isEmpty() == false) {
+      ref = ref.getSObject(copiedRelationshipNames.remove(0));
+      isAlreadySet = ref != null;
+      if (isAlreadySet == false) {
+        break;
+      }
+    }
+    if (ref.getSObjectType() == this.ultimateParent && ref.isSet(this.metadata.GrandparentRelationshipFieldPath__c.substringAfterLast('.')) == false) {
+      isAlreadySet = false;
+    }
+    return isAlreadySet;
   }
 
   private class WhereClauseSorter extends RollupComparer {

--- a/rollup/core/classes/RollupRelationshipFieldFinder.cls
+++ b/rollup/core/classes/RollupRelationshipFieldFinder.cls
@@ -755,8 +755,13 @@ public without sharing class RollupRelationshipFieldFinder {
         break;
       }
     }
-    if (ref.getSObjectType() == this.ultimateParent && ref.isSet(this.metadata.GrandparentRelationshipFieldPath__c.substringAfterLast('.')) == false) {
-      isAlreadySet = false;
+    if (ref?.getSObjectType() == this.ultimateParent) {
+      try {
+        ref?.get(this.metadata.GrandparentRelationshipFieldPath__c.substringAfterLast('.'));
+        isAlreadySet = true;
+      } catch (Exception ex) {
+        isAlreadySet = false;
+      }
     }
     return isAlreadySet;
   }

--- a/rollup/core/classes/RollupSObjectUpdater.cls
+++ b/rollup/core/classes/RollupSObjectUpdater.cls
@@ -171,7 +171,7 @@ public without sharing virtual class RollupSObjectUpdater {
   }
 
   private void updateRecords(List<SObject> recordsToUpdate, Database.DMLOptions options) {
-    RollupPlugin__mdt updaterPlugin = new RollupPlugin().getInstance(UPDATER_NAME);
+    RollupPlugin__mdt updaterPlugin = this.plugin.getInstance(UPDATER_NAME);
     Type updaterType = updaterPlugin != null ? Type.forName(updaterPlugin.DeveloperName) : DefaultUpdater.class;
     ((IUpdater) updaterType.newInstance()).performUpdate(recordsToUpdate, options);
     this.forceSyncUpdate = false;

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -109,6 +109,6 @@
         "apex-rollup@1.5.61-0": "04t6g000008o01wAAA",
         "apex-rollup@1.5.62-0": "04t6g000008o0DQAAY",
         "apex-rollup@1.5.63-0": "04t6g000008o0DaAAI",
-        "apex-rollup@1.5.64-0": "04t6g000008SnWCAA0"
+        "apex-rollup@1.5.64-0": "04t6g000008SnX0AAK"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -108,6 +108,7 @@
         "apex-rollup@1.5.60-0": "04t6g000008o01XAAQ",
         "apex-rollup@1.5.61-0": "04t6g000008o01wAAA",
         "apex-rollup@1.5.62-0": "04t6g000008o0DQAAY",
-        "apex-rollup@1.5.63-0": "04t6g000008o0DaAAI"
+        "apex-rollup@1.5.63-0": "04t6g000008o0DaAAI",
+        "apex-rollup@1.5.64-0": "04t6g000008SnWCAA0"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Fixes The number of results does not match the number of interviews that were executed in a single bulk execution request issue in RollupFlowBulkProcessor",
-            "versionNumber": "1.5.63.0",
+            "versionName": "Grandparent full recalc rollup optimizations",
+            "versionNumber": "1.5.64.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
* Optimizes number of queries performed for full recalc grandparent rollups, which prevents the need to re-query the entire chain of objects between children and the parent records (since we already are starting with all children in a full recalc) care of #414 
* Optimizes `RollupFlowBulkProcessor` to consume less in the way of `Rollup__mdt` queries
* Optimizes `RollupCalcItemReplacer` to avoid calling some methods when there are no fields to replace