### PR TITLE
v1.5.65 - Support for Validation Rule Exclusions on Apex Rollup Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnX0AAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnXoAAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnX0AAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnXoAAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -1064,7 +1064,17 @@ You can use the included `Rollup Plugin Parameter` CMDT record `Logging Debug Le
 
 ### Other Rollup Plugins
 
-- To perform additional post-processing on the newly updated parent records, a ["callback" plugin](plugins/RollupCallback) is also now available as a 2GP unmanaged package. For more information, check out [the Readme](plugins/RollupCallback), as there are a variety of options available when it comes to post-processing.
+- To perform additional asynchronous post-processing on the newly updated parent records, a ["callback" plugin](plugins/RollupCallback) is also now available as a 2GP unmanaged package. For more information, check out [the Readme](plugins/RollupCallback), as there are a variety of options available when it comes to post-processing.
+
+- To customize the `Database.DMLOptions` before records are updated, or to perform additional synchronous pre & post-processing on the newly updated parent records, you can add a Rollup Plugin Parameter CMDT record linked to the `Rollup Pre And Post Updater` Rollup Plugin record. By default, an implementation is included if your org would like to exclude rollup updates from being considered in validation rules by using `$Setup.RollupSettings__c.BypassValidationRules__c = false`, as this value will only be true when Apex Rollup is updating records. To use the default implementation, set the Value for the Plugin Parameter record linked to the Pre/Post Updater plugin to `RollupSObjectUpdater.PreAndPostUpdater` (or the namespaced version of that class name, `please.RollupSObjectUpdater.PreAndPostUpdater` if you are using the namespaced version of Apex Rollup). Otherwise, you can provide your own implementation so long as it implements `RollupSObjectUpdater.IPrePostUpdater` (or `please.RollupSObjectUpdater.IPrePostUpdater` for the namespaced version):
+
+```java
+// in RollupSObjectUpdater
+global interface IPrePostUpdater {
+  void preUpdate(List<SObject> recordsToUpdate, Database.DMLOptions options);
+  void postUpdate(List<SObject> recordsToUpate);
+}
+```
 
 - If you need to generate additional test code coverage for `apex-rollup` (which might be necessary in a highly declarative org), you can install the [Extra Code Coverage plugin](plugins/ExtraCodeCoverage), which automatically gets updated any time I make changes to tests here.
 

--- a/extra-tests/classes/RollupSObjectUpdaterTests.cls
+++ b/extra-tests/classes/RollupSObjectUpdaterTests.cls
@@ -149,6 +149,24 @@ public class RollupSObjectUpdaterTests {
     System.assertEquals(2, mockUpdatedRecords.size());
   }
 
+  @IsTest
+  static void updatesSettingsWhenPreAndPostUpdaterIsUsed() {
+    upsert new RollupSettings__c();
+    RollupSettings__c initial = RollupSettings__c.getInstance();
+
+    waitSeconds(1);
+    RollupSObjectUpdater.UPDATER_NAME = MockUpdater.class.getName();
+    RollupPlugin.parameterMock = new RollupPluginParameter__mdt(
+      Value__c = RollupSObjectUpdater.class.getName() + '.' + 'PreAndPostUpdater',
+      RollupPlugin__c = RollupPlugin__mdt.getInstance(RollupSObjectUpdater.PRE_AND_POST_UPDATER_NAME).Id
+    );
+    RollupSObjectUpdater updater = new RollupSObjectUpdater();
+    updater.forceSyncUpdate();
+    updater.doUpdate(new List<SObject>{ new Account() });
+
+    System.assertNotEquals(initial, RollupSettings__c.getInstance());
+  }
+
   public class MockUpdater implements RollupSObjectUpdater.IUpdater {
     public void performUpdate(List<SObject> recordsToUpdate, Database.DMLOptions options) {
       mockUpdatedRecords = recordsToUpdate;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.64",
+  "version": "1.5.65",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnX5AAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnXtAAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnX5AAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnXtAAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Grandparent full recalc rollup optimizations",
-            "versionNumber": "1.0.37.0",
+            "versionName": "Adding RollupSettings__c.BypassValidationRules__c custom setting field to reference in validation rules",
+            "versionNumber": "1.0.38.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -31,6 +31,7 @@
         "apex-rollup-namespaced@1.0.34-0": "04t6g000008o021AAA",
         "apex-rollup-namespaced@1.0.35-0": "04t6g000008o0DVAAY",
         "apex-rollup-namespaced@1.0.36-0": "04t6g000008o0DfAAI",
-        "apex-rollup-namespaced@1.0.37-0": "04t6g000008SnX5AAK"
+        "apex-rollup-namespaced@1.0.37-0": "04t6g000008SnX5AAK",
+        "apex-rollup-namespaced@1.0.38-0": "04t6g000008SnXtAAK"
     }
 }

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.64';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.65';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupSObjectUpdater.cls
+++ b/rollup/core/classes/RollupSObjectUpdater.cls
@@ -1,6 +1,8 @@
-public without sharing virtual class RollupSObjectUpdater {
+global without sharing virtual class RollupSObjectUpdater {
   @TestVisible
   private static String UPDATER_NAME = 'RollupCustomUpdater';
+  @TestVisible
+  private static String PRE_AND_POST_UPDATER_NAME = 'RollupPreAndPostUpdater';
   @TestVisible
   private static final String DISPATCH_NAME = 'RollupDispatch';
   private static final SObjectSorter SORTER = new SObjectSorter();
@@ -12,15 +14,20 @@ public without sharing virtual class RollupSObjectUpdater {
   private Boolean forceSyncUpdate = false;
   private RollupControl__mdt rollupControl;
 
-  public interface IDispatcher {
+  global interface IDispatcher {
     void dispatch(List<SObject> records);
   }
 
-  public interface IUpdater {
+  global interface IUpdater {
     void performUpdate(List<SObject> recordsToUpdate, Database.DMLOptions options);
   }
 
-  public RollupSObjectUpdater() {
+  global interface IPrePostUpdater {
+    void preUpdate(List<SObject> recordsToUpdate, Database.DMLOptions options);
+    void postUpdate(List<SObject> recordsToUpate);
+  }
+
+  global RollupSObjectUpdater() {
     this.plugin = new RollupPlugin();
     this.dispatchers = this.fillDispatchers();
   }
@@ -37,7 +44,7 @@ public without sharing virtual class RollupSObjectUpdater {
     this.forceSyncUpdate = true;
   }
 
-  public virtual void doUpdate(List<SObject> recordsToUpdate) {
+  global virtual void doUpdate(List<SObject> recordsToUpdate) {
     if (this.forceSyncUpdate == false && Rollup.hasExceededCurrentRollupLimits(this.rollupControl)) {
       this.performAsyncUpdate(recordsToUpdate);
       return;
@@ -82,7 +89,7 @@ public without sharing virtual class RollupSObjectUpdater {
             value = Datetime.parse((String) value);
           }
         }
-        when Date {
+        when DATE {
           if (value instanceof Datetime) {
             value = ((Datetime) value).dateGmt();
           } else if (valueisString) {
@@ -172,9 +179,35 @@ public without sharing virtual class RollupSObjectUpdater {
 
   private void updateRecords(List<SObject> recordsToUpdate, Database.DMLOptions options) {
     RollupPlugin__mdt updaterPlugin = this.plugin.getInstance(UPDATER_NAME);
-    Type updaterType = updaterPlugin != null ? Type.forName(updaterPlugin.DeveloperName) : DefaultUpdater.class;
-    ((IUpdater) updaterType.newInstance()).performUpdate(recordsToUpdate, options);
+    IUpdater updater = (IUpdater) this.getInstanceOrDefault(updaterPlugin?.DeveloperName, IUpdater.class, DefaultUpdater.class);
+    IPrePostUpdater preAndPostUpdater = this.getPreAndPostUpdater();
+    preAndPostUpdater?.preUpdate(recordsToUpdate, options);
+    updater.performUpdate(recordsToUpdate, options);
+    preAndPostUpdater?.postUpdate(recordsToUpdate);
     this.forceSyncUpdate = false;
+  }
+
+  private IPrePostUpdater getPreAndPostUpdater() {
+    RollupPlugin__mdt preAndPostUpdaterPlugin = this.plugin.getInstance(PRE_AND_POST_UPDATER_NAME);
+    List<RollupPluginParameter__mdt> parameters = this.plugin.getMatchingParameters(preAndPostUpdaterPlugin?.Id);
+    String typeName;
+
+    for (RollupPluginParameter__mdt param : parameters) {
+      typeName = param.Value__c;
+    }
+    return (IPrePostUpdater) this.getInstanceOrDefault(typeName, IPrePostUpdater.class, null);
+  }
+
+  private Object getInstanceOrDefault(String typeName, Type desiredType, Type defaultType) {
+    Type potentialType;
+    if (typeName != null) {
+      potentialType = Type.forName(typeName);
+    }
+    // Type.isAssignableFrom is great, but it throws instead of returning false for null
+    if (potentialType != null && desiredType.isAssignableFrom(potentialType)) {
+      return potentialType.newInstance();
+    }
+    return defaultType?.newInstance();
   }
 
   private class SObjectSorter extends RollupComparer {
@@ -213,6 +246,21 @@ public without sharing virtual class RollupSObjectUpdater {
     @SuppressWarnings('PMD.ApexCrudViolation')
     public void performUpdate(List<SObject> recordsToUpdate, Database.DMLOptions options) {
       Database.update(recordsToUpdate, options);
+    }
+  }
+
+  @SuppressWarnings('PMD.ApexCrudViolation')
+  global without sharing class PreAndPostUpdater implements IPrePostUpdater {
+    public void preUpdate(List<SObject> records, Database.DMLOptions options) {
+      RollupSettings__c settings = RollupSettings__c.getInstance();
+      settings.BypassValidationRules__c = true;
+      Database.upsert(settings, false);
+    }
+
+    public void postUpdate(List<SObject> records) {
+      RollupSettings__c settings = RollupSettings__c.getInstance();
+      settings.BypassValidationRules__c = false;
+      Database.upsert(settings, false);
     }
   }
 }

--- a/rollup/core/customMetadata/RollupPlugin.RollupPreAndPostUpdater.md-meta.xml
+++ b/rollup/core/customMetadata/RollupPlugin.RollupPreAndPostUpdater.md-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomMetadata
+  xmlns="http://soap.sforce.com/2006/04/metadata"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+>
+    <label>Rollup Pre And Post Updater</label>
+    <protected>false</protected>
+    <values>
+        <field>RollupControl__c</field>
+        <value xsi:type="xsd:string">Org_Defaults</value>
+    </values>
+</CustomMetadata>

--- a/rollup/core/objects/RollupSettings__c/fields/BypassValidationRules__c.field-meta.xml
+++ b/rollup/core/objects/RollupSettings__c/fields/BypassValidationRules__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>BypassValidationRules__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>Apex Rollup updates this field to true when updating records</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Apex Rollup updates this field to true when updating records</inlineHelpText>
+    <label>Bypass Validation Rules</label>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -109,6 +109,7 @@
         "apex-rollup@1.5.61-0": "04t6g000008o01wAAA",
         "apex-rollup@1.5.62-0": "04t6g000008o0DQAAY",
         "apex-rollup@1.5.63-0": "04t6g000008o0DaAAI",
-        "apex-rollup@1.5.64-0": "04t6g000008SnX0AAK"
+        "apex-rollup@1.5.64-0": "04t6g000008SnX0AAK",
+        "apex-rollup@1.5.65-0": "04t6g000008SnXoAAK"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Grandparent full recalc rollup optimizations",
-            "versionNumber": "1.5.64.0",
+            "versionName": "TODO",
+            "versionNumber": "1.5.65.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "TODO",
+            "versionName": "Adding RollupSettings__c.BypassValidationRules__c custom setting field to reference in validation rules",
             "versionNumber": "1.5.65.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",


### PR DESCRIPTION
* Fixes #440 by including an internal, opt-in plugin, which updates .RollupSettings__c.BypassValidationRules__c so that validation rules can make exceptions for when Apex Rollup is the one updating records. For more info, see the `Rollup Plugins` section of the README - this (internally included) plugin allows subscribers to pre/post-process record synchronously, allowing for:
  * additional updates to the `Database.DMLOptions` that Apex Rollup uses to be made pre-update
  * any additional pre-processing _before_ parent records are updated can be made
  * any additional post-processing that you would prefer to do synchronously on parent records can be made (I recommend using the Rollup Callback plugin to respond to updates in an asynchronous fashion, but it's always good to have options!). Keep in mind that hooking into post-processing using the synchronous version means that CPU and heap limits from Apex Rollup's processing will still be in effect. 