### PR TITLE
v1.5.66 - Small Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnXoAAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SneHAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnXoAAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SneHAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupCalculatorTests.cls
+++ b/extra-tests/classes/RollupCalculatorTests.cls
@@ -1477,28 +1477,6 @@ private class RollupCalculatorTests {
   // Factory tests
 
   @IsTest
-  static void shouldThrowExceptionIfTypeNotSupported() {
-    Exception ex;
-
-    try {
-      RollupCalculator calc = getCalculator(
-        Blob.valueOf(''), // unsupported type
-        Rollup.Op.CONCAT,
-        Opportunity.Name,
-        QuickText.Channel,
-        new Rollup__mdt(),
-        RollupTestUtils.createId(QuickText.SObjectType),
-        QuickText.Name
-      );
-      calc.getReturnValue();
-    } catch (Exception e) {
-      ex = e;
-    }
-
-    System.assertNotEquals(null, ex, 'Exception should have been thrown');
-  }
-
-  @IsTest
   static void shouldNotMixReturnTypesWithBigDecimalUnsortableValues() {
     RollupCalculator calc = getCalculator(
       0,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.65",
+  "version": "1.5.66",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnXtAAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SneMAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnXtAAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SneMAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Adding RollupSettings__c.BypassValidationRules__c custom setting field to reference in validation rules",
-            "versionNumber": "1.0.38.0",
+            "versionName": "Slight cleanup on RollupOrderBy__mdt transformations",
+            "versionNumber": "1.0.39.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -32,6 +32,7 @@
         "apex-rollup-namespaced@1.0.35-0": "04t6g000008o0DVAAY",
         "apex-rollup-namespaced@1.0.36-0": "04t6g000008o0DfAAI",
         "apex-rollup-namespaced@1.0.37-0": "04t6g000008SnX5AAK",
-        "apex-rollup-namespaced@1.0.38-0": "04t6g000008SnXtAAK"
+        "apex-rollup-namespaced@1.0.38-0": "04t6g000008SnXtAAK",
+        "apex-rollup-namespaced@1.0.39-0": "04t6g000008SneMAAS"
     }
 }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1751,7 +1751,7 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
       }
     }
     String childrenJson = '"' + orderByRelationshipName + '" : ' + JSON.serialize(new ChildrenSObject(children));
-    serializedMeta = serializedMeta += ',' + childrenJson + '}';
+    serializedMeta += ',' + childrenJson + '}';
 
     return (Rollup__mdt) JSON.deserialize(serializedMeta, Rollup__mdt.class);
   }

--- a/rollup/core/classes/RollupCalculator.cls
+++ b/rollup/core/classes/RollupCalculator.cls
@@ -515,7 +515,9 @@ public without sharing abstract class RollupCalculator {
 
     public virtual override void setDefaultValues(String lookupRecordKey, Object priorVal) {
       super.setDefaultValues(lookupRecordKey, priorVal);
-      this.returnDecimal = (Decimal) this.returnVal;
+      if (this.returnVal instanceof Decimal) {
+        this.returnDecimal = (Decimal) this.returnVal;
+      }
     }
 
     protected virtual Decimal getDecimalOrDefault(Object potentiallyUnitializedDecimal) {
@@ -871,7 +873,9 @@ public without sharing abstract class RollupCalculator {
 
     public virtual override void setDefaultValues(String lookupRecordKey, Object priorVal) {
       super.setDefaultValues(lookupRecordKey, isConcatDistinct(this.op) ? '' : priorVal);
-      this.stringVal = (String) this.returnVal;
+      if (this.returnVal instanceof String) {
+        this.stringVal = (String) this.returnVal;
+      }
     }
 
     protected override void setReturnValue() {

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.65';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.66';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -110,6 +110,7 @@
         "apex-rollup@1.5.62-0": "04t6g000008o0DQAAY",
         "apex-rollup@1.5.63-0": "04t6g000008o0DaAAI",
         "apex-rollup@1.5.64-0": "04t6g000008SnX0AAK",
-        "apex-rollup@1.5.65-0": "04t6g000008SnXoAAK"
+        "apex-rollup@1.5.65-0": "04t6g000008SnXoAAK",
+        "apex-rollup@1.5.66-0": "04t6g000008SneHAAS"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Adding RollupSettings__c.BypassValidationRules__c custom setting field to reference in validation rules",
-            "versionNumber": "1.5.65.0",
+            "versionName": "Slight cleanup on RollupOrderBy__mdt transformations",
+            "versionNumber": "1.5.66.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
* Slight cleanup on some `RollupOrderBy__mdt` transformations
* Fixes an issue raised in #443 related to invalid casts being performed in `RollupCalculator`