### PR TITLE
v1.5.68 - RollupCalcItemReplacer bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SneWAAS">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnlYAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SneWAAS">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnlYAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupCalcItemReplacerTests.cls
+++ b/extra-tests/classes/RollupCalcItemReplacerTests.cls
@@ -128,10 +128,10 @@ private class RollupCalcItemReplacerTests {
     Account acc = [SELECT Id FROM Account];
 
     RollupCalcItemReplacer replacer = new RollupCalcItemReplacer(
-      new RollupControl__mdt(IsRollupLoggingEnabled__c = true, ReplaceCalcItemsAsyncWhenOverCount__c = 1)
+      new RollupControl__mdt(IsRollupLoggingEnabled__c = true, ReplaceCalcItemsAsyncWhenOverCount__c = 2)
     );
     acc = (Account) replacer.replace(
-      new List<Account>{ acc },
+      new List<Account>{ acc, acc },
       new List<Rollup__mdt>{ new Rollup__mdt(CalcItemWhereClause__c = 'AnnualRevenue != 0', CalcItem__c = 'Account') }
     )[0];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.67",
+  "version": "1.5.68",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnebAAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnldAAC">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnebAAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008SnldAAC">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Slight cleanup on RollupOrderBy__mdt transformations",
-            "versionNumber": "1.0.40.0",
+            "versionName": "Removed chance for row with duplicate Id possibility in RollupCalcItemReplacer",
+            "versionNumber": "1.0.41.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -34,6 +34,7 @@
         "apex-rollup-namespaced@1.0.37-0": "04t6g000008SnX5AAK",
         "apex-rollup-namespaced@1.0.38-0": "04t6g000008SnXtAAK",
         "apex-rollup-namespaced@1.0.39-0": "04t6g000008SneMAAS",
-        "apex-rollup-namespaced@1.0.40-0": "04t6g000008SnebAAC"
+        "apex-rollup-namespaced@1.0.40-0": "04t6g000008SnebAAC",
+        "apex-rollup-namespaced@1.0.41-0": "04t6g000008SnldAAC"
     }
 }

--- a/rollup/core/classes/RollupCalcItemReplacer.cls
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls
@@ -135,7 +135,10 @@ public without sharing class RollupCalcItemReplacer {
     if (calcItems.isEmpty()) {
       return calcItems;
     }
-    Map<Id, SObject> idToCalcItem = new Map<Id, SObject>(calcItems);
+    Map<Id, SObject> idToCalcItem = new Map<Id, SObject>();
+    for (SObject calcItem : calcItems) {
+      idToCalcItem.put(calcItem.Id, calcItem);
+    }
     Set<String> baseFields = this.baseQueryFields.get(calcItems[0].getSObjectType());
     if (baseFields?.isEmpty() == false) {
       SObject firstItem = calcItems[0];

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.67';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.68';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Slight cleanup on RollupOrderBy__mdt transformations",
-            "versionNumber": "1.5.67.0",
+            "versionName": "Removed chance for row with duplicate Id possibility in RollupCalcItemReplacer",
+            "versionNumber": "1.5.68.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -104,6 +104,7 @@
         "apex-rollup@1.5.64-0": "04t6g000008SnX0AAK",
         "apex-rollup@1.5.65-0": "04t6g000008SnXoAAK",
         "apex-rollup@1.5.66-0": "04t6g000008SneHAAS",
-        "apex-rollup@1.5.67-0": "04t6g000008SneWAAS"
+        "apex-rollup@1.5.67-0": "04t6g000008SneWAAS",
+        "apex-rollup@1.5.68-0": "04t6g000008SnlYAAS"
     }
 }


### PR DESCRIPTION
* Removes chance for row with duplicate Id possibility in `RollupCalcItemReplacer`, reported by @fefris