### PR TITLE
v1.5.77 - Two Batch Full Recalc Bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6iTAAS">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6iYAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6iTAAS">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6iYAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6ghAAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6iTAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6ghAAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6iTAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -1409,7 +1409,7 @@ private class RollupFullRecalcTests {
 
   @IsTest
   static void doesNotClearParentFieldsWhenFullRecalcIsDeferred() {
-    Account acc = [SELECT Id FROM Account];
+    Account acc = [SELECT Id FROM Account]; // 1 query
     acc.AnnualRevenue = acc.NumberOfEmployees = 5;
     update acc;
 
@@ -1425,7 +1425,7 @@ private class RollupFullRecalcTests {
 
     Rollup.defaultControl = new RollupControl__mdt(
       MaxLookupRowsBeforeBatching__c = 50,
-      MaxNumberOfQueries__c = 4, // set to explicitly be too low for rollup to proceed
+      MaxNumberOfQueries__c = 2, // set to explicitly be too low for rollup to proceed
       BatchChunkSize__c = 10,
       ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.Synchronous,
       IsRollupLoggingEnabled__c = true,
@@ -1481,7 +1481,7 @@ private class RollupFullRecalcTests {
 
     Rollup.defaultControl = new RollupControl__mdt(
       MaxLookupRowsBeforeBatching__c = 50,
-      MaxNumberOfQueries__c = 7, // has to be exactly the number that allows the first rollup but not the second
+      MaxNumberOfQueries__c = 2, // has to be exactly the number that allows the first rollup but not the second
       BatchChunkSize__c = 10,
       ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.Synchronous,
       IsRollupLoggingEnabled__c = true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.76",
+  "version": "1.5.77",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Memory overhead reduction and prevents stale parent values from being re-saved",
+            "versionName": "Fixes cascading issues with full recalc app, RollupParentResetProcessor improvements",
             "versionNumber": "1.0.45.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -565,6 +565,8 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
 
       SObjectType childType = RollupFieldInitializer.Current.getDescribeFromName(matchingMeta.CalcItem__c).getSObjectType();
       RollupMetadata wrappedMeta = getWrappedMeta(childType, childToMetaWrapper, matchingMeta, matchingMeta.CalcItemWhereClause__c);
+      // duplicate check to the above, but since the CalcItemWhereClause__c is modified in the original guard clause
+      // we need to wait till after that guard clause to initialize wrappedMeta
       if (possibleParentId != null) {
         wrappedMeta.recordIds.add(possibleParentId);
       }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -30,6 +30,8 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   @TestVisible
   private static Integer additionalCalcItemCount;
   private static Boolean hasAlreadyAsyncEnqueued = false;
+  @TestVisible
+  private static String stubRequestId;
 
   private enum CollectionType {
     DICTIONARY,
@@ -97,6 +99,26 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         CACHED_CALC_ITEM_LOOKUPS = new Map<Integer, Map<String, CalcItemBag>>();
       }
       return CACHED_CALC_ITEM_LOOKUPS;
+    }
+    set;
+  }
+
+  private static String currentRequestId {
+    get {
+      if (currentRequestId == null) {
+        currentRequestId = stubRequestId != null ? stubRequestId : REQUEST_ID;
+      }
+      return currentRequestId;
+    }
+    set;
+  }
+
+  private static final String REQUEST_ID {
+    get {
+      if (REQUEST_ID == null) {
+        REQUEST_ID = System.Request.getCurrent().getRequestId();
+      }
+      return REQUEST_ID;
     }
     set;
   }
@@ -725,9 +747,12 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     return this.hasParentRollupFieldBeenReset(meta.RollupFieldOnLookupObject__c, parent);
   }
 
+  /**
+   * Includes `RollupAsyncProcessor.currentRequestId` to prevent unintentional cross-batch spillover
+   */
   protected Boolean parentRollupFieldHasBeenReset(RollupAsyncProcessor processor, SObject parent) {
     return this.hasParentRollupFieldBeenReset(String.valueOf(processor.opFieldOnLookupObject), parent) ||
-      this.uniqueParentFields.contains(processor.op.name() + processor.lookupObj + processor.opFieldOnLookupObject);
+      this.uniqueParentFields.contains(processor.op.name() + processor.lookupObj + processor.opFieldOnLookupObject + currentRequestId);
   }
 
   protected void storeUniqueParentFields(Rollup__mdt meta) {

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -485,37 +485,35 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   protected List<SObject> getExistingLookupItems(Set<String> lookupKeys, RollupAsyncProcessor rollup, Set<String> uniqueQueryFieldNames) {
     if (lookupKeys.isEmpty()) {
       this.lookupItems = new List<SObject>();
-    } else if (stubParentRecords != null) {
+    } else if (stubParentRecords != null && this.lookupItems == null) {
       this.lookupItems = stubParentRecords;
-    }
-    // for Rollups that are Batchable, the lookup items are retrieved en masse in the "start" method and cached in the "execute" method
-    if (this.lookupItems != null) {
-      return this.lookupItems;
-    }
-    List<SObject> localLookupItems;
-    if (rollup.traversal != null) {
-      localLookupItems = rollup.traversal.getAllParents();
-    } else {
-      localLookupItems = new RollupRepository(rollup.accessLevel)
-        .setQuery(
-          RollupQueryBuilder.Current.getQuery(
-            rollup.lookupObj,
-            new List<String>(uniqueQueryFieldNames),
-            String.valueOf(rollup.lookupFieldOnLookupObject),
-            '='
-          ) + (this.isSingleRecordSyncUpdate(rollup) ? '\nFOR UPDATE' : '')
-        )
-        .setArg(lookupKeys)
-        .get();
-    }
-    List<SObject> recordsToReset = new List<SObject>();
-    for (SObject lookupItem : localLookupItems) {
-      if (this.parentRollupFieldHasBeenReset(rollup, lookupItem) == false) {
-        recordsToReset.add(lookupItem);
+    } else if (this.lookupItems == null) {
+      // lookup items are retrieved en masse in the "start" method for standard (not full recalc) Batch rollups, and are cached in the "execute" method
+      List<SObject> localLookupItems;
+      if (rollup.traversal != null) {
+        localLookupItems = rollup.traversal.getAllParents();
+      } else {
+        localLookupItems = new RollupRepository(rollup.accessLevel)
+          .setQuery(
+            RollupQueryBuilder.Current.getQuery(
+              rollup.lookupObj,
+              new List<String>(uniqueQueryFieldNames),
+              String.valueOf(rollup.lookupFieldOnLookupObject),
+              '='
+            ) + (this.isSingleRecordSyncUpdate(rollup) ? '\nFOR UPDATE' : '')
+          )
+          .setArg(lookupKeys)
+          .get();
       }
+      List<SObject> recordsToReset = new List<SObject>();
+      for (SObject lookupItem : localLookupItems) {
+        if (this.parentRollupFieldHasBeenReset(rollup, lookupItem) == false) {
+          recordsToReset.add(lookupItem);
+        }
+      }
+      this.lookupItems = localLookupItems;
+      this.fullRecalcProcessor?.processParentFieldsToReset(recordsToReset);
     }
-    this.lookupItems = localLookupItems;
-    this.fullRecalcProcessor?.processParentFieldsToReset(recordsToReset);
     return this.lookupItems;
   }
 
@@ -777,8 +775,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
   private Boolean isValidAdditionalCalcItemRetrieval(RollupAsyncProcessor roll) {
     if (roll.fullRecalcProcessor != null) {
-      // if we aren't batching, safe to assume a full recalc has already pulled the rest of the records back
-      return roll.fullRecalcProcessor.isBatch() != true;
+      return false;
     } else {
       return roll.isFullRecalc || roll.metadata.IsFullRecordSet__c == true;
     }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -30,8 +30,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   @TestVisible
   private static Integer additionalCalcItemCount;
   private static Boolean hasAlreadyAsyncEnqueued = false;
-  @TestVisible
-  private static String stubRequestId;
 
   private enum CollectionType {
     DICTIONARY,
@@ -99,16 +97,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         CACHED_CALC_ITEM_LOOKUPS = new Map<Integer, Map<String, CalcItemBag>>();
       }
       return CACHED_CALC_ITEM_LOOKUPS;
-    }
-    set;
-  }
-
-  private static String currentRequestId {
-    get {
-      if (currentRequestId == null) {
-        currentRequestId = stubRequestId != null ? stubRequestId : REQUEST_ID;
-      }
-      return currentRequestId;
     }
     set;
   }
@@ -747,17 +735,14 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     return this.hasParentRollupFieldBeenReset(meta.RollupFieldOnLookupObject__c, parent);
   }
 
-  /**
-   * Includes `RollupAsyncProcessor.currentRequestId` to prevent unintentional cross-batch spillover
-   */
   protected Boolean parentRollupFieldHasBeenReset(RollupAsyncProcessor processor, SObject parent) {
     return this.hasParentRollupFieldBeenReset(String.valueOf(processor.opFieldOnLookupObject), parent) ||
-      this.uniqueParentFields.contains(processor.op.name() + processor.lookupObj + processor.opFieldOnLookupObject + currentRequestId);
+      this.uniqueParentFields.contains(this.getUniqueParentKey(processor.metadata));
   }
 
   protected void storeUniqueParentFields(Rollup__mdt meta) {
     if (meta != null) {
-      String uniqueParentKey = meta.RollupOperation__c + meta.LookupObject__c + meta.RollupFieldOnLookupObject__c;
+      String uniqueParentKey = this.getUniqueParentKey(meta);
       this.uniqueParentFields.add(uniqueParentKey);
       this.fullRecalcProcessor?.uniqueParentFields.add(uniqueParentKey);
     }
@@ -773,6 +758,13 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
   protected virtual Boolean getCanRollupWithoutCustomSetting() {
     return this.metadata?.ShouldRunWithoutCustomSettingEnabled__c == true;
+  }
+
+  /**
+   * Includes `RollupAsyncProcessor.currentRequestId` to prevent unintentional cross-batch spillover
+   */
+  private String getUniqueParentKey(Rollup__mdt meta) {
+    return meta.RollupOperation__c + meta.LookupObject__c + meta.RollupFieldOnLookupObject__c + REQUEST_ID;
   }
 
   private void clearPreviouslyResetParents(RollupAsyncProcessor processor, SObject parent) {

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -101,17 +101,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     set;
   }
 
-  private static final String REQUEST_ID {
-    get {
-      if (REQUEST_ID == null) {
-        // https://github.com/jongpie/NebulaLogger/issues/227#issuecomment-1143086485 for more on this
-        REQUEST_ID = System.Request.getCurrent().getRequestId() + System.now().getTime();
-      }
-      return REQUEST_ID;
-    }
-    set;
-  }
-
   public static RollupAsyncProcessor getConductor(InvocationPoint invokePoint, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
     return new QueueableProcessor(invokePoint, calcItems, oldCalcItems);
   }
@@ -761,11 +750,8 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     return this.metadata?.ShouldRunWithoutCustomSettingEnabled__c == true;
   }
 
-  /**
-   * Includes `RollupAsyncProcessor.currentRequestId` to prevent unintentional cross-batch spillover
-   */
   private String getUniqueParentKey(Rollup__mdt meta) {
-    return meta.RollupOperation__c + meta.LookupObject__c + meta.RollupFieldOnLookupObject__c + REQUEST_ID;
+    return meta.RollupOperation__c + meta.LookupObject__c + meta.RollupFieldOnLookupObject__c;
   }
 
   private void clearPreviouslyResetParents(RollupAsyncProcessor processor, SObject parent) {
@@ -1422,5 +1408,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   private void cleanup() {
     RollupEvaluator.clearConditionCache();
     CACHED_CALC_ITEM_LOOKUPS = null;
+    this.uniqueParentFields.clear();
   }
 }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -971,6 +971,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       this.getAsyncRollup()?.beginAsyncRollup();
     } else if (this.rollups.isEmpty() == false) {
       this.logger.log('deferral was explicitly disallowed for rollups:', this.rollups, LoggingLevel.ERROR);
+      // this.getCachedRollups().addAll(this.rollups);
     }
   }
 

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -104,7 +104,8 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   private static final String REQUEST_ID {
     get {
       if (REQUEST_ID == null) {
-        REQUEST_ID = System.Request.getCurrent().getRequestId();
+        // https://github.com/jongpie/NebulaLogger/issues/227#issuecomment-1143086485 for more on this
+        REQUEST_ID = System.Request.getCurrent().getRequestId() + System.now().getTime();
       }
       return REQUEST_ID;
     }

--- a/rollup/core/classes/RollupDateLiteral.cls
+++ b/rollup/core/classes/RollupDateLiteral.cls
@@ -3,9 +3,7 @@ public without sharing abstract class RollupDateLiteral {
   private static final Pattern RELATIVE_LITERAL_PATTERN {
     get {
       if (RELATIVE_LITERAL_PATTERN == null) {
-        RELATIVE_LITERAL_PATTERN = Pattern.compile(
-          '(LAST_|NEXT_|)N_(DAYS|WEEKS|MONTHS|YEARS|QUARTERS|FISCAL_QUARTERS|FISCAL_YEARS)(|_AGO):\\s?\\d*'
-        );
+        RELATIVE_LITERAL_PATTERN = Pattern.compile('(LAST_|NEXT_|)N_(DAYS|WEEKS|MONTHS|YEARS|QUARTERS|FISCAL_QUARTERS|FISCAL_YEARS)(|_AGO):\\s?\\d*');
       }
       return RELATIVE_LITERAL_PATTERN;
     }
@@ -14,7 +12,7 @@ public without sharing abstract class RollupDateLiteral {
   private static final Pattern DATE_FUNCTION_PATTERN {
     get {
       if (DATE_FUNCTION_PATTERN == null) {
-        DATE_FUNCTION_PATTERN =  Pattern.compile(
+        DATE_FUNCTION_PATTERN = Pattern.compile(
           '(CALENDAR_MONTH|CALENDAR_QUARTER|CALENDAR_YEAR|DAY_IN_MONTH|DAY_IN_WEEK|DAY_IN_YEAR|DAY_ONLY|FISCAL_MONTH|' +
           'FISCAL_QUARTER|FISCAL_YEAR|HOUR_IN_DAY|WEEK_IN_MONTH|WEEK_IN_YEAR)\\(.+?\\)'
         );
@@ -425,7 +423,7 @@ public without sharing abstract class RollupDateLiteral {
   private class Next90DaysLiteral extends RollupDateLiteral {
     public Next90DaysLiteral() {
       this.ref = START_OF_TODAY.addDays(1);
-      this.bound = getRelativeDatetime(this.ref.addDays(89).date(), END_TIME);
+      this.bound = getRelativeDatetime(this.ref.addDays(89).dateGmt(), END_TIME);
     }
   }
 

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -5,7 +5,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
   private static final Set<String> POLYMORPHIC_FIELDS = new Set<String>{ 'Owner', 'Type' };
   private static final AlwaysTrueEvaluator ALWAYS_TRUE_SINGLETON = new AlwaysTrueEvaluator();
   @TestVisible
-  static String stubRequestId;
+  private static String stubRequestId;
 
   private static final Map<String, WhereFieldEvaluator> CACHED_WHERE_EVALS = new Map<String, WhereFieldEvaluator>();
   private static Map<String, Boolean> CACHED_WHERE_DECISIONS = new Map<String, Boolean>();

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.76';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.77';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupParentResetProcessor.cls
+++ b/rollup/core/classes/RollupParentResetProcessor.cls
@@ -52,7 +52,7 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
       // avoids System.LimitException: Too many queueable jobs added to the queue: { output of Limits.getQueueableJobs() }
       // down the rabbit hole we go again
       processId = this.startAsyncWork();
-    } else {
+    } else if (this.getNumberOfItems() > 0) {
       this.runSync();
     }
 

--- a/rollup/core/classes/RollupSObjectUpdater.cls
+++ b/rollup/core/classes/RollupSObjectUpdater.cls
@@ -43,8 +43,11 @@ global without sharing virtual class RollupSObjectUpdater {
   }
 
   public void updateRecords() {
-    this.doUpdate(RECORDS_TO_UPDATE.values());
+    List<SObject> recordsToUpdate = RECORDS_TO_UPDATE.values();
+    // static map has to be cleared BEFORE calling "doUpdate"
+    // otherwise any cascading rollups on the parent will cause recursion here
     RECORDS_TO_UPDATE.clear();
+    this.doUpdate(recordsToUpdate);
   }
 
   global virtual void doUpdate(List<SObject> recordsToUpdate) {
@@ -56,7 +59,7 @@ global without sharing virtual class RollupSObjectUpdater {
     // typically I wouldn't advocate for the use of a guard clause here since an empty list
     // getting updated is a no-op, but the addition of the logging item is annoying ...
     if (recordsToUpdate.isEmpty() == false) {
-      RollupLogger.Instance.log('updating the following records:', recordsToUpdate, LoggingLevel.FINE);
+      RollupLogger.Instance.log('updating ' + recordsToUpdate.size() + ' records', LoggingLevel.INFO);
       SORTER.sort(recordsToUpdate);
       Database.DMLOptions dmlOptions = new Database.DMLOptions();
       dmlOptions.AllowFieldTruncation = true;

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -102,6 +102,7 @@
         "apex-rollup@1.5.73-0": "04t6g000008So7xAAC",
         "apex-rollup@1.5.74-0": "04t6g000008So9AAAS",
         "apex-rollup@1.5.75-0": "04t6g000008KRIbAAO",
-        "apex-rollup@1.5.76-0": "04t6g000008C6ghAAC"
+        "apex-rollup@1.5.76-0": "04t6g000008C6ghAAC",
+        "apex-rollup@1.5.77-0": "04t6g000008C6iTAAS"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -103,6 +103,6 @@
         "apex-rollup@1.5.74-0": "04t6g000008So9AAAS",
         "apex-rollup@1.5.75-0": "04t6g000008KRIbAAO",
         "apex-rollup@1.5.76-0": "04t6g000008C6ghAAC",
-        "apex-rollup@1.5.77-0": "04t6g000008C6iTAAS"
+        "apex-rollup@1.5.77-0": "04t6g000008C6iYAAS"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Memory overhead reduction and prevents stale parent values from being re-saved",
-            "versionNumber": "1.5.76.0",
+            "versionName": "Fixes cascading issues with full recalc app, RollupParentResetProcessor improvements",
+            "versionNumber": "1.5.77.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
* Fixes an issue reported in #467 where parent values were not being reset properly between batches
* Fixes cascading update issue in full recalc app
* Prevents a number of extra queries being issued during full recalcs, which should speed them up _and_ prevent the full recalc app from exceeding the configured query limit (defaults to 50 queries as the max, currently)
* Small improvements made to `RollupParentResetProcessor` to prevent an unnecessary query from running
* Promoted `INFO` level logging statement back into `RollupSObjectUpdater`. Previously, this log message had been demoted to `FINEST` because it logged out all of the updated parent records; I've updated it to only log the number of parent records, which prevents it from overly contributing to heap size and is consistent with the other `INFO` level messages (which are only logged once per file)