### PR TITLE
v1.5.78 RollupAsyncProcessor.retrieveAdditionalCalcItems bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6j7AAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6jHAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6j7AAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6jHAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6iYAAS">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6j7AAC">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6iYAAS">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6j7AAC">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -1709,7 +1709,7 @@ private class RollupIntegrationTests {
     Rollup.defaultControl = new RollupControl__mdt(
       BatchChunkSize__c = 1,
       MaxRollupRetries__c = 1,
-      MaxNumberOfQueries__c = 3,
+      MaxNumberOfQueries__c = 1,
       IsRollupLoggingEnabled__c = true,
       ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.Synchronous
     );

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -1800,6 +1800,7 @@ private class RollupTests {
   @IsTest
   static void shouldMinDateOnUpdate() {
     Contact con = new Contact(LastName = 'Min date on insert test', BirthDate = System.today());
+    insert con;
     RollupAsyncProcessor.stubParentRecords = new List<SObject>{ con };
 
     Task taskOne = new Task(Subject = 'Test One', ActivityDate = con.BirthDate.addDays(-50), WhoId = con.Id);
@@ -1809,13 +1810,13 @@ private class RollupTests {
 
     RollupTestUtils.DMLMock mock = RollupTestUtils.getWhatIdMock(new List<Task>{ taskTwo }, con.Id);
     Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
-    Rollup.oldRecordsMap = new Map<Id, Task>(new List<Task>{ new Task(Id = taskTwo.Id, ActivityDate = con.BirthDate) });
+    Rollup.oldRecordsMap = new Map<Id, Task>(new List<Task>{ new Task(Id = taskTwo.Id, ActivityDate = con.BirthDate, WhoId = con.Id) });
 
     Test.startTest();
     Rollup.minFromApex(Task.ActivityDate, Task.WhoId, Contact.Id, Contact.BirthDate, Contact.SObjectType).runCalc();
     Test.stopTest();
 
-    System.assertEquals(1, mock.Records.size(), 'Records should have been populated MIN DATE AFTER_INSERT');
+    System.assertEquals(1, mock.Records.size(), 'Records should have been populated MIN DATE AFTER_UPDATE');
     System.assertEquals(taskOne.ActivityDate, con.BirthDate);
   }
 
@@ -2043,7 +2044,8 @@ private class RollupTests {
   static void shouldMinTimeOnUpdate() {
     ContactPointEmail cpe = new ContactPointEmail(
       BestTimeToContactEndTime = Time.newInstance(0, 0, 0, 0),
-      Id = RollupTestUtils.createId(ContactPointEmail.SObjectType)
+      Id = RollupTestUtils.createId(ContactPointEmail.SObjectType),
+      EmailDomain = 'io'
     );
     RollupAsyncProcessor.stubParentRecords = new List<SObject>{ cpe };
 
@@ -2059,7 +2061,9 @@ private class RollupTests {
     );
 
     RollupTestUtils.DMLMock mock = RollupTestUtils.loadMock(new List<ContactPointAddress>{ cp1, cp2 });
-    Rollup.oldRecordsMap = new Map<Id, SObject>{ cp1.Id => new ContactPointAddress(BestTimeToContactEndTime = Time.newInstance(12, 12, 12, 12), Id = cp1.Id) };
+    Rollup.oldRecordsMap = new Map<Id, SObject>{
+      cp1.Id => new ContactPointAddress(BestTimeToContactEndTime = Time.newInstance(12, 12, 12, 12), Id = cp1.Id, Name = cp1.Name)
+    };
     Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
 
     Test.startTest();
@@ -2922,5 +2926,25 @@ private class RollupTests {
     Assert.areEqual(50, acc.AnnualRevenue);
     Assert.areEqual(acc.AnnualRevenue, mock.Records.get(0).get(Account.AnnualRevenue));
     Assert.isNull(mock.Records.get(0).get(Account.NumberOfEmployees), 'Should not persist potentially stale value');
+  }
+
+  @IsTest
+  static void isNoOpWhenParentFieldIsNullOnInsert() {
+    Rollup.onlyUseMockMetadata = true;
+    ContactPointAddress cpa = new ContactPointAddress(Id = RollupTestUtils.createId(ContactPointAddress.SObjectType), PreferenceRank = 50, ParentId = null);
+    Rollup.shouldRun = true;
+    Rollup.apexContext = TriggerOperation.AFTER_INSERT;
+    Rollup.records = new List<SObject>{ cpa };
+
+    String rollupResponse = Rollup.averageFromApex(
+        ContactPointAddress.PreferenceRank,
+        ContactPointAddress.ParentId,
+        Account.Id,
+        Account.AnnualRevenue,
+        Account.SObjectType
+      )
+      .runCalc();
+
+    Assert.areEqual('no-op', rollupResponse);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.77",
+  "version": "1.5.78",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Fixes cascading issues with full recalc app, RollupParentResetProcessor improvements",
+            "versionName": "RollupAsyncProcessor.retrieveAdditionalCalcItems no longer looks for null lookup fields. Further optimizations to prevent async runs when appropriate.",
             "versionNumber": "1.0.45.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -342,8 +342,8 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
   }
 
   global virtual String runCalc() {
-    this.logger.log('no-op!', LoggingLevel.WARN);
-    return 'Not implemented';
+    this.logger.log('no-op!', LoggingLevel.INFO);
+    return 'no-op';
   }
 
   global virtual Rollup addLimit(Integer limitAmount, Schema.SObjectField calcItemRollupField) {
@@ -1856,8 +1856,10 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
     }
     Boolean hasExceededLimits = limitTester.hasExceededLimits && isDeferralAllowed;
     if (hasExceededLimits) {
-      control.IsRollupLoggingEnabled__c = true;
-      RollupLogger.Instance.updateRollupControl(control);
+      if (control.IsRollupLoggingEnabled__c == false) {
+        control.IsRollupLoggingEnabled__c = true;
+        RollupLogger.Instance.updateRollupControl(control);
+      }
       RollupLogger.Instance.log('exceeded limits:', limitTester, LoggingLevel.WARN);
     }
     return hasExceededLimits;
@@ -2728,21 +2730,22 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
       }
 
       FilterResults filterResults = filter(calcItems, oldCalcItems, eval, rollupMetadata, sObjectType, shouldFilterCalcItems);
-
-      loadRollups(
-        rollupFieldOnCalcItem,
-        calcLookupField,
-        lookupFieldOnOpObject,
-        rollupFieldOnOpObject,
-        lookupDescribe.getSObjectType(),
-        sObjectType, // child object SObjectType
-        rollupOp,
-        filterResults,
-        rollupConductor,
-        localControl,
-        rollupInvokePoint,
-        rollupMetadata
-      );
+      if (filterResults.matchingItemIds.isEmpty() == false) {
+        loadRollups(
+          rollupFieldOnCalcItem,
+          calcLookupField,
+          lookupFieldOnOpObject,
+          rollupFieldOnOpObject,
+          lookupDescribe.getSObjectType(),
+          sObjectType, // child object SObjectType
+          rollupOp,
+          filterResults,
+          rollupConductor,
+          localControl,
+          rollupInvokePoint,
+          rollupMetadata
+        );
+      }
     }
     rollupConductor.isNoOp = rollupConductor.rollups.isEmpty();
     return rollupConductor;
@@ -3029,7 +3032,13 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
     // mean inadvertently filtering the items for other rollups on the same child SObject type. Instead, we track the matching Ids
     // to avoid unintended side-effects
     for (SObject item : calcItems) {
-      if (shouldFilterCalcItems == false || results.eval.matches(item)) {
+      if (
+        metadata.IsRollupStartedFromParent__c == false &&
+        item.get(metadata.LookupFieldOnCalcItem__c) == null &&
+        oldCalcItems?.get(item.Id)?.get(metadata.LookupFieldOnCalcItem__c) == null
+      ) {
+        continue;
+      } else if (shouldFilterCalcItems == false || results.eval.matches(item)) {
         results.matchingItemIds.add(item.Id);
       } else if (oldCalcItems?.containsKey(item.Id) == true && results.eval.matches(oldCalcItems.get(item.Id))) {
         // if the where clause would exclude something, but we're in an update

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -342,7 +342,7 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
   }
 
   global virtual String runCalc() {
-    this.logger.log('no-op!', LoggingLevel.INFO);
+    this.logger.log('no-op!', this.getTypeName(), LoggingLevel.INFO);
     return 'no-op';
   }
 

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -971,7 +971,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       this.getAsyncRollup()?.beginAsyncRollup();
     } else if (this.rollups.isEmpty() == false) {
       this.logger.log('deferral was explicitly disallowed for rollups:', this.rollups, LoggingLevel.ERROR);
-      // this.getCachedRollups().addAll(this.rollups);
     }
   }
 

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -289,7 +289,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
     String rollupProcessId = this.getNoProcessId();
     String logMessage;
-    System.LoggingLevel logLevel = System.LoggingLevel.INFO;
     if (this.isNoOp) {
       logMessage = 'no-op, exiting early to avoid burning async job';
     } else if (this.rollupControl.ShouldAbortRun__c) {
@@ -297,7 +296,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     } else if (RollupSettings__c.getInstance().IsEnabled__c == false && shouldRunWithoutCustomSetting == false) {
       logMessage = String.valueOf(RollupSettings__c.SObjectType) + '.' + String.valueOf(RollupSettings__c.IsEnabled__c) + ' is false, exiting early';
     } else if (syncRollups.isEmpty() == false) {
-      this.logger.log('about to process sync rollups', logLevel);
+      this.logger.log('about to process sync rollups', System.LoggingLevel.INFO);
       this.process(syncRollups);
       logMessage = 'finished running sync rollups';
       if (this.rollups.isEmpty()) {
@@ -312,7 +311,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       rollupProcessId = this.getAsyncRollup()?.beginAsyncRollup();
     }
     if (logMessage != null) {
-      this.logger.log(logMessage, logLevel);
+      this.logger.log(logMessage, System.LoggingLevel.INFO);
       rollupProcessId = logMessage;
     }
     this.logger.save();
@@ -377,8 +376,25 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     } else if (canEnqueue) {
       roll = this.rollupControl.IsDevEdOrTrialOrg__c && this.stackDepth >= 4 ? new RollupAsyncProcessor(this) : this;
     }
+    if (roll.isNoOp && (roll instanceof RollupFullRecalcProcessor) == false) {
+      roll = new NoOpProcessor(roll.invokePoint);
+    }
 
     return roll;
+  }
+
+  public without sharing class NoOpProcessor extends RollupAsyncProcessor {
+    public NoOpProcessor(InvocationPoint invokePoint) {
+      super(invokePoint);
+    }
+
+    protected override String beginAsyncRollup() {
+      return new Rollup(this.invokePoint).runCalc();
+    }
+
+    protected override String getTypeName() {
+      return NoOpProcessor.class.getName();
+    }
   }
 
   public without sharing virtual class QueueableProcessor extends RollupAsyncProcessor implements System.Queueable {
@@ -468,7 +484,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
   }
 
-  protected String beginAsyncRollup() {
+  protected virtual String beginAsyncRollup() {
     this.isTimingOut = false;
     this.logger.log('about to start for ' + this.getTypeName(), this, LoggingLevel.INFO);
     return this.startAsyncWork();
@@ -539,6 +555,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         bag.clear();
       }
     }
+    lookupKeys.remove(null);
 
     if (lookupKeys.isEmpty()) {
       return;
@@ -1158,6 +1175,9 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       localAccessLevel = roll.accessLevel;
       if (roll.queryCount != null) {
         totalCountOfRecords += roll.queryCount;
+        continue;
+      } else if (stubParentRecords != null) {
+        totalCountOfRecords += stubParentRecords.size();
         continue;
       }
 

--- a/rollup/core/classes/RollupLimits.cls
+++ b/rollup/core/classes/RollupLimits.cls
@@ -4,7 +4,7 @@ public without sharing class RollupLimits {
   @TestVisible
   private static Integer orgAsyncJobsUsed;
 
-  private static final Integer SYNC_TIMEOUT_INTERVAL_MS = 3000;
+  private static final Integer SYNC_TIMEOUT_INTERVAL_MS = 1500;
   private static final Integer ASYNC_TIMEOUT_INTERVAL_MS = 13000;
 
   private static final Integer LIMIT_HEAP_SIZE = Limits.getLimitHeapSize();

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.77';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.78';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -103,6 +103,7 @@
         "apex-rollup@1.5.74-0": "04t6g000008So9AAAS",
         "apex-rollup@1.5.75-0": "04t6g000008KRIbAAO",
         "apex-rollup@1.5.76-0": "04t6g000008C6ghAAC",
-        "apex-rollup@1.5.77-0": "04t6g000008C6iYAAS"
+        "apex-rollup@1.5.77-0": "04t6g000008C6iYAAS",
+        "apex-rollup@1.5.78-0": "04t6g000008C6j7AAC"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -104,6 +104,6 @@
         "apex-rollup@1.5.75-0": "04t6g000008KRIbAAO",
         "apex-rollup@1.5.76-0": "04t6g000008C6ghAAC",
         "apex-rollup@1.5.77-0": "04t6g000008C6iYAAS",
-        "apex-rollup@1.5.78-0": "04t6g000008C6j7AAC"
+        "apex-rollup@1.5.78-0": "04t6g000008C6jHAAS"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Fixes cascading issues with full recalc app, RollupParentResetProcessor improvements",
-            "versionNumber": "1.5.77.0",
+            "versionName": "RollupAsyncProcessor.retrieveAdditionalCalcItems no longer looks for null lookup fields. Further optimizations to prevent async runs when appropriate.",
+            "versionNumber": "1.5.78.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
* Fixes issue raised in #467 - proper null handling in RollupAsyncProcessor.retrieveAdditionalCalcItems when lookup field is null on calc items
* Optimized even further by preventing async run entirely when there was never a lookup field set