### PR TITLE
v1.5.79 - Fixes NPE In RollupAsyncProcessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6jHAAS">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6kPAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6jHAAS">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6kPAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -2804,7 +2804,7 @@ private class RollupTests {
     RollupTestUtils.DMLMock mock = RollupTestUtils.loadMock(cpas);
     Rollup.defaultControl = new RollupControl__mdt(MaxNumberOfQueries__c = 2, BatchChunkSize__c = 1, MaxRollupRetries__c = 100);
     // start as synchronous rollup to allow for one deferral
-    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.Synchronous, MaxNumberOfQueries__c = 2);
+    Rollup.specificControl = new RollupControl__mdt(ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.Synchronous, MaxNumberOfQueries__c = 4);
     Rollup.rollupMetadata = new List<Rollup__mdt>{
       new Rollup__mdt(
         CalcItem__c = 'ContactPointAddress',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.78",
+  "version": "1.5.79",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,7 +4,7 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "RollupAsyncProcessor.retrieveAdditionalCalcItems no longer looks for null lookup fields. Further optimizations to prevent async runs when appropriate.",
+            "versionName": "Prevents null pointer exception when cascasding rollups create a no-op rollup",
             "versionNumber": "1.0.45.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -376,7 +376,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     } else if (canEnqueue) {
       roll = this.rollupControl.IsDevEdOrTrialOrg__c && this.stackDepth >= 4 ? new RollupAsyncProcessor(this) : this;
     }
-    if (roll.isNoOp && (roll instanceof RollupFullRecalcProcessor) == false) {
+    if (roll == null || (roll.isNoOp == false && (roll instanceof RollupFullRecalcProcessor) == false)) {
       roll = new NoOpProcessor(roll.invokePoint);
     }
 

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -376,7 +376,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     } else if (canEnqueue) {
       roll = this.rollupControl.IsDevEdOrTrialOrg__c && this.stackDepth >= 4 ? new RollupAsyncProcessor(this) : this;
     }
-    if (roll == null || (roll.isNoOp == false && (roll instanceof RollupFullRecalcProcessor) == false)) {
+    if (roll?.isNoOp != false && (roll instanceof RollupFullRecalcProcessor) == false) {
       roll = new NoOpProcessor(roll.invokePoint);
     }
 

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.78';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.79';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/scripts/convert-dlrs-rules-namespaced.apex
+++ b/scripts/convert-dlrs-rules-namespaced.apex
@@ -1,0 +1,143 @@
+// This script converts all DLRS rules (stored in dlrs__LookupRollupSummary2__mdt) to please__Rollup__mdt records and deploys them to the current org
+
+// Use the org defaults for all converted rules
+static final please__RollupControl__mdt ROLLUP_CONTROL = please__RollupControl__mdt.getInstance('Org_Defaults');
+
+// Prepare the converted Rollup__mdt CMDT records for deployment
+String customMetadataTypePrefix = Schema.please__Rollup__mdt.SObjectType.getDescribe().getName().replace('__mdt', '');
+Metadata.DeployContainer deployment = new Metadata.DeployContainer();
+
+// Field/Entity Definition particles in CMDT don't currently support these three objects
+// so we'll print out the info necessary to set up invocables for them if there are any matching DLRS rules
+// for those objects
+Set<String> invalidChildren = new Set<String>{
+  Event.SObjectType.getDescribe().getName(),
+  Task.SObjectType.getDescribe().getName(),
+  User.SObjectType.getDescribe().getName()
+};
+List<Map<String, String>> unmigrateableRules = new List<Map<String, String>>();
+Boolean shouldDeploy = false;
+
+for (dlrs__LookupRollupSummary2__mdt dlrsRule : dlrs__LookupRollupSummary2__mdt.getAll().values()) {
+  if (dlrsRule.dlrs__Active__c == false) {
+    // we won't migrate inactive rules
+    continue;
+  }
+
+  Metadata.CustomMetadata customMetadata = new Metadata.CustomMetadata();
+  customMetadata.fullName = customMetadataTypePrefix + '.' + dlrsRule.DeveloperName;
+  customMetadata.label = dlrsRule.MasterLabel;
+
+  String operation;
+  switch on dlrsRule.dlrs__AggregateOperation__c {
+    when 'Avg' {
+      operation = 'AVERAGE';
+    }
+    when 'Concatenate' {
+      operation = 'CONCAT';
+    }
+    when 'Concatenate Distinct' {
+      operation = 'CONCAT_DISTINCT';
+    }
+    when 'Count Distinct' {
+      operation = 'COUNT_DISTINCT';
+    }
+    when else {
+      operation = dlrsRule.dlrs__AggregateOperation__c;
+    }
+  }
+
+  if (invalidChildren.contains(dlrsRule.dlrs__ChildObject__c)) {
+    // build up a list of unmigrateable rules to assist with the creation of the flow actions
+
+    Map<String, String> unmigratableRule = new Map<String, String>();
+    unmigratableRule.put('Action label', customMetadata.label);
+    unmigratableRule.put(
+      'Records to rollup',
+      'Provide the collection of rollup records (if the rollup starts from parent records, set Is Rollup Started From Parent to {!$GlobalConstant.True})'
+    );
+    unmigratableRule.put(
+      'Prior records to rollup',
+      'A collection variable with {!$Record__Prior} in it, when using after update or after create and update flows'
+    );
+    unmigratableRule.put('Object for \"Prior records to rollup\" and \"Records to rollup\"', dlrsRule.dlrs__ChildObject__c);
+
+    unmigratableRule.put('Child Object Calc Field', dlrsRule.dlrs__FieldToAggregate__c);
+    unmigratableRule.put('Child Object Lookup Field', dlrsRule.dlrs__RelationshipField__c);
+    unmigratableRule.put('Rollup Object API Name', dlrsRule.dlrs__ParentObject__c);
+    unmigratableRule.put('Rollup Object Calc Field', dlrsRule.dlrs__AggregateResultField__c);
+    unmigratableRule.put('Rollup Object Lookup Field', 'Id');
+    unmigratableRule.put('Rollup Operation', operation.toUpperCase());
+    unmigratableRule.put('Rollup Operation Context', 'INSERT / UPDATE / UPSERT / DELETE: see README for more info');
+    if (operation.startsWith('CONCAT')) {
+      unmigratableRule.put('Concat Delimiter', dlrsRule.dlrs__ConcatenateDelimiter__c);
+    }
+    if (dlrsRule.dlrs__FieldToOrderBy__c != null) {
+      unmigratableRule.put('Order By (First/Last)', dlrsRule.dlrs__FieldToOrderBy__c);
+    }
+    if (dlrsRule.dlrs__RelationshipCriteria__c != null) {
+      unmigratableRule.put('SOQL Where Clause To Exclude Calc Items', dlrsRule.dlrs__RelationshipCriteria__c);
+    }
+    unmigrateableRules.add(unmigratableRule);
+  } else {
+    // This code uses instances of Metadata.CustomMetadataValue for the deployment - not instances of Rollup__mdt
+    // So, use a map & field tokens to store the expected values - Salesforce will store the data as Rollup__mdt records when deployed
+    Map<String, Object> fieldValuesToCopy = new Map<String, Object>{
+      please__Rollup__mdt.please__CalcItem__c.getDescribe().getName() => dlrsRule.dlrs__ChildObject__c,
+      please__Rollup__mdt.please__CalcItemWhereClause__c.getDescribe().getName() => dlrsRule.dlrs__RelationshipCriteria__c,
+      please__Rollup__mdt.please__ConcatDelimiter__c.getDescribe().getName() => operation.startsWith('CONCAT') ? dlrsRule.dlrs__ConcatenateDelimiter__c : null,
+      please__Rollup__mdt.please__Description__c.getDescribe().getName() => dlrsRule.dlrs__Description__c,
+      please__Rollup__mdt.please__LimitAmount__c.getDescribe().getName() => dlrsRule.dlrs__RowLimit__c,
+      please__Rollup__mdt.please__LookupFieldOnCalcItem__c.getDescribe().getName() => dlrsRule.dlrs__RelationshipField__c,
+      please__Rollup__mdt.please__LookupFieldOnLookupObject__c.getDescribe().getName() => 'Id',
+      please__Rollup__mdt.please__LookupObject__c.getDescribe().getName() => dlrsRule.dlrs__ParentObject__c,
+      please__Rollup__mdt.please__OrderByFirstLast__c.getDescribe().getName() => dlrsRule.dlrs__FieldToOrderBy__c,
+      please__Rollup__mdt.please__RollupControl__c.getDescribe().getName() => ROLLUP_CONTROL.DeveloperName,
+      please__Rollup__mdt.please__RollupFieldOnCalcItem__c.getDescribe().getName() => dlrsRule.dlrs__FieldToAggregate__c,
+      please__Rollup__mdt.please__RollupFieldOnLookupObject__c.getDescribe().getName() => dlrsRule.dlrs__AggregateResultField__c,
+      please__Rollup__mdt.please__RollupOperation__c.getDescribe().getName() => operation.toUpperCase(),
+      please__Rollup__mdt.please__SharingMode__c.getDescribe().getName() => dlrsRule.dlrs__CalculationSharingMode__c
+
+      // Additional DLRS fields that are not supported/used by Rollup
+      // dlrs__AggregateAllRows__c
+      // dlrs__CalculationMode__c
+      // dlrs__RelationshipCriteriaFields__c
+    };
+
+    // Create the instance of Metadata.CustomMetadataValue for the current DLRS rule
+    for (String fieldName : fieldValuesToCopy.keySet()) {
+      Metadata.CustomMetadataValue customField = new Metadata.CustomMetadataValue();
+      customField.field = fieldName;
+      if (fieldName == please__Rollup__mdt.please__Description__c.getDescribe().getName()) {
+        customField.value = 'Generated by migration script:\n' + fieldValuesToCopy.get(fieldName);
+      } else {
+        customField.value = fieldValuesToCopy.get(fieldName);
+      }
+
+      customMetadata.values.add(customField);
+    }
+
+    shouldDeploy = true;
+    deployment.addMetadata(customMetadata);
+  }
+}
+
+// TODO refactor to use LOGGER constant and remove System.debug statements
+if (shouldDeploy) {
+  // Deploy the converted Rollup__mdt CMDT records - these will be treated like an upsert based on DeveloperName
+  System.debug(LoggingLevel.INFO, 'Deployment metadata==' + JSON.serialize(deployment));
+  Id jobId = Metadata.Operations.enqueueDeployment(deployment, null);
+  System.debug(LoggingLevel.INFO, 'Deployment Job ID: ' + jobId);
+} else {
+  System.debug(LoggingLevel.INFO, 'No DLRS rules to migrate, skipping metadata deploy');
+}
+
+if (unmigrateableRules.isEmpty() == false) {
+  // Debug the information necessary for rules that couldn't be created due to lack of support for certain objects
+  System.debug(LoggingLevel.INFO, 'The following DLRS rules could not be migrated, please create Rollup flow actions for them!');
+  for (Map<String, String> unmigrateableRule : unmigrateableRules) {
+    System.debug(LoggingLevel.INFO, JSON.serializePretty(unmigrateableRule));
+  }
+} else {
+  System.debug(LoggingLevel.INFO, 'All DLRS rules were migrated to Rollup metadata successfully');
+}

--- a/scripts/deactivate-converted-dlrs-rules-namespaced.apex
+++ b/scripts/deactivate-converted-dlrs-rules-namespaced.apex
@@ -25,7 +25,6 @@ for (dlrs__LookupRollupSummary2__mdt dlrsRule : dlrs__LookupRollupSummary2__mdt.
 
 if (deployment.getMetadata().isEmpty() == false) {
   // Deploy the dlrs__LookupRollupSummary2__mdt CMDT records to deactivate them - these will be treated like an upsert based on DeveloperName
-  // TODO refactor to LOGGER constant
   System.debug(LoggingLevel.INFO, 'Deployment metadata==' + JSON.serialize(deployment));
   Id jobId = Metadata.Operations.enqueueDeployment(deployment, null);
   System.debug(LoggingLevel.INFO, 'Deployment Job ID: ' + jobId);

--- a/scripts/deactivate-converted-dlrs-rules-namespaced.apex
+++ b/scripts/deactivate-converted-dlrs-rules-namespaced.apex
@@ -1,0 +1,32 @@
+// This script deactivates all DLRS rules (stored in dlrs__LookupRollupSummary2__mdt) that have been converted to please__Rollup__mdt records
+// This assumes that the records in dlrs__LookupRollupSummary2__mdt and please__Rollup__mdt have the same DeveloperName
+
+Set<String> rollupRecordDeveloperNames = please__Rollup__mdt.getAll().keySet();
+String dlrsCustomMetadataTypePrefix = Schema.dlrs__LookupRollupSummary2__mdt.SObjectType.getDescribe().getName().replace('__mdt', '');
+Metadata.DeployContainer deployment = new Metadata.DeployContainer();
+
+for (dlrs__LookupRollupSummary2__mdt dlrsRule : dlrs__LookupRollupSummary2__mdt.getAll().values()) {
+  // Skip any DLRS rules that are already inactive, or that have not been migrated to please__Rollup__mdt
+  if (dlrsRule.dlrs__Active__c == false || rollupRecordDeveloperNames.contains(dlrsRule.DeveloperName) == false) {
+    continue;
+  }
+
+  Metadata.CustomMetadataValue dlrsIsActiveField = new Metadata.CustomMetadataValue();
+  dlrsIsActiveField.field = Schema.dlrs__LookupRollupSummary2__mdt.dlrs__Active__c.getDescribe().getName();
+  dlrsIsActiveField.value = false;
+
+  Metadata.CustomMetadata dlrsCustomMetadataRecord = new Metadata.CustomMetadata();
+  dlrsCustomMetadataRecord.fullName = dlrsCustomMetadataTypePrefix + '.' + dlrsRule.DeveloperName;
+  dlrsCustomMetadataRecord.label = dlrsRule.MasterLabel;
+  dlrsCustomMetadataRecord.values.add(dlrsIsActiveField);
+
+  deployment.addMetadata(dlrsCustomMetadataRecord);
+}
+
+if (deployment.getMetadata().isEmpty() == false) {
+  // Deploy the dlrs__LookupRollupSummary2__mdt CMDT records to deactivate them - these will be treated like an upsert based on DeveloperName
+  // TODO refactor to LOGGER constant
+  System.debug(LoggingLevel.INFO, 'Deployment metadata==' + JSON.serialize(deployment));
+  Id jobId = Metadata.Operations.enqueueDeployment(deployment, null);
+  System.debug(LoggingLevel.INFO, 'Deployment Job ID: ' + jobId);
+}

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "RollupAsyncProcessor.retrieveAdditionalCalcItems no longer looks for null lookup fields. Further optimizations to prevent async runs when appropriate.",
-            "versionNumber": "1.5.78.0",
+            "versionName": "Prevents null pointer exception when cascasding rollups create a no-op rollup",
+            "versionNumber": "1.5.79.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -99,9 +99,6 @@
         "Apex Rollup - Rollup Callback@0.0.3-0": "04t6g000008Sis0AAC",
         "Nebula Logger - Core@4.8.0-NEXT-ignore-origin-method": "04t5Y0000015lslQAA",
         "apex-rollup": "0Ho6g000000TNcOCAW",
-        "apex-rollup@1.5.73-0": "04t6g000008So7xAAC",
-        "apex-rollup@1.5.74-0": "04t6g000008So9AAAS",
-        "apex-rollup@1.5.75-0": "04t6g000008KRIbAAO",
         "apex-rollup@1.5.76-0": "04t6g000008C6ghAAC",
         "apex-rollup@1.5.77-0": "04t6g000008C6iYAAS",
         "apex-rollup@1.5.78-0": "04t6g000008C6jHAAS"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -101,6 +101,7 @@
         "apex-rollup": "0Ho6g000000TNcOCAW",
         "apex-rollup@1.5.76-0": "04t6g000008C6ghAAC",
         "apex-rollup@1.5.77-0": "04t6g000008C6iYAAS",
-        "apex-rollup@1.5.78-0": "04t6g000008C6jHAAS"
+        "apex-rollup@1.5.78-0": "04t6g000008C6jHAAS",
+        "apex-rollup@1.5.79-0": "04t6g000008C6kPAAS"
     }
 }


### PR DESCRIPTION
* Prevent NPE for no-op property access in `RollupAsyncProcessor.getAsyncRollup`
* Fixes #474 by adding namespaced migration scripts for DLRS