### PR TITLE
v1.5.82 - Rollup Caboose updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6kyAAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6lXAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6kyAAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6lXAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -2607,7 +2607,7 @@ private class RollupFullRecalcTests {
   static void allowsMultipleRollupsToSameFieldWithDifferentBatches() {
     // an interesting one because it's again an implementation detail - this time,
     // of the batch "caboose" process. if the full recalc is BELOW the batch limit,
-    // the queueable will already correctly handle everything since the shared parent field will only be reset once
+    // the queueable will already correctly handle everything since the shared parent field will only be reset once.
     // batch processes, on the other hand, would otherwise simply see the existing value on the parent as something
     // that needs to be cleared out
     Rollup.defaultControl = new RollupControl__mdt(
@@ -2638,6 +2638,15 @@ private class RollupFullRecalcTests {
           RollupFieldOnLookupObject__c = 'AnnualRevenue'
         ),
         new Rollup__mdt(
+          CalcItem__c = 'ContactPointAddress',
+          LookupFieldOnCalcItem__c = 'ParentId',
+          RollupFieldOnCalcItem__c = 'PreferenceRank',
+          RollupOperation__c = 'MIN',
+          LookupObject__c = 'Account',
+          LookupFieldOnLookupObject__c = 'Id',
+          RollupFieldOnLookupObject__c = 'NumberOfEmployees'
+        ),
+        new Rollup__mdt(
           CalcItem__c = 'Opportunity',
           LookupFieldOnCalcItem__c = 'AccountId',
           RollupFieldOnCalcItem__c = 'Amount',
@@ -2656,8 +2665,9 @@ private class RollupFullRecalcTests {
       [SELECT COUNT() FROM AsyncApexJob WHERE JobType = 'BatchApexWorker' AND ApexClass.Name = :getNamespaceSafeClassName(RollupFullBatchRecalculator.class)],
       'Test requires batch apex to have been the full recalc mechanism'
     );
-    parent = [SELECT AnnualRevenue FROM Account WHERE Id = :parent.Id];
+    parent = [SELECT AnnualRevenue, NumberOfEmployees FROM Account WHERE Id = :parent.Id];
     Assert.areEqual(40, parent.AnnualRevenue, 'Both children types should have correctly summed to one field in batch recalc');
+    Assert.areEqual(25, parent.NumberOfEmployees, 'Additional field on parent should have been queried successfully in second rollup');
   }
 
   @IsTest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.5.81",
+  "version": "1.5.82",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6l3AAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6lcAAC">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6l3AAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6lcAAC">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Actual NPE fix",
-            "versionNumber": "1.0.46.0",
+            "versionName": "Reducing heap size",
+            "versionNumber": "1.0.47.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -26,6 +26,7 @@
         "apex-rollup-namespaced@1.0.43-0": "04t6g000008SnrcAAC",
         "apex-rollup-namespaced@1.0.44-0": "04t6g000008So66AAC",
         "apex-rollup-namespaced@1.0.45-0": "04t6g000008C6koAAC",
-        "apex-rollup-namespaced@1.0.46-0": "04t6g000008C6l3AAC"
+        "apex-rollup-namespaced@1.0.46-0": "04t6g000008C6l3AAC",
+        "apex-rollup-namespaced@1.0.47-0": "04t6g000008C6lcAAC"
     }
 }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -154,8 +154,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     this.calcItemReplacer = innerRollup.calcItemReplacer;
     this.lookupItems = innerRollup.lookupItems;
     this.previouslyResetParents.addAll(innerRollup.getPreviouslyResetParents());
-    this.calcObjectToUniqueFieldNames = innerRollup.calcObjectToUniqueFieldNames;
-    this.lookupObjectToUniqueFieldNames = innerRollup.lookupObjectToUniqueFieldNames;
   }
 
   // Inner rollup constructor - a rollup solely concerned with calculations
@@ -982,6 +980,8 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     this.rollups.addAll(this.deferredRollups);
     this.deferredRollups.clear();
     this.isTimingOut = false;
+    this.lookupObjectToUniqueFieldNames = null;
+    this.calcObjectToUniqueFieldNames = null;
 
     if (isDeferralAllowed) {
       this.logger.log('deferred rollups remaining:', this.rollups, LoggingLevel.INFO);
@@ -999,11 +999,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   private void populateObjectFields(List<RollupAsyncProcessor> rollups) {
-    if (this.lookupObjectToUniqueFieldNames != null) {
-      return;
+    if (this.lookupObjectToUniqueFieldNames == null) {
+      this.lookupObjectToUniqueFieldNames = new Map<SObjectType, Set<String>>();
+      this.calcObjectToUniqueFieldNames = new Map<SObjectType, Set<String>>();
     }
-    this.lookupObjectToUniqueFieldNames = new Map<SObjectType, Set<String>>();
-    this.calcObjectToUniqueFieldNames = new Map<SObjectType, Set<String>>();
     List<Rollup__mdt> combinedMeta = new List<Rollup__mdt>();
     for (RollupAsyncProcessor roll : rollups) {
       if (roll.lookupObj == null) {

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -1024,11 +1024,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         childFieldsToAdd.add(orderBy.FieldName__c);
       }
       this.mapFields(this.calcObjectToUniqueFieldNames, roll.calcItemType, childFieldsToAdd);
-
-      if (this.fullRecalcProcessor != null) {
-        this.fullRecalcProcessor.calcObjectToUniqueFieldNames = this.calcObjectToUniqueFieldNames;
-        this.fullRecalcProcessor.lookupObjectToUniqueFieldNames = this.lookupObjectToUniqueFieldNames;
-      }
     }
 
     if (this.calcItems != null && this.calcItemReplacer?.hasProcessedMetadata(combinedMeta, this.calcItems) == false) {

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.5.81';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.5.82';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Actual NPE fix",
-            "versionNumber": "1.5.81.0",
+            "versionName": "Reducing heap size",
+            "versionNumber": "1.5.82.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -104,6 +104,7 @@
         "apex-rollup@1.5.78-0": "04t6g000008C6jHAAS",
         "apex-rollup@1.5.79-0": "04t6g000008C6kPAAS",
         "apex-rollup@1.5.80-0": "04t6g000008C6kjAAC",
-        "apex-rollup@1.5.81-0": "04t6g000008C6kyAAC"
+        "apex-rollup@1.5.81-0": "04t6g000008C6kyAAC",
+        "apex-rollup@1.5.82-0": "04t6g000008C6lXAAS"
     }
 }


### PR DESCRIPTION
* Heap reductions/optimizations with regards to how unexpected full recalcs (which populate rollup cabooses) store field-level data about parent/child query fields