### PR TITLE
refactor: All CMDT layouts top sections tab L-R

### DIFF
--- a/rollup/core/layouts/RollupControl__mdt-Rollup Control Layout.layout-meta.xml
+++ b/rollup/core/layouts/RollupControl__mdt-Rollup Control Layout.layout-meta.xml
@@ -49,7 +49,7 @@
                 <field>IsMergeReparentingEnabled__c</field>
             </layoutItems>
         </layoutColumns>
-        <style>TwoColumnsTopToBottom</style>
+        <style>TwoColumnsLeftToRight</style>
     </layoutSections>
     <layoutSections>
         <customLabel>true</customLabel>

--- a/rollup/core/layouts/RollupOrderBy__mdt-Rollup Order By Layout.layout-meta.xml
+++ b/rollup/core/layouts/RollupOrderBy__mdt-Rollup Order By Layout.layout-meta.xml
@@ -29,7 +29,7 @@
                 <field>Ranking__c</field>
             </layoutItems>
         </layoutColumns>
-        <style>TwoColumnsTopToBottom</style>
+        <style>TwoColumnsLeftToRight</style>
     </layoutSections>
     <layoutSections>
         <customLabel>true</customLabel>

--- a/rollup/core/layouts/RollupPluginParameter__mdt-Rollup Plugin Parameter Layout.layout-meta.xml
+++ b/rollup/core/layouts/RollupPluginParameter__mdt-Rollup Plugin Parameter Layout.layout-meta.xml
@@ -29,7 +29,7 @@
                 <field>Description__c</field>
             </layoutItems>
         </layoutColumns>
-        <style>TwoColumnsTopToBottom</style>
+        <style>TwoColumnsLeftToRight</style>
     </layoutSections>
     <layoutSections>
         <customLabel>false</customLabel>

--- a/rollup/core/layouts/RollupPlugin__mdt-Rollup Plugin Layout.layout-meta.xml
+++ b/rollup/core/layouts/RollupPlugin__mdt-Rollup Plugin Layout.layout-meta.xml
@@ -21,7 +21,7 @@
                 <field>DeveloperName</field>
             </layoutItems>
         </layoutColumns>
-        <style>TwoColumnsTopToBottom</style>
+        <style>TwoColumnsLeftToRight</style>
     </layoutSections>
     <layoutSections>
         <customLabel>false</customLabel>


### PR DESCRIPTION
Updating the rest of the CMDT layouts to match Salesforce recommendations to have `Name` tab immediately after `Label` to facilitate refreshing the name when label is changed (by clearing name and tabbing back and forth only once).