### PR TITLE
v1.6.2 - Intermediate Grandparent Rollup bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OZwYAAW">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Oa7TAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OZwYAAW">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Oa7TAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupEvaluatorTests.cls
+++ b/extra-tests/classes/RollupEvaluatorTests.cls
@@ -1195,6 +1195,63 @@ private class RollupEvaluatorTests {
     System.assertEquals(true, eval.matches(oppFive), 'Id matches inner nested conditional!');
   }
 
+  @IsTest
+  static void nestedConditionalWorksWithInSpaces() {
+    String whereClause = 'PrivacyConsentStatus = \'Yes\' and EffectiveTo <= TODAY and Effectivefrom >= TODAY and CaptureSource in ( \'Hi\' , \'Hello\' , \'Hola\') and (Name = \'excellent\' or Name = \'stellar\')';
+
+    ContactPointConsent match1 = new ContactPointConsent(
+      PrivacyConsentStatus = 'Yes',
+      EffectiveTo = System.now().addDays(-1),
+      EffectiveFrom = System.now(),
+      CaptureSource = 'Hi',
+      Name = 'Excellent'
+    );
+    ContactPointConsent match2 = new ContactPointConsent(
+      PrivacyConsentStatus = 'Yes',
+      EffectiveTo = System.now().addDays(-1),
+      EffectiveFrom = System.now(),
+      CaptureSource = 'hello',
+      Name = 'stellar'
+    );
+    ContactPointConsent match3 = new ContactPointConsent(
+      PrivacyConsentStatus = 'Yes',
+      EffectiveTo = System.now().addDays(-1),
+      EffectiveFrom = System.now(),
+      CaptureSource = 'Hola',
+      Name = 'stellar'
+    );
+    ContactPointConsent nonMatch1 = new ContactPointConsent(
+      PrivacyConsentStatus = 'nonmatch',
+      EffectiveTo = System.now().addDays(2),
+      EffectiveFrom = System.now().addDays(-1),
+      CaptureSource = 'Hi',
+      Name = 'stellar'
+    );
+    ContactPointConsent nonMatch2 = new ContactPointConsent(
+      PrivacyConsentStatus = 'Yes',
+      EffectiveTo = System.now(),
+      EffectiveFrom = System.now().addDays(-1),
+      CaptureSource = 'nonmatch',
+      Name = 'stellar'
+    );
+    ContactPointConsent nonMatch3 = new ContactPointConsent(
+      PrivacyConsentStatus = 'Yes',
+      EffectiveTo = System.now(),
+      EffectiveFrom = System.now().addDays(-1),
+      CaptureSource = 'hi',
+      Name = 'nonmatch'
+    );
+
+    Rollup.Evaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, ContactPointConsent.SObjectType);
+
+    System.assertEquals(true, eval.matches(match1));
+    System.assertEquals(true, eval.matches(match2));
+    System.assertEquals(true, eval.matches(match3));
+    System.assertEquals(false, eval.matches(nonMatch1));
+    System.assertEquals(false, eval.matches(nonMatch2));
+    System.assertEquals(false, eval.matches(nonMatch3));
+  }
+
   private static String getSoqlCompliantDatetime(Datetime dt) {
     return dt.format('yyyy-MM-dd\'T\'HH:mm:ssZ');
   }

--- a/extra-tests/classes/RollupFlowBulkProcessorTests.cls
+++ b/extra-tests/classes/RollupFlowBulkProcessorTests.cls
@@ -125,9 +125,8 @@ private class RollupFlowBulkProcessorTests {
 
     newGrandparent = [SELECT NaicsDesc FROM Account WHERE Id = :newGrandparent.Id];
     System.assertEquals(grandchild.Name, newGrandparent.NaicsDesc);
-    // TODO - continue WIP to fully fix the reset part
-    // oldGrandparent = [SELECT NaicsDesc FROM Account WHERE Id = :oldGrandparent.Id];
-    // System.assertEquals(null, oldGrandparent.NaicsDesc, 'Old grandparent value should have been cleared');
+    oldGrandparent = [SELECT NaicsDesc FROM Account WHERE Id = :oldGrandparent.Id];
+    System.assertEquals(null, oldGrandparent.NaicsDesc, 'Old grandparent value should have been cleared');
   }
 
   @IsTest

--- a/extra-tests/classes/RollupFlowBulkProcessorTests.cls
+++ b/extra-tests/classes/RollupFlowBulkProcessorTests.cls
@@ -130,6 +130,44 @@ private class RollupFlowBulkProcessorTests {
   }
 
   @IsTest
+  static void shouldClearGrandparentForIntermediateParentDeletion() {
+    Account oldGrandparent = [SELECT Id, Name FROM Account];
+    oldGrandparent.NaicsDesc = oldGrandparent.Name;
+    update oldGrandparent;
+    Rollup.onlyUseMockMetadata = true;
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupOperation__c = 'CONCAT',
+        CalcItem__c = 'ContactPointAddress',
+        LookupObject__c = 'Account',
+        RollupFieldOnCalcItem__c = 'Name',
+        LookupFieldOnCalcItem__c = 'ContactPointPhoneId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'NaicsDesc',
+        GrandparentRelationshipFieldPath__c = 'ContactPointPhone.Parent.Name'
+      )
+    };
+    ContactPointPhone parent = new ContactPointPhone(TelephoneNumber = 'Parent Again', ParentId = oldGrandparent.Id);
+    insert parent;
+    ContactPointAddress grandchild = new ContactPointAddress(Name = 'Hello Again', ContactPointPhoneId = parent.Id);
+    insert grandchild;
+
+    delete parent;
+
+    RollupFlowBulkProcessor.FlowInput input = new RollupFlowBulkProcessor.FlowInput();
+    input.recordsToRollup = new List<SObject>{ parent };
+    input.rollupContext = 'DELETE';
+    input.deferProcessing = false;
+
+    Test.startTest();
+    RollupFlowBulkProcessor.addRollup(new List<RollupFlowBulkProcessor.FlowInput>{ input });
+    Test.stopTest();
+
+    oldGrandparent = [SELECT NaicsDesc FROM Account WHERE Id = :oldGrandparent.Id];
+    System.assertEquals(null, oldGrandparent.NaicsDesc, 'Old grandparent value should have been cleared');
+  }
+
+  @IsTest
   static void shouldProcessDeferredFlowRollups() {
     Account acc = [SELECT Id FROM Account];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OZwdAAG">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Oa7YAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OZwdAAG">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Oa7YAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Fixes wildcard support for LIKE where clauses. Adds support for intermediate rollup reparenting detection in Flow.",
-            "versionNumber": "1.1.1.0",
+            "versionName": "Intermediate grandparent reparenting/deletion now properly recalculates grandparent rollups",
+            "versionNumber": "1.1.2.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -25,6 +25,7 @@
         "apex-rollup-namespaced@1.0.52-0": "04t6g000008C72GAAS",
         "apex-rollup-namespaced@1.0.53-0": "04t6g000008C739AAC",
         "apex-rollup-namespaced@1.1.0-0": "04t6g000008C7AVAA0",
-        "apex-rollup-namespaced@1.1.1-0": "04t6g000008OZwdAAG"
+        "apex-rollup-namespaced@1.1.1-0": "04t6g000008OZwdAAG",
+        "apex-rollup-namespaced@1.1.2-0": "04t6g000008Oa7YAAS"
     }
 }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -240,7 +240,7 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
   }
 
   private class RollupMetadata {
-    public final Map<Schema.SObjectType, Set<String>> typeToOldIntermediateParents = new Map<Schema.SObjectType, Set<String>>();
+    public final Map<Schema.SObjectType, Set<Id>> typeToOldIntermediateParents = new Map<Schema.SObjectType, Set<Id>>();
     public final Set<String> recordIds = new Set<String>();
     public final Set<String> queryFields = new Set<String>();
     public final List<Rollup__mdt> metadata = new List<Rollup__mdt>();
@@ -2376,6 +2376,10 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
       fullRecalc.storeParentFieldsToClear(wrappedMeta.parentRecordsToReset);
       fullRecalc.isNoOp = false;
     }
+    if (wrappedMeta.typeToOldIntermediateParents.isEmpty() == false) {
+      fullRecalc.setOldIntermediateGrandparents(wrappedMeta.typeToOldIntermediateParents);
+      fullRecalc.isNoOp = false;
+    }
     return fullRecalc;
   }
 
@@ -2528,12 +2532,12 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
           wrapper.addRecordId(currentLookup);
           if (oldLookup != null) {
             wrapper.addRecordId(oldLookup);
-            Set<String> oldIntermediateParents = wrapper.typeToOldIntermediateParents.get(calcItem.getSObjectType());
+            Set<Id> oldIntermediateParents = wrapper.typeToOldIntermediateParents.get(calcItem.getSObjectType());
             if (oldIntermediateParents == null) {
-              oldIntermediateParents = new Set<String>();
+              oldIntermediateParents = new Set<Id>();
               wrapper.typeToOldIntermediateParents.put(calcItem.getSObjectType(), oldIntermediateParents);
             }
-            oldIntermediateParents.add(oldLookup);
+            oldIntermediateParents.add((Id) oldLookup);
           }
         }
       }
@@ -2546,7 +2550,7 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
     private String query;
     private final List<SObject> parentRecordsToReset = new List<SObject>();
     private final Set<String> recordIds = new Set<String>();
-    private final Map<Schema.SObjectType, Set<String>> typeToOldIntermediateParents = new Map<Schema.SObjectType, Set<String>>();
+    private final Map<Schema.SObjectType, Set<Id>> typeToOldIntermediateParents = new Map<Schema.SObjectType, Set<Id>>();
 
     private QueryWrapper() {
     }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -2081,7 +2081,7 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
       } else if (meta.IsRollupStartedFromParent__c) {
         queryWrapper = getParentQueryWrapper(calcItems, oldCalcItems, meta);
       } else if (isIntermediateRollupForGrandparent) {
-        queryWrapper = getIntermediateGrandparentQueryWrapper(meta, calcItems, oldCalcItems);
+        queryWrapper = getIntermediateGrandparentQueryWrapper(meta, calcItems, oldCalcItems, rollupContext);
       }
 
       if (queryWrapper?.hasQuery == true) {
@@ -2502,8 +2502,14 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
     throw ex;
   }
 
-  private static QueryWrapper getIntermediateGrandparentQueryWrapper(Rollup__mdt meta, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
-    if (isCDC || oldCalcItems?.isEmpty() != false) {
+  private static QueryWrapper getIntermediateGrandparentQueryWrapper(
+    Rollup__mdt meta,
+    List<SObject> calcItems,
+    Map<Id, SObject> oldCalcItems,
+    String rollupContext
+  ) {
+    Boolean isDelete = rollupContext.startsWithIgnoreCase('delete');
+    if (isCDC || oldCalcItems?.isEmpty() != false && isDelete == false) {
       return new QueryWrapper();
     }
 
@@ -2523,13 +2529,18 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
     }
 
     QueryWrapper wrapper = new QueryWrapper('', priorFieldPath);
+    SObject possibleOldItem = sObjectType.newSObject();
     for (SObject calcItem : calcItems) {
-      SObject oldCalcItem = oldCalcItems.get(calcItem.Id);
+      SObject oldCalcItem = isDelete ? possibleOldItem : oldCalcItems.get(calcItem.Id);
       if (oldCalcItem != null) {
         String currentLookup = (String) calcItem.get(fieldToken);
         String oldLookup = (String) oldCalcItem.get(fieldToken);
         if (currentLookup != oldLookup) {
           wrapper.addRecordId(currentLookup);
+          if (isDelete) {
+            oldLookup = currentLookup;
+            currentLookup = null;
+          }
           if (oldLookup != null) {
             wrapper.addRecordId(oldLookup);
             Set<Id> oldIntermediateParents = wrapper.typeToOldIntermediateParents.get(calcItem.getSObjectType());

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -153,7 +153,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     this.stackDepth = innerRollup.stackDepth;
     this.calcItemReplacer = innerRollup.calcItemReplacer;
     this.lookupItems = innerRollup.lookupItems;
-    this.previouslyResetParents.addAll(innerRollup.previouslyResetParents);
   }
 
   // Inner rollup constructor - a rollup solely concerned with calculations
@@ -856,6 +855,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
             roll.oldCalcItems
           )
           .setIsFullRecalc(this.isFullRecalc)
+          .setOldIntermediateGrandparents(this.fullRecalcProcessor?.getOldIntermediateGrandparents())
           .getParents(roll.calcItems);
       } else if (roll.traversal?.getIsFinished() == false) {
         roll.traversal.recommence();

--- a/rollup/core/classes/RollupDateLiteral.cls
+++ b/rollup/core/classes/RollupDateLiteral.cls
@@ -361,7 +361,7 @@ public without sharing abstract class RollupDateLiteral {
   private class ThisWeekLiteral extends RollupDateLiteral {
     public ThisWeekLiteral() {
       this.ref = getRelativeDatetime(System.today().toStartOfWeek(), START_TIME);
-      this.bound = getRelativeDatetime(this.ref.addDays(6).date(), END_TIME);
+      this.bound = getRelativeDatetime(this.ref.addDays(6).dateGmt(), END_TIME);
     }
   }
 
@@ -392,7 +392,7 @@ public without sharing abstract class RollupDateLiteral {
   private class ThisMonthLiteral extends RollupDateLiteral {
     public ThisMonthLiteral() {
       this.ref = getRelativeDatetime(System.today().toStartOfMonth(), START_TIME);
-      this.bound = offsetToFirstDay(getRelativeDatetime(this.ref.addMonths(1).date().toStartOfMonth(), END_TIME));
+      this.bound = offsetToFirstDay(getRelativeDatetime(this.ref.addMonths(1).dateGmt().toStartOfMonth(), END_TIME));
     }
   }
 

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -548,6 +548,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
           if (this.hasValues == null) {
             this.hasValues = true;
           }
+          val = val.trim();
           // coerce Boolean values to their standard representation
           if (val.equalsIgnoreCase(TRUE_VAL)) {
             val = TRUE_VAL;
@@ -556,7 +557,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
           } else if (val.equalsIgnoreCase('null')) {
             val = null;
           }
-          this.values.add(val?.trim());
+          this.values.add(val);
         }
       }
       if (this.hasValues == null) {

--- a/rollup/core/classes/RollupFullRecalcProcessor.cls
+++ b/rollup/core/classes/RollupFullRecalcProcessor.cls
@@ -132,7 +132,6 @@ global abstract without sharing class RollupFullRecalcProcessor extends RollupAs
   }
 
   protected List<RollupAsyncProcessor> getDelegatedFullRecalcRollups(List<SObject> calcItems) {
-    this.fullRecalcProcessor = this;
     for (Schema.SObjectType intermediateGrandparent : this.getOldIntermediateGrandparents().keySet()) {
       for (Id resetId : this.getOldIntermediateGrandparents().get(intermediateGrandparent)) {
         this.parentRecordsToClear.put(resetId, resetId.getSobjectType().newSObject(resetId));
@@ -144,6 +143,7 @@ global abstract without sharing class RollupFullRecalcProcessor extends RollupAs
       innerRoll.isFullRecalc = true;
       innerRoll.calcItems = calcItems;
     }
+    this.fullRecalcProcessor = this;
     return processor.rollups;
   }
 

--- a/rollup/core/classes/RollupFullRecalcProcessor.cls
+++ b/rollup/core/classes/RollupFullRecalcProcessor.cls
@@ -132,13 +132,18 @@ global abstract without sharing class RollupFullRecalcProcessor extends RollupAs
   }
 
   protected List<RollupAsyncProcessor> getDelegatedFullRecalcRollups(List<SObject> calcItems) {
+    this.fullRecalcProcessor = this;
+    for (Schema.SObjectType intermediateGrandparent : this.getOldIntermediateGrandparents().keySet()) {
+      for (Id resetId : this.getOldIntermediateGrandparents().get(intermediateGrandparent)) {
+        this.parentRecordsToClear.put(resetId, resetId.getSobjectType().newSObject(resetId));
+      }
+    }
     RollupAsyncProcessor processor = this.getAsyncRollup(this.rollupMetas, this.calcItemType, calcItems, new Map<Id, SObject>(), null, this.invokePoint);
     for (RollupAsyncProcessor innerRoll : processor.rollups) {
       innerRoll.fullRecalcProcessor = this;
       innerRoll.isFullRecalc = true;
       innerRoll.calcItems = calcItems;
     }
-    this.fullRecalcProcessor = this;
     return processor.rollups;
   }
 

--- a/rollup/core/classes/RollupFullRecalcProcessor.cls
+++ b/rollup/core/classes/RollupFullRecalcProcessor.cls
@@ -1,11 +1,12 @@
 global abstract without sharing class RollupFullRecalcProcessor extends RollupAsyncProcessor.QueueableProcessor {
   protected final List<Rollup__mdt> rollupMetas;
   protected final Set<String> objIds = new Set<String>();
+  protected String queryString;
+
   private final RollupFullRecalcProcessor postProcessor;
   private final Map<Id, SObject> parentRecordsToClear = new Map<Id, SObject>();
   private final List<RollupFullRecalcProcessor> cabooses = new List<RollupFullRecalcProcessor>();
-
-  protected String queryString;
+  private Map<Schema.SObjectType, Set<Id>> typeToOldIntermediateGrandparents;
   private Boolean hasProcessedParentRecords = false;
 
   protected RollupFullRecalcProcessor(
@@ -116,6 +117,14 @@ global abstract without sharing class RollupFullRecalcProcessor extends RollupAs
     relatedParentRecords.clear();
     relatedParentRecords.addAll(relatedParentRecordsMap.values());
     this.parentRecordsToClear.clear();
+  }
+
+  public void setOldIntermediateGrandparents(Map<Schema.SObjectType, Set<Id>> typeToOldIntermediateGrandparents) {
+    this.typeToOldIntermediateGrandparents = typeToOldIntermediateGrandparents;
+  }
+
+  public Map<Schema.SObjectType, Set<Id>> getOldIntermediateGrandparents() {
+    return this.typeToOldIntermediateGrandparents == null ? new Map<Schema.SObjectType, Set<Id>>() : this.typeToOldIntermediateGrandparents;
   }
 
   protected override RollupRepository preStart() {

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.6.2-beta';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.6.2';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.6.1';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.6.2-beta';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupRelationshipFieldFinder.cls
+++ b/rollup/core/classes/RollupRelationshipFieldFinder.cls
@@ -191,7 +191,9 @@ public without sharing class RollupRelationshipFieldFinder {
   }
 
   public RollupRelationshipFieldFinder setOldIntermediateGrandparents(Map<Schema.SObjectType, Set<Id>> typeToOldIntermediateGrandparents) {
-    this.typeToOldIntermediateGrandparents = typeToOldIntermediateGrandparents;
+    if (typeToOldIntermediateGrandparents != null) {
+      this.typeToOldIntermediateGrandparents = typeToOldIntermediateGrandparents;
+    }
     return this;
   }
 
@@ -792,14 +794,14 @@ public without sharing class RollupRelationshipFieldFinder {
       parentFieldNames.add(baseGrandparentPath + '.' + parentField);
     }
     List<String> splitRelationshipNames = baseGrandparentPath.split('\\.');
-    String query = RollupQueryBuilder.Current.getQuery(
-      children[0].getSObjectType(),
-      new List<String>(parentFieldNames),
-      'Id',
-      '=',
-      this.metadata.CalcItemWhereClause__c
-    );
     if (children.isEmpty() == false) {
+      String query = RollupQueryBuilder.Current.getQuery(
+        children[0].getSObjectType(),
+        new List<String>(parentFieldNames),
+        'Id',
+        '=',
+        this.metadata.CalcItemWhereClause__c
+      );
       List<SObject> requeriedChildren = this.areParentFieldsAlreadySet(splitRelationshipNames, children[0])
         ? children
         : this.repo.setQuery(query).setArg(children).get();
@@ -845,7 +847,7 @@ public without sharing class RollupRelationshipFieldFinder {
           // TODO handle idType == null
           if (idType == this.ultimateParent) {
             fullParentPath = splitRelationshipName + this.metadata.GrandparentRelationshipFieldPath__c.substringAfter(splitRelationshipName);
-            query = RollupQueryBuilder.Current.getQuery(
+            String query = RollupQueryBuilder.Current.getQuery(
               this.ultimateParent,
               new List<String>{ this.metadata.RollupFieldOnLookupObject__c, this.metadata.LookupFieldOnLookupObject__c },
               'Id',

--- a/rollup/core/classes/RollupRelationshipFieldFinder.cls
+++ b/rollup/core/classes/RollupRelationshipFieldFinder.cls
@@ -24,6 +24,7 @@ public without sharing class RollupRelationshipFieldFinder {
   private Boolean isFirstRun = true;
   private String currentRelationshipName;
   private Boolean isFullRecalc = false;
+  private Map<Schema.SObjectType, Set<Id>> typeToOldIntermediateGrandparents = new Map<Schema.SObjectType, Set<Id>>();
 
   private static final Integer MAX_FOREIGN_KEY_RELATIONSHIP_HOPS = 5;
 
@@ -87,6 +88,7 @@ public without sharing class RollupRelationshipFieldFinder {
     private Map<Id, List<Id>> lookupIdMap = new Map<Id, List<Id>>();
     private final Map<Id, List<Id>> hierarchy = new Map<Id, List<Id>>();
     private final RollupRelationshipFieldFinder finder;
+    private final List<SObject> oldGrandparents = new List<SObject>();
 
     private Traversal(RollupRelationshipFieldFinder finder) {
       this.finder = finder;
@@ -127,14 +129,20 @@ public without sharing class RollupRelationshipFieldFinder {
           continue;
         }
         for (SObject parentRecord : parentRecords) {
-          if (parentToLookupRecords.containsKey(parentRecord.Id)) {
-            parentToLookupRecords.get(parentRecord.Id).add(record);
-          } else {
-            Rollup.CalcItemBag bag = new Rollup.CalcItemBag(new List<SObject>{ record });
+          Rollup.CalcItemBag bag = parentToLookupRecords.get(parentRecord.Id);
+          if (bag == null) {
+            bag = new Rollup.CalcItemBag(new List<SObject>());
             bag.hasQueriedForAdditionalItems = true;
             parentToLookupRecords.put(parentRecord.Id, bag);
           }
+          bag.add(record);
         }
+      }
+      for (SObject oldGrandparent : this.oldGrandparents) {
+        Rollup.CalcItemBag bag = new Rollup.CalcItemBag(new List<SObject>());
+        bag.hasQueriedForAdditionalItems = true;
+        parentToLookupRecords.put(oldGrandparent.Id, bag);
+        this.lookupIdToFinalRecords.put(oldGrandparent.Id, new List<SObject>{ oldGrandparent });
       }
       return parentToLookupRecords;
     }
@@ -179,6 +187,11 @@ public without sharing class RollupRelationshipFieldFinder {
 
   public RollupRelationshipFieldFinder setIsFullRecalc(Boolean isFullRecalc) {
     this.isFullRecalc = isFullRecalc;
+    return this;
+  }
+
+  public RollupRelationshipFieldFinder setOldIntermediateGrandparents(Map<Schema.SObjectType, Set<Id>> typeToOldIntermediateGrandparents) {
+    this.typeToOldIntermediateGrandparents = typeToOldIntermediateGrandparents;
     return this;
   }
 
@@ -773,20 +786,20 @@ public without sharing class RollupRelationshipFieldFinder {
 
   private void getFullRecalcParents(List<SObject> children) {
     this.setFirstRunFlags(children);
+    Set<String> parentFieldNames = new Set<String>{ this.metadata.GrandparentRelationshipFieldPath__c };
+    String baseGrandparentPath = this.metadata.GrandparentRelationshipFieldPath__c.substringBeforeLast('.');
+    for (String parentField : this.uniqueFinalParentFieldNames) {
+      parentFieldNames.add(baseGrandparentPath + '.' + parentField);
+    }
+    List<String> splitRelationshipNames = baseGrandparentPath.split('\\.');
+    String query = RollupQueryBuilder.Current.getQuery(
+      children[0].getSObjectType(),
+      new List<String>(parentFieldNames),
+      'Id',
+      '=',
+      this.metadata.CalcItemWhereClause__c
+    );
     if (children.isEmpty() == false) {
-      Set<String> parentFieldNames = new Set<String>{ this.metadata.GrandparentRelationshipFieldPath__c };
-      String baseGrandparentPath = this.metadata.GrandparentRelationshipFieldPath__c.substringBeforeLast('.');
-      for (String parentField : this.uniqueFinalParentFieldNames) {
-        parentFieldNames.add(baseGrandparentPath + '.' + parentField);
-      }
-      String query = RollupQueryBuilder.Current.getQuery(
-        children[0].getSObjectType(),
-        new List<String>(parentFieldNames),
-        'Id',
-        '=',
-        this.metadata.CalcItemWhereClause__c
-      );
-      List<String> splitRelationshipNames = baseGrandparentPath.split('\\.');
       List<SObject> requeriedChildren = this.areParentFieldsAlreadySet(splitRelationshipNames, children[0])
         ? children
         : this.repo.setQuery(query).setArg(children).get();
@@ -813,6 +826,42 @@ public without sharing class RollupRelationshipFieldFinder {
         finalParents.add(priorRelationship);
       }
       this.prepFinishedObject(finalParents);
+    }
+    for (Schema.SObjectType intermediateGrandparent : this.typeToOldIntermediateGrandparents.keySet()) {
+      List<Schema.SObjectField> fields = intermediateGrandparent.getDescribe().fields.getMap().values();
+      Boolean hasFoundMatch = false;
+      String fullParentPath = '';
+      for (String splitRelationshipName : splitRelationshipNames) {
+        for (Schema.SObjectField field : fields) {
+          if (field.getDescribe().getRelationshipName() == splitRelationshipName) {
+            hasFoundMatch = true;
+            break;
+          }
+        }
+        if (hasFoundMatch) {
+          Set<Id> otherIds = this.typeToOldIntermediateGrandparents.get(intermediateGrandparent);
+          System.Iterator<Id> iterator = otherIds.iterator();
+          Schema.SObjectType idType = iterator.hasNext() ? iterator.next().getSObjectType() : null;
+          // TODO handle idType == null
+          if (idType == this.ultimateParent) {
+            fullParentPath = splitRelationshipName + this.metadata.GrandparentRelationshipFieldPath__c.substringAfter(splitRelationshipName);
+            query = RollupQueryBuilder.Current.getQuery(
+              this.ultimateParent,
+              new List<String>{ this.metadata.RollupFieldOnLookupObject__c, this.metadata.LookupFieldOnLookupObject__c },
+              'Id',
+              '=',
+              this.metadata.CalcItemWhereClause__c
+            );
+
+            List<SObject> otherPossibleGrandparents = this.repo.setQuery(query).setArg(otherIds).get();
+            for (SObject otherPossibleGrandparent : otherPossibleGrandparents) {
+              if (this.traversal.finalParentIdToRecords.containsKey(otherPossibleGrandparent.Id) == false) {
+                this.traversal.oldGrandparents.add(otherPossibleGrandparent);
+              }
+            }
+          }
+        }
+      }
     }
   }
 

--- a/rollup/core/classes/RollupSObjectUpdater.cls
+++ b/rollup/core/classes/RollupSObjectUpdater.cls
@@ -247,7 +247,18 @@ global without sharing virtual class RollupSObjectUpdater {
   private without sharing class DefaultUpdater implements IUpdater {
     @SuppressWarnings('PMD.ApexCrudViolation')
     public void performUpdate(List<SObject> recordsToUpdate, Database.DMLOptions options) {
-      Database.update(recordsToUpdate, options);
+      List<Database.SaveResult> results = Database.update(recordsToUpdate, options);
+      for (Integer index = 0; index < results.size(); index++) {
+        Database.SaveResult res = results[index];
+        if (res.isSuccess() == false) {
+          String flattenedErrorString = '';
+          for (Database.Error err : res.getErrors()) {
+            flattenedErrorString += err.getStatusCode() + ': ' + err.getMessage() + '\n';
+          }
+
+          RollupLogger.Instance.log(flattenedErrorString.removeEnd('\n'), recordsToUpdate[index], System.LoggingLevel.ERROR);
+        }
+      }
     }
   }
 

--- a/rollup/core/objects/Rollup__mdt/fields/IsFullRecordSet__c.field-meta.xml
+++ b/rollup/core/objects/Rollup__mdt/fields/IsFullRecordSet__c.field-meta.xml
@@ -3,11 +3,11 @@
     <fullName>IsFullRecordSet__c</fullName>
     <defaultValue>false</defaultValue>
     <description
-  >If the calc items you are passing in comprise the entirety of the rollup values you&apos;d like, toggle this to ensure Rollup does not abort before clearing the lookup item&apos;s rollup value</description>
+  >Turns any diff-based rollup (COUNT or SUM) into a query-based rollup that pulls back all children for any given parent</description>
     <externalId>false</externalId>
     <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
-  >If the calc items you are passing in comprise the entirety of the rollup values you&apos;d like, toggle this to ensure Rollup does not abort before clearing the lookup item&apos;s rollup value</inlineHelpText>
+  >Turns any diff-based rollup (COUNT or SUM) into a query-based rollup that pulls back all children for any given parent</inlineHelpText>
     <label>Is Full Record Set</label>
     <type>Checkbox</type>
 </CustomField>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -103,6 +103,7 @@
         "apex-rollup@1.5.88-0": "04t6g000008C734AAC",
         "apex-rollup@1.5.89-0": "04t6g000008C77gAAC",
         "apex-rollup@1.6.0-0": "04t6g000008C7AQAA0",
-        "apex-rollup@1.6.1-0": "04t6g000008OZwYAAW"
+        "apex-rollup@1.6.1-0": "04t6g000008OZwYAAW",
+        "apex-rollup@1.6.2-0": "04t6g000008Oa7TAAS"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Fixes wildcard support for LIKE where clauses. Adds support for intermediate rollup reparenting detection in Flow.",
-            "versionNumber": "1.6.1.0",
+            "versionName": "Intermediate grandparent reparenting/deletion now properly recalculates grandparent rollups",
+            "versionNumber": "1.6.2.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
* Fixes #514 by retrieving now-orphaned grandparent records when an intermediate lookup is changed and there are no further connections to the grandparent
* Fixing DST literals
* Adds additional logging to assist with #523
* Updating Is Full Record Set helptext
* Fixes #530 by detecting intermediate grandparent deletions