### PR TITLE
v1.6.7 - CDC updates

### DIFF
--- a/extra-tests/classes/RollupFlowTests.cls
+++ b/extra-tests/classes/RollupFlowTests.cls
@@ -1022,6 +1022,7 @@ private class RollupFlowTests {
     RollupAsyncProcessor.stubParentRecords = new List<SObject>{ acc };
 
     List<Rollup.FlowInput> flowInputs = RollupTestUtils.prepareFlowTest(new List<SObject>(), 'REFRESH', 'SUM');
+    flowInputs[0].recordsToRollup = null; // Get Records passes null for something that doesn't match
     flowInputs[0].parentRecordIdForEmptyChildrenCollections = acc.Id;
     flowInputs[0].calcItemTypeWhenRollupStartedFromParent = 'ContactPointAddress';
 

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -2319,7 +2319,6 @@ private class RollupTests {
 
     EventBus.ChangeEventHeader header = new EventBus.ChangeEventHeader();
     header.changeType = 'CREATE';
-    header.changedFields = new List<String>{ 'PreferenceRank', 'LastModifiedDate' };
     header.recordIds = new List<Id>{ cpa.Id };
     header.entityName = 'ContactPointAddress';
     ContactPointAddressChangeEvent ev = new ContactPointAddressChangeEvent(ChangeEventHeader = header, PreferenceRank = 500);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -30,6 +30,7 @@
         "apex-rollup-namespaced@1.1.3": "04t6g000008Oa8lAAC",
         "apex-rollup-namespaced@1.1.4": "04t6g000008Oa9ZAAS",
         "apex-rollup-namespaced@1.1.5": "04t6g000008OaAcAAK",
-        "apex-rollup-namespaced@1.1.6": "04t6g000008OaFnAAK"
+        "apex-rollup-namespaced@1.1.6": "04t6g000008OaFnAAK",
+        "apex-rollup-namespaced@1.1.7": "04t6g000008OaHPAA0"
     }
 }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1642,7 +1642,7 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
 
     // it would have been nice if this was an enum!
     switch on header.changeType {
-      when 'CREATE', 'GAP_CREATE' {
+      when 'CREATE', 'GAP_CREATE', 'UNDELETE' {
         apexContext = TriggerOperation.AFTER_INSERT;
       }
       when 'UPDATE', 'GAP_UPDATE' {

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1629,7 +1629,8 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
       return;
     }
 
-    Set<String> uniqueFieldNames = new Set<String>();
+    Set<String> uniqueFieldNames = new Set<String>(firstRecord.getPopulatedFieldsAsMap().keySet());
+    uniqueFieldNames.remove('ChangeEventHeader');
     RollupRepository.RunAsMode permissionLevel = RollupRepository.RunAsMode.SYSTEM_LEVEL;
     for (Rollup__mdt rollupInfo : matchingMetadata) {
       permissionLevel = RollupMetaPicklists.getAccessLevel(rollupInfo);

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -784,8 +784,9 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
       if (
         flowInput.parentRecordIdForEmptyChildrenCollections != null &&
         flowInput.calcItemTypeWhenRollupStartedFromParent != null &&
-        flowInput.recordsToRollup?.isEmpty() == true
+        flowInput.recordsToRollup?.isEmpty() != false
       ) {
+        flowInput.recordsToRollup = new List<SObject>();
         Schema.DescribeSObjectResult childDescribe = RollupFieldInitializer.Current.getDescribeFromName(flowInput.calcItemTypeWhenRollupStartedFromParent);
         SObject stubChild = childDescribe.getSObjectType().newSObject(childDescribe.getKeyPrefix() + '0'.repeat(12));
         stubChild.put(flowInput.lookupFieldOnCalcItem, flowInput.parentRecordIdForEmptyChildrenCollections);

--- a/rollup/core/classes/RollupFullRecalcProcessor.cls
+++ b/rollup/core/classes/RollupFullRecalcProcessor.cls
@@ -162,7 +162,7 @@ global abstract without sharing class RollupFullRecalcProcessor extends RollupAs
   protected override Boolean getCanRollupWithoutCustomSetting() {
     Boolean canRollupWithoutCustomSetting = false;
     for (Rollup__mdt rollupMeta : this.rollupMetas) {
-      canRollupWithoutCustomSetting = rollupMeta.ShouldRunWithoutCustomSettingEnabled__c == true;
+      canRollupWithoutCustomSetting = rollupMeta.ShouldRunWithoutCustomSettingEnabled__c;
       // all included rollups need to have the override enabled; if even one does NOT, we can stop
       if (canRollupWithoutCustomSetting == false) {
         break;

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.6.6';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.6.7';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Flow optimizations continued",
-            "versionNumber": "1.6.6.0",
+            "versionName": "CDC create updates",
+            "versionNumber": "1.6.7.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -108,6 +108,7 @@
         "apex-rollup@1.6.3": "04t6g000008Oa8gAAC",
         "apex-rollup@1.6.4": "04t6g000008Oa9UAAS",
         "apex-rollup@1.6.5": "04t6g000008OaAXAA0",
-        "apex-rollup@1.6.6": "04t6g000008OaFiAAK"
+        "apex-rollup@1.6.6": "04t6g000008OaFiAAK",
+        "apex-rollup@1.6.7": "04t6g000008OaHKAA0"
     }
 }


### PR DESCRIPTION
* Added support for undelete in CDC triggers
* Updated expectations in a few CDC tests to more properly align with what actually happens in the `CREATE` and `GAP_CREATE` change types
* Fixed an issue with Flow where REFRESH flows that pass Parent Record Id For Empty Children Collections with the result of a non-matching Get Records input reported by Katherine West