### PR TITLE
v1.6.9 - Fixes "No such column 'Field__c' on entity 'Object' error"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaJLAA0">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaJkAAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaJLAA0">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaJkAAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupFlowBulkProcessorTests.cls
+++ b/extra-tests/classes/RollupFlowBulkProcessorTests.cls
@@ -362,7 +362,13 @@ private class RollupFlowBulkProcessorTests {
   @IsTest
   static void shouldMapBulkFlowInputToRegularOne() {
     Rollup.rollupMetadata = new List<Rollup__mdt>{
-      new Rollup__mdt(CalcItem__c = 'Opportunity', LookupFieldOnLookupObject__c = 'Id', LookupObject__c = 'User', RollupOperation__c = 'CONCAT')
+      new Rollup__mdt(
+        CalcItem__c = 'Opportunity',
+        LookupFieldOnLookupObject__c = 'Id',
+        LookupObject__c = 'User',
+        RollupOperation__c = 'CONCAT',
+        RollupFieldOnLookupObject__c = 'AboutMe'
+      )
     };
     RollupFlowBulkProcessor.FlowInput input = new RollupFlowBulkProcessor.FlowInput();
     input.recordsToRollup = new List<SObject>{ new Opportunity(Amount = 5, Id = RollupTestUtils.createId(Opportunity.SObjectType)) };

--- a/extra-tests/classes/RollupParentResetProcessorTests.cls
+++ b/extra-tests/classes/RollupParentResetProcessorTests.cls
@@ -205,4 +205,23 @@ private class RollupParentResetProcessorTests {
     Account updatedAcc = [SELECT AnnualRevenue FROM Account WHERE Id = :acc.Id];
     System.assertEquals(originalValue, updatedAcc.AnnualRevenue);
   }
+
+  @IsTest
+  static void skipsMetadataForDifferentResetParents() {
+    insert new Account(AnnualRevenue = 5, Name = 'Should reset');
+    RollupParentResetProcessor processor = new RollupParentResetProcessor(
+      new List<Rollup__mdt>{
+        new Rollup__mdt(RollupFieldOnLookupObject__c = 'AnnualRevenue', LookupObject__c = 'Account', LookupFieldOnLookupObject__c = 'Id'),
+        new Rollup__mdt(RollupFieldOnLookupObject__c = 'FirstName', LookupObject__c = 'Contact')
+      },
+      Account.SObjectType,
+      'SELECT Id, AnnualRevenue\nFROM Account WHERE Id != null',
+      new Set<String>(),
+      null
+    );
+
+    processor.runCalc();
+
+    Assert.areEqual(null, [SELECT AnnualRevenue FROM Account].AnnualRevenue);
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaJQAA0">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaJpAAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaJQAA0">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaJpAAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Fixes null pointer exception for some rollups",
-            "versionNumber": "1.1.7.0",
+            "versionName": "Safer RollupParentResetProcessor queries",
+            "versionNumber": "1.1.8.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -31,6 +31,7 @@
         "apex-rollup-namespaced@1.1.4": "04t6g000008Oa9ZAAS",
         "apex-rollup-namespaced@1.1.5": "04t6g000008OaAcAAK",
         "apex-rollup-namespaced@1.1.6": "04t6g000008OaFnAAK",
-        "apex-rollup-namespaced@1.1.7": "04t6g000008OaJQAA0"
+        "apex-rollup-namespaced@1.1.7": "04t6g000008OaJQAA0",
+        "apex-rollup-namespaced@1.1.8": "04t6g000008OaJpAAK"
     }
 }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -2346,13 +2346,14 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
       meta.IsFullRecordSet__c = true;
       meta.RollupOperation__c = getBaseOperationName(meta.RollupOperation__c);
       rollupControlId = meta.RollupControl__c;
-      lookupFields.add(meta.LookupFieldOnLookupObject__c);
-      lookupFields.add(meta.RollupFieldOnLookupObject__c);
+      lookupFields.add(meta.LookupFieldOnLookupObject__c.toLowerCase());
+      lookupFields.add(meta.RollupFieldOnLookupObject__c.toLowerCase());
       keyField = meta.LookupFieldOnLookupObject__c;
     }
     RollupControl__mdt control = getSingleControlOrDefault(RollupControl__mdt.Id, rollupControlId, defaultControl);
     Schema.SObjectType parentType = RollupFieldInitializer.Current.getDescribeFromName(wrappedMeta.metadata[0].LookupObject__c).getSObjectType();
     String equality = invokePoint == InvocationPoint.FROM_SINGULAR_PARENT_RECALC_LWC ? '=' : '!=';
+    lookupFields.retainAll(parentType.getDescribe().fields.getMap().keyset());
     String parentQuery = RollupQueryBuilder.Current.getQuery(parentType, new List<String>(lookupFields), keyField, equality);
 
     RollupParentResetProcessor parentResetProcessor = new RollupParentResetProcessor(

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.6.8';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.6.9';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupParentResetProcessor.cls
+++ b/rollup/core/classes/RollupParentResetProcessor.cls
@@ -68,12 +68,14 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
     for (SObject parentItem : parentItems) {
       for (Rollup__mdt rollupMeta : this.rollupMetas) {
         if (
+          rollupMeta.LookupObject__c == this.calcItemType.getDescribe().getName() &&
           this.parentRollupFieldHasBeenReset(
             rollupMeta.LookupFieldOnLookupObject__c,
             parentItem,
             rollupMeta.LookupObject__c,
             rollupMeta.RollupFieldOnLookupObject__c
-          ) == false && parentFields.containsKey(rollupMeta.RollupFieldOnLookupObject__c)
+          ) == false &&
+          parentFields.containsKey(rollupMeta.RollupFieldOnLookupObject__c)
         ) {
           parentItem.put(rollupMeta.RollupFieldOnLookupObject__c, getDefaultValue(rollupMeta));
         }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup",
             "path": "rollup",
-            "versionName": "Fixes null pointer exception for some rollups",
-            "versionNumber": "1.6.8.0",
+            "versionName": "Safer RollupParentResetProcessor queries",
+            "versionNumber": "1.6.9.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -102,6 +102,7 @@
         "apex-rollup@1.6.5": "04t6g000008OaAXAA0",
         "apex-rollup@1.6.6": "04t6g000008OaFiAAK",
         "apex-rollup@1.6.7": "04t6g000008OaHKAA0",
-        "apex-rollup@1.6.8": "04t6g000008OaJLAA0"
+        "apex-rollup@1.6.8": "04t6g000008OaJLAA0",
+        "apex-rollup@1.6.9": "04t6g000008OaJkAAK"
     }
 }


### PR DESCRIPTION
* Prevents `RollupParentResetProcessor` from attempting to reset fields on different parent objects