### PR TITLE
v1.6.14 - Fixes ordering issue for batch full recalcs to multiple parents

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaUUAA0">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaYrAAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaUUAA0">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaYrAAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupFlowBulkProcessorTests.cls
+++ b/extra-tests/classes/RollupFlowBulkProcessorTests.cls
@@ -370,6 +370,7 @@ private class RollupFlowBulkProcessorTests {
         RollupFieldOnLookupObject__c = 'AboutMe'
       )
     };
+    Rollup.onlyUseMockMetadata = true;
     RollupFlowBulkProcessor.FlowInput input = new RollupFlowBulkProcessor.FlowInput();
     input.recordsToRollup = new List<SObject>{ new Opportunity(Amount = 5, Id = RollupTestUtils.createId(Opportunity.SObjectType)) };
     input.rollupContext = 'INSERT';

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -1775,6 +1775,92 @@ private class RollupFullRecalcTests {
   }
 
   @IsTest
+  static void multipleParentRollupsMultipleBatchesStoreStateProperly() {
+    Rollup.defaultControl = new RollupControl__mdt(ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.Synchronous, IsRollupLoggingEnabled__c = true);
+    Account parentA = [SELECT Id FROM Account];
+    Individual parentB = new Individual(LastName = 'Parent B');
+    Individual unrelatedParent = new Individual(LastName = 'Unrelated');
+    Opportunity parentC = new Opportunity(Name = 'Parent C', StageName = 'Test', CloseDate = System.today());
+    insert new List<SObject>{ parentB, parentC, unrelatedParent };
+
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
+      new ContactPointAddress(ParentId = parentA.Id, PreferenceRank = 1, Name = 'One A', UsageType = '1'),
+      new ContactPointAddress(ParentId = parentB.Id, PreferenceRank = 1, Name = 'One B', UsageType = '1'),
+      new ContactPointAddress(ParentId = unrelatedParent.Id, PreferenceRank = 1, Name = parentC.Id, UsageType = '1'),
+      new ContactPointAddress(ParentId = parentA.Id, PreferenceRank = 2, Name = 'Two A', UsageType = '1'),
+      new ContactPointAddress(ParentId = parentB.Id, PreferenceRank = 8, Name = 'Two B', UsageType = '1'),
+      new ContactPointAddress(ParentId = unrelatedParent.Id, PreferenceRank = 7, Name = parentC.Id, UsageType = '1'),
+      new ContactPointAddress(ParentId = parentA.Id, PreferenceRank = 3, Name = 'Three A', UsageType = '2'),
+      new ContactPointAddress(ParentId = parentB.Id, PreferenceRank = 3, Name = 'Three B', UsageType = '2'),
+      new ContactPointAddress(ParentId = unrelatedParent.Id, PreferenceRank = 2, Name = parentC.Id, UsageType = '2')
+    };
+    insert cpas;
+
+    RollupFullBatchRecalculator fullRecalc = new RollupFullBatchRecalculator(
+      'SELECT Id, PreferenceRank, ParentId, Name FROM ContactPointAddress ORDER BY ParentId, Name',
+      Rollup.InvocationPoint.FROM_FULL_RECALC_LWC,
+      new List<Rollup__mdt>{
+        new Rollup__mdt(
+          CalcItem__c = 'ContactPointAddress',
+          RollupFieldOnCalcItem__c = 'PreferenceRank',
+          LookupFieldOnCalcItem__c = 'ParentId',
+          LookupObject__c = 'Account',
+          LookupFieldOnLookupObject__c = 'Id',
+          RollupFieldOnLookupObject__c = 'AnnualRevenue',
+          RollupOperation__c = 'SUM'
+        ),
+        new Rollup__mdt(
+          CalcItem__c = 'ContactPointAddress',
+          RollupFieldOnCalcItem__c = 'PreferenceRank',
+          LookupFieldOnCalcItem__c = 'ParentId',
+          LookupObject__c = 'Individual',
+          LookupFieldOnLookupObject__c = 'Id',
+          RollupFieldOnLookupObject__c = 'ConsumerCreditScore',
+          RollupOperation__c = 'SUM'
+        ),
+        new Rollup__mdt(
+          CalcItem__c = 'ContactPointAddress',
+          RollupFieldOnCalcItem__c = 'PreferenceRank',
+          LookupFieldOnCalcItem__c = 'Name',
+          LookupObject__c = 'Opportunity',
+          LookupFieldOnLookupObject__c = 'Id',
+          RollupFieldOnLookupObject__c = 'Amount',
+          RollupOperation__c = 'MAX'
+        ),
+        new Rollup__mdt(
+          CalcItem__c = 'ContactPointAddress',
+          RollupFieldOnCalcItem__c = 'UsageType',
+          LookupFieldOnCalcItem__c = 'ParentId',
+          LookupObject__c = 'Account',
+          LookupFieldOnLookupObject__c = 'Id',
+          RollupFieldOnLookupObject__c = 'Sic',
+          RollupOperation__c = 'SOME',
+          CalcItemWhereClause__c = 'PreferenceRank = 2'
+        )
+      },
+      ContactPointAddress.SObjectType,
+      new Set<String>(),
+      null
+    );
+
+    Test.startTest();
+    fullRecalc.execute(null, new List<ContactPointAddress>{ cpas[0], cpas[1], cpas[2] });
+    fullRecalc.execute(null, new List<ContactPointAddress>{ cpas[3], cpas[4], cpas[5] });
+    fullRecalc.execute(null, new List<ContactPointAddress>{ cpas[6], cpas[7], cpas[8] });
+    Test.stopTest();
+
+    parentA = [SELECT AnnualRevenue, Description, NumberOfEmployees, Name, Sic FROM Account WHERE Id = :parentA.Id];
+    System.assertEquals(6, parentA.AnnualRevenue);
+    System.assertEquals('true', parentA.Sic);
+    parentB = [SELECT ConsumerCreditScore FROM Individual WHERE Id = :parentB.Id];
+    System.assertEquals(12, parentB.ConsumerCreditScore);
+    parentC = [SELECT Amount FROM Opportunity WHERE Id = :parentC.Id];
+    System.assertEquals(7, parentC.Amount);
+
+    System.assertEquals(true, Rollup.CACHED_ROLLUPS.isEmpty(), 'all deferrals should have been run');
+  }
+
+  @IsTest
   static void shouldFullRecalcWithInWhereClauses() {
     RollupParentResetProcessor.maxQueryRows = 0;
     Rollup.defaultControl = new RollupControl__mdt(ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.Batchable);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.6.13",
+  "version": "1.6.14",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaUZAA0">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaYwAAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaUZAA0">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaYwAAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -28,6 +28,5 @@
         "apex-rollup-namespaced@1.1.11": "04t6g000008OaOzAAK",
         "apex-rollup-namespaced@1.1.12": "04t6g000008OaUZAA0",
         "apex-rollup-namespaced@1.1.13": "04t6g000008OaYwAAK"
-    },
-    "target-dev-hub": "tester@sheandjim.com"
+    }
 }

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Spring 24",
-            "versionNumber": "1.1.12.0",
+            "versionName": "Fixes an issue where rollups to multiple parents running in an unordered fashion could accidentally reset parents between bulk full recalc batches",
+            "versionNumber": "1.1.13.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -26,6 +26,8 @@
         "apex-rollup-namespaced@1.1.9": "04t6g000008OaLHAA0",
         "apex-rollup-namespaced@1.1.10": "04t6g000008OaOBAA0",
         "apex-rollup-namespaced@1.1.11": "04t6g000008OaOzAAK",
-        "apex-rollup-namespaced@1.1.12": "04t6g000008OaUZAA0"
-    }
+        "apex-rollup-namespaced@1.1.12": "04t6g000008OaUZAA0",
+        "apex-rollup-namespaced@1.1.13": "04t6g000008OaYwAAK"
+    },
+    "target-dev-hub": "tester@sheandjim.com"
 }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1865,6 +1865,7 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
             (SELECT Id, FieldName__c, NullSortOrder__c, Ranking__c, SortOrder__c FROM RollupOrderBys__r ORDER BY Ranking__c, DeveloperName)
           FROM Rollup__mdt
           WHERE RollupControl__r.ShouldAbortRun__c = FALSE
+          ORDER BY CalcItem__c, LookupObject__c
         ];
         // do the transforms
         for (Rollup__mdt meta : cachedMetadata) {

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -89,16 +89,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     set;
   }
 
-  private static Map<Integer, Map<String, CalcItemBag>> CACHED_CALC_ITEM_LOOKUPS {
-    get {
-      if (CACHED_CALC_ITEM_LOOKUPS == null) {
-        CACHED_CALC_ITEM_LOOKUPS = new Map<Integer, Map<String, CalcItemBag>>();
-      }
-      return CACHED_CALC_ITEM_LOOKUPS;
-    }
-    set;
-  }
-
   public static RollupAsyncProcessor getConductor(InvocationPoint invokePoint, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
     return new QueueableProcessor(invokePoint, calcItems, oldCalcItems);
   }
@@ -148,6 +138,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     this.isFullRecalc = innerRollup.isFullRecalc;
     this.isCDCUpdate = innerRollup.isCDCUpdate;
     this.fullRecalcProcessor = innerRollup.fullRecalcProcessor;
+    this.fullRecalcProcessor?.previouslyResetParents.clear();
     this.stackDepth = innerRollup.stackDepth;
     this.calcItemReplacer = innerRollup.calcItemReplacer;
     this.lookupItems = innerRollup.lookupItems;
@@ -354,7 +345,11 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     // swap off on which async process is running to achieve infinite scaling
     Boolean canEnqueue = this.getCanEnqueue();
     RollupAsyncProcessor roll;
-    if (this.rollups.size() == 1 && this.rollups[0] instanceof RollupFullRecalcProcessor && (System.isBatch() == false || this.rollups[0].isBatch() == false)) {
+    if (
+      this.rollups.size() == 1 &&
+      this.rollups[0] instanceof RollupFullRecalcProcessor &&
+      (System.isBatch() == false || this.isBatch() == false && this.rollups[0].isBatch() == false)
+    ) {
       roll = this.rollups[0];
     } else if (this instanceof RollupFullRecalcProcessor && this.isBatch() == false) {
       roll = this;
@@ -858,16 +853,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       return new Map<String, CalcItemBag>();
     }
 
-    Integer cacheKey = roll.calcItems.hashCode();
-    switch on this.invokePoint {
-      when FROM_FULL_RECALC_LWC, FROM_SINGULAR_PARENT_RECALC_LWC, FROM_FULL_RECALC_FLOW {
-        Map<String, CalcItemBag> possiblyCachedItems = CACHED_CALC_ITEM_LOOKUPS.get(cacheKey);
-        if (possiblyCachedItems != null) {
-          return possiblyCachedItems;
-        }
-      }
-    }
-
     Map<String, CalcItemBag> lookupFieldToCalcItems = new Map<String, CalcItemBag>();
     if (String.isNotBlank(roll.metadata.GrandparentRelationshipFieldPath__c) || roll.metadata.RollupToUltimateParent__c) {
       if (roll.traversal == null) {
@@ -932,7 +917,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       }
     }
 
-    CACHED_CALC_ITEM_LOOKUPS.put(cacheKey, lookupFieldToCalcItems);
     return lookupFieldToCalcItems;
   }
 
@@ -1002,6 +986,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     this.isTimingOut = false;
     this.lookupObjectToUniqueFieldNames = null;
     this.calcObjectToUniqueFieldNames = null;
+    this.fullRecalcProcessor?.previouslyResetParents.clear();
 
     if (isDeferralAllowed) {
       this.rollups.clear();
@@ -1460,7 +1445,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
   private void cleanup() {
     RollupEvaluator.clearCache();
-    CACHED_CALC_ITEM_LOOKUPS = null;
     this.uniqueParentFields.clear();
     this.cleanupStaticVars();
     this.getCachedApexOperations().clear();

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.6.13';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.6.14';
   private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/scripts/generatePackage.ps1
+++ b/scripts/generatePackage.ps1
@@ -75,7 +75,7 @@ function Update-Logger-Class {
 
 function Update-SFDX-Project-JSON {
   Write-Host "Re-writing sfdx-project.json  ..."
-  ConvertTo-Json -InputObject $sfdxProjectJson -Depth 4 | Set-Content -Path $sfdxProjectJsonPath -NoNewline
+  Get-SFDX-Project-JSON | ConvertTo-Json -Depth 4 | Set-Content -Path $sfdxProjectJsonPath -NoNewline
   # sfdx-project.json is ignored by default; use another file as the --ignore-path to force prettier
   # to run on it
   npx prettier --write $sfdxProjectJsonPath --tab-width 4 --ignore-path ..\.forceignore

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,8 +5,8 @@
             "package": "apex-rollup",
             "path": "rollup",
             "scopeProfiles": true,
-            "versionName": "Spring 24",
-            "versionNumber": "1.6.13.0",
+            "versionName": "Fixes an issue where rollups to multiple parents running in an unordered fashion could accidentally reset parents between bulk full recalc batches",
+            "versionNumber": "1.6.14.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -103,6 +103,8 @@
         "apex-rollup@1.6.10": "04t6g000008OaLCAA0",
         "apex-rollup@1.6.11": "04t6g000008OaO6AAK",
         "apex-rollup@1.6.12": "04t6g000008OaOuAAK",
-        "apex-rollup@1.6.13": "04t6g000008OaUUAA0"
-    }
+        "apex-rollup@1.6.13": "04t6g000008OaUUAA0",
+        "apex-rollup@1.6.14": "04t6g000008OaYrAAK"
+    },
+    "target-dev-hub": "tester@sheandjim.com"
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -105,6 +105,5 @@
         "apex-rollup@1.6.12": "04t6g000008OaOuAAK",
         "apex-rollup@1.6.13": "04t6g000008OaUUAA0",
         "apex-rollup@1.6.14": "04t6g000008OaYrAAK"
-    },
-    "target-dev-hub": "tester@sheandjim.com"
+    }
 }


### PR DESCRIPTION
* Fixes an issue reported by @solo-1234 where rolling up 1 child to multiple parents where the parent types keep alternating lead to rollup fields accidentally being cleared