### PR TITLE
v1.6.15 - Continued Bulk Full Recalc Work

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaYrAAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaZ6AAK">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaYrAAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaZ6AAK">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -1020,8 +1020,8 @@ You have several options for custom logging plugins for Rollup (all Rollup Plugi
 public class RollupLogger {
 
   public interface ILogger {
-    void log(String logString, LoggingLevel logLevel);
-    void log(String logString, Object logObject, LoggingLevel logLevel);
+    void log(String logString, System.LoggingLevel logLevel);
+    void log(String logString, Object logObject, System.LoggingLevel logLevel);
     void save();
   }
 }
@@ -1030,7 +1030,7 @@ public class RollupLogger {
 
 You can implement `RollupLogger.ILogger` with your own code and specify that class name in the `Rollup Plugin` CMDT records. _Alternatively_, you can also _extend_ `RollupLogger` itself and override its own logging methods; this gives you the benefit of built-in message formatting through the use of the protected method `getLogStringFromObject`, found in `RollupLogger.cls`. For more info, refer to that class and its methods. Either way, the API name for the CMDT record **must** include `Logger` in order to work (eg: `RollupCustomObjectLogger`, `RollupNebulaLoggerAdapter`).
 
-You can use the included `Rollup Plugin Parameter` CMDT record `Logging Debug Level` to fine-tune the logging level you'd like to use when making use of Apex debug logs (from method #3, above). Valid entries conform to the `LoggingLevel` enum: ERROR, WARN, INFO, DEBUG, FINE, FINER, FINEST. FINEST provides the highest level of detail; ERROR provides the least. INFO will provide a high-level overview, while DEBUG will contain data about individual parent records being rolled up. The granularity of the data logged will continue to get finer as you move towards FINEST as the logging level.
+You can use the included `Rollup Plugin Parameter` CMDT record `Logging Debug Level` to fine-tune the logging level you'd like to use when making use of Apex debug logs (from method #3, above). Valid entries conform to the `System.LoggingLevel` enum: ERROR, WARN, INFO, DEBUG, FINE, FINER, FINEST. FINEST provides the highest level of detail; ERROR provides the least. INFO will provide a high-level overview, while DEBUG will contain data about individual parent records being rolled up. The granularity of the data logged will continue to get finer as you move towards FINEST as the logging level.
 
 ### Other Rollup Plugins
 

--- a/extra-tests/classes/RollupLoggerTests.cls
+++ b/extra-tests/classes/RollupLoggerTests.cls
@@ -9,10 +9,10 @@ private class RollupLoggerTests {
   static void shouldLogUsingCustomLoggerWhenSupplied() {
     setup();
 
-    RollupLogger.Instance.log('hi', LoggingLevel.DEBUG);
+    RollupLogger.Instance.log('hi', System.LoggingLevel.DEBUG);
 
     System.assertEquals('hi', locallogString);
-    System.assertEquals(LoggingLevel.DEBUG, localLogLevel);
+    System.assertEquals(System.LoggingLevel.DEBUG, localLogLevel);
   }
 
   @IsTest
@@ -20,11 +20,11 @@ private class RollupLoggerTests {
     setup();
     Account acc = new Account();
 
-    RollupLogger.Instance.log('hello', acc, LoggingLevel.FINE);
+    RollupLogger.Instance.log('hello', acc, System.LoggingLevel.FINE);
 
     System.assertEquals('hello', locallogString);
     System.assertEquals(acc, localLogObject);
-    System.assertEquals(LoggingLevel.FINE, localLogLevel);
+    System.assertEquals(System.LoggingLevel.FINE, localLogLevel);
   }
 
   @IsTest
@@ -61,15 +61,15 @@ private class RollupLoggerTests {
     Rollup.defaultControl = new RollupControl__mdt(IsRollupLoggingEnabled__c = false);
     RollupPlugin.pluginMocks = new List<RollupPlugin__mdt>{ new RollupPlugin__mdt(DeveloperName = ControlUpdatingLogger.class.getName()) };
 
-    RollupLogger.Instance.log('Should not be logged', LoggingLevel.DEBUG);
+    RollupLogger.Instance.log('Should not be logged', System.LoggingLevel.DEBUG);
     System.assertEquals('logging isn\'t enabled, no further output', localLogString);
 
     RollupLogger.Instance.updateRollupControl(new RollupControl__mdt(IsRollupLoggingEnabled__c = true));
     String expectedLogMessage = 'hi';
-    RollupLogger.Instance.log(expectedLogMessage, LoggingLevel.INFO);
+    RollupLogger.Instance.log(expectedLogMessage, System.LoggingLevel.INFO);
 
     System.assertEquals(expectedLogMessage, localLogString);
-    System.assertEquals(LoggingLevel.INFO, localLogLevel);
+    System.assertEquals(System.LoggingLevel.INFO, localLogLevel);
   }
 
   private static void setup() {
@@ -79,11 +79,11 @@ private class RollupLoggerTests {
 
   // Type.forName requires public visibility
   public class ExampleLogger implements RollupLogger.ILogger {
-    public void log(String logString, LoggingLevel logLevel) {
+    public void log(String logString, System.LoggingLevel logLevel) {
       locallogString = logString;
       localLogLevel = logLevel;
     }
-    public void log(String logString, Object logObject, LoggingLevel logLevel) {
+    public void log(String logString, Object logObject, System.LoggingLevel logLevel) {
       locallogString = logString;
       localLogObject = logObject;
       localLogLevel = logLevel;

--- a/extra-tests/classes/RollupTestUtils.cls
+++ b/extra-tests/classes/RollupTestUtils.cls
@@ -29,7 +29,7 @@ public class RollupTestUtils {
   public class DMLMock extends RollupSObjectUpdater {
     public List<SObject> Records = new List<SObject>();
     public override void doUpdate(List<SObject> recordsToUpdate) {
-      RollupLogger.Instance.log('mock received the following for update:', recordsToUpdate, LoggingLevel.DEBUG);
+      RollupLogger.Instance.log('mock received the following for update:', recordsToUpdate, System.LoggingLevel.DEBUG);
       this.Records = recordsToUpdate;
     }
   }

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -1749,30 +1749,30 @@ private class RollupTests {
   static void shouldPassRecalcValueForConcatDistinct() {
     rollupOp = Rollup.Op.CONCAT_DISTINCT;
     RollupCalculator.Factory = new FactoryMock();
-    RollupTestUtils.loadAccountIdMock(new List<ContactPointAddress>{ new ContactPointAddress(PreferenceRank = 5) });
+    RollupTestUtils.DMLMock mock = RollupTestUtils.loadAccountIdMock(new List<ContactPointAddress>{ new ContactPointAddress(Name = 'Hi', PreferenceRank = 5) });
     Rollup.apexContext = TriggerOperation.AFTER_INSERT;
 
     Test.startTest();
-    Rollup.concatDistinctFromApex(ContactPointAddress.PreferenceRank, ContactPointAddress.ParentId, Account.Id, Account.AnnualRevenue, Account.SObjectType, 'a')
-      .runCalc();
+    Rollup.concatDistinctFromApex(ContactPointAddress.Name, ContactPointAddress.ParentId, Account.Id, Account.Description, Account.SObjectType, 'a').runCalc();
     Test.stopTest();
 
     System.assertEquals('a', testMetadata.FullRecalculationDefaultStringValue__c);
+    System.assertEquals('a', mock.Records.get(0).get(Account.Description));
   }
 
   @IsTest
   static void shouldPassRecalcValueForConcat() {
     rollupOp = Rollup.Op.CONCAT;
     RollupCalculator.Factory = new FactoryMock();
-    RollupTestUtils.loadAccountIdMock(new List<ContactPointAddress>{ new ContactPointAddress(PreferenceRank = 5) });
+    RollupTestUtils.DMLMock mock = RollupTestUtils.loadAccountIdMock(new List<ContactPointAddress>{ new ContactPointAddress(Name = 'Hi', PreferenceRank = 5) });
     Rollup.apexContext = TriggerOperation.AFTER_INSERT;
 
     Test.startTest();
-    Rollup.concatFromApex(ContactPointAddress.PreferenceRank, ContactPointAddress.ParentId, Account.Id, Account.AnnualRevenue, Account.SObjectType, 'a')
-      .runCalc();
+    Rollup.concatFromApex(ContactPointAddress.Name, ContactPointAddress.ParentId, Account.Id, Account.Description, Account.SObjectType, 'a').runCalc();
     Test.stopTest();
 
     System.assertEquals('a', testMetadata.FullRecalculationDefaultStringValue__c);
+    System.assertEquals('a', mock.Records.get(0).get(Account.Description));
   }
 
   @IsTest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.6.14",
+  "version": "1.6.15",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/plugins/CustomObjectRollupLogger/README.md
+++ b/plugins/CustomObjectRollupLogger/README.md
@@ -16,7 +16,7 @@ To install this plugin and get it setup within your org properly:
 2. Navigate to the Rollup Plugin CMDT (Setup -> Custom Metadata Types -> Manage Records next to Rollup Plugin -> New)
 3. (This should already be done for you, upon install, but always good to double-check) - Enter `RollupCustomObjectLogger` into the `Rollup Plugin Name` field, choose the `Org_Default` rollup control record (and ensure `Is Rollup Logging Enabled?` is checked off on that record); the label can be whatever you'd like
 
-That's it! Logs will now start flowing through on all rollup operations to `RollupLog__c`. A permission set, `Rollup Log Viewer` is included so that you can grant Rollup Log access to users other than yourself (should you be so inclined). You can use the included `Rollup Plugin Parameter` CMDT record `Custom Logging Debug Level` to fine-tune the logging level you'd like to use. Valid entries conform to the `LoggingLevel` enum: ERROR, WARN, INFO, DEBUG, FINE, FINER, FINEST. FINEST provides the highest level of detail; ERROR provides the least.
+That's it! Logs will now start flowing through on all rollup operations to `RollupLog__c`. A permission set, `Rollup Log Viewer` is included so that you can grant Rollup Log access to users other than yourself (should you be so inclined). You can use the included `Rollup Plugin Parameter` CMDT record `Custom Logging Debug Level` to fine-tune the logging level you'd like to use. Valid entries conform to the `System.LoggingLevel` enum: ERROR, WARN, INFO, DEBUG, FINE, FINER, FINEST. FINEST provides the highest level of detail; ERROR provides the least.
 
 ---
 

--- a/plugins/CustomObjectRollupLogger/classes/RollupCustomObjectLogger.cls
+++ b/plugins/CustomObjectRollupLogger/classes/RollupCustomObjectLogger.cls
@@ -11,7 +11,7 @@ public class RollupCustomObjectLogger extends RollupLogger {
     this.rollupLogEvents.clear();
   }
 
-  protected override void innerLog(String logString, Object logObject, LoggingLevel logLevel) {
+  protected override void innerLog(String logString, Object logObject, System.LoggingLevel logLevel) {
     logString = this.getBaseLoggingMessage() + logString + '\n' + this.getLogStringFromObject(logObject);
     if (logString.length() >= MAX_LENGTH) {
       // normally we could do this with the AllowFieldTruncation property on Database.DMLOptions

--- a/plugins/CustomObjectRollupLogger/classes/RollupLogBatchPurger.cls
+++ b/plugins/CustomObjectRollupLogger/classes/RollupLogBatchPurger.cls
@@ -36,13 +36,13 @@ global without sharing class RollupLogBatchPurger implements Database.Batchable<
   }
 
   public void finish(Database.BatchableContext bc) {
-    RollupLogger.Instance.log('RollupLogBatchPurger finishing up after having deleted ' + this.recordCount + ' rollup logs', LoggingLevel.DEBUG);
+    RollupLogger.Instance.log('RollupLogBatchPurger finishing up after having deleted ' + this.recordCount + ' rollup logs', System.LoggingLevel.DEBUG);
 
     String orphanedLogsQuery = 'SELECT Count() FROM RollupLog__c WHERE NumberOfLogEntries__c = 0 AND IsDeleted = false';
     if (Database.countQuery(orphanedLogsQuery) > 0 && this.hasDeletedOrphanedLogs == false) {
       orphanedLogsQuery = orphanedLogsQuery.replace('Count()', 'Id');
       this.hasDeletedOrphanedLogs = true;
-      RollupLogger.Instance.log('Deleting orphaned logs ...', LoggingLevel.DEBUG);
+      RollupLogger.Instance.log('Deleting orphaned logs ...', System.LoggingLevel.DEBUG);
       delete Database.query(orphanedLogsQuery);
     }
     RollupLogger.Instance.save();

--- a/plugins/CustomObjectRollupLogger/classes/RollupLogEventHandler.cls
+++ b/plugins/CustomObjectRollupLogger/classes/RollupLogEventHandler.cls
@@ -5,7 +5,7 @@ public without sharing class RollupLogEventHandler {
 
     for (RollupLogEvent__e logEvent : logEvents) {
       RollupLog__c rollupLog = new RollupLog__c(
-        ErrorWouldHaveBeenThrown__c = logEvent.LoggingLevel__c == LoggingLevel.ERROR.name(),
+        ErrorWouldHaveBeenThrown__c = logEvent.LoggingLevel__c == System.LoggingLevel.ERROR.name(),
         LoggedBy__c = Id.valueOf(logEvent.LoggedBy__c),
         TransactionId__c = logEvent.TransactionId__c
       );

--- a/plugins/CustomObjectRollupLogger/customMetadata/RollupPluginParameter.CustomLoggingDebugLevel.md-meta.xml
+++ b/plugins/CustomObjectRollupLogger/customMetadata/RollupPluginParameter.CustomLoggingDebugLevel.md-meta.xml
@@ -1,10 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomMetadata
+  xmlns="http://soap.sforce.com/2006/04/metadata"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+>
     <label>Custom Logging Debug Level</label>
     <protected>false</protected>
     <values>
         <field>Description__c</field>
-        <value xsi:type="xsd:string">Conforms to the standard LoggingLevel enum - valid values are ERROR, WARN, INFO, DEBUG, FINE, FINER, FINEST. FINEST provides the highest level of detail; ERROR provides the least.</value>
+        <value
+      xsi:type="xsd:string"
+    >Conforms to the standard System.LoggingLevel enum - valid values are ERROR, WARN, INFO, DEBUG, FINE, FINER, FINEST. FINEST provides the highest level of detail; ERROR provides the least.</value>
     </values>
     <values>
         <field>RollupPlugin__c</field>

--- a/plugins/CustomObjectRollupLogger/objects/RollupLog__c/fields/ErrorWouldHaveBeenThrown__c.field-meta.xml
+++ b/plugins/CustomObjectRollupLogger/objects/RollupLog__c/fields/ErrorWouldHaveBeenThrown__c.field-meta.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ErrorWouldHaveBeenThrown__c</fullName>
     <defaultValue>false</defaultValue>
-    <description>If Rollup logs an otherwise fatal exception (with LoggingLevel.ERROR), this field is checked off</description>
+    <description>If Rollup logs an otherwise fatal exception (with System.LoggingLevel.ERROR), this field is checked off</description>
     <externalId>false</externalId>
-    <inlineHelpText>If Rollup logs an otherwise fatal exception (with LoggingLevel.ERROR), this field is checked off</inlineHelpText>
+    <inlineHelpText>If Rollup logs an otherwise fatal exception (with System.LoggingLevel.ERROR), this field is checked off</inlineHelpText>
     <label>Error Would Have Been Thrown</label>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>

--- a/plugins/CustomObjectRollupLogger/tests/RollupCustomObjectLoggerTests.cls
+++ b/plugins/CustomObjectRollupLogger/tests/RollupCustomObjectLoggerTests.cls
@@ -4,7 +4,7 @@ private class RollupCustomObjectLoggerTests {
   static void shouldSaveToRollupLog() {
     Rollup.defaultControl = new RollupControl__mdt(IsRollupLoggingEnabled__c = true);
     RollupCustomObjectLogger rollupCustomLogger = new RollupCustomObjectLogger();
-    rollupCustomLogger.log('Test log', LoggingLevel.DEBUG);
+    rollupCustomLogger.log('Test log', System.LoggingLevel.DEBUG);
     rollupCustomLogger.log('Second test log with record', new Account(), LoggingLevel.ERROR);
 
     Test.startTest();
@@ -22,10 +22,10 @@ private class RollupCustomObjectLoggerTests {
 
     // Rollup Log Entries
     System.assertEquals(2, firstEntry.RollupLogEntry__r.size());
-    System.assertEquals(LoggingLevel.DEBUG.name(), firstEntry.RollupLogEntry__r[0].LoggingLevel__c);
+    System.assertEquals(System.LoggingLevel.DEBUG.name(), firstEntry.RollupLogEntry__r[0].LoggingLevel__c);
     System.assertEquals('Rollup ' + RollupLogger.CURRENT_VERSION_NUMBER + ': Test log', firstEntry.RollupLogEntry__r[0].Message__c);
 
-    System.assertEquals(LoggingLevel.ERROR.name(), firstEntry.RollupLogEntry__r[1].LoggingLevel__c);
+    System.assertEquals(System.LoggingLevel.ERROR.name(), firstEntry.RollupLogEntry__r[1].LoggingLevel__c);
     System.assertEquals(true, firstEntry.RollupLogEntry__r[1].Message__c.contains('Second test log with record' + '\n' + JSON.serializePretty(new Account())));
   }
 
@@ -36,7 +36,7 @@ private class RollupCustomObjectLoggerTests {
     // this test is to ensure a RollupLogEntry__c is created
     RollupCustomObjectLogger rollupCustomLogger = new RollupCustomObjectLogger();
     Integer maximumLength = RollupLogEvent__e.Message__c.getDescribe().getLength();
-    rollupCustomLogger.log('1'.repeat(maximumLength + 1), LoggingLevel.ERROR);
+    rollupCustomLogger.log('1'.repeat(maximumLength + 1), System.LoggingLevel.ERROR);
 
     Test.startTest();
     rollupCustomLogger.save();
@@ -51,10 +51,10 @@ private class RollupCustomObjectLoggerTests {
   static void shouldNotLogBelowSpecifiedLoggingLevel() {
     Rollup.defaultControl = new RollupControl__mdt(IsRollupLoggingEnabled__c = true);
     // override whatever's included in the CMDT to ensure we arrive at this value deterministically
-    RollupPlugin.parameterMock = new RollupPluginParameter__mdt(Value__c = LoggingLevel.DEBUG.name());
+    RollupPlugin.parameterMock = new RollupPluginParameter__mdt(Value__c = System.LoggingLevel.DEBUG.name());
 
     RollupCustomObjectLogger rollupCustomLogger = new RollupCustomObjectLogger();
-    rollupCustomLogger.log('Test message', LoggingLevel.FINE);
+    rollupCustomLogger.log('Test message', System.LoggingLevel.FINE);
 
     Test.startTest();
     rollupCustomLogger.save();
@@ -68,7 +68,7 @@ private class RollupCustomObjectLoggerTests {
     Rollup.defaultControl = new RollupControl__mdt(IsRollupLoggingEnabled__c = true);
     RollupPlugin.pluginMocks.add(new RollupPlugin__mdt(DeveloperName = RollupCustomObjectLogger.class.getName()));
     // load a valid message into the buffer prior to disabling logging again
-    RollupLogger.Instance.log('Test message', LoggingLevel.ERROR);
+    RollupLogger.Instance.log('Test message', System.LoggingLevel.ERROR);
     RollupLogger.Instance.updateRollupControl(new RollupControl__mdt(IsRollupLoggingEnabled__c = false));
 
     Test.startTest();

--- a/plugins/CustomObjectRollupLogger/tests/RollupLogBatchPurgerTests.cls
+++ b/plugins/CustomObjectRollupLogger/tests/RollupLogBatchPurgerTests.cls
@@ -9,7 +9,7 @@ private class RollupLogBatchPurgerTests {
     List<RollupLog__c> logs = new List<RollupLog__c>{ log, logWithoutChildren };
     insert logs;
 
-    RollupLogEntry__c entry = new RollupLogEntry__c(LoggingLevel__c = 'DEBUG', RollupLog__c = log.Id);
+    RollupLogEntry__c entry = new RollupLogEntry__c(LoggingLevel__c = System.LoggingLevel.DEBUG.name(), RollupLog__c = log.Id);
     insert entry;
     // UTC time can lead to some weird Datetime issues with adding simply a single day
     // Let's go with 2 to make things completely solid

--- a/plugins/NebulaLogger/classes/RollupNebulaLoggerAdapter.cls
+++ b/plugins/NebulaLogger/classes/RollupNebulaLoggerAdapter.cls
@@ -13,7 +13,7 @@ public class RollupNebulaLoggerAdapter extends RollupLogger {
     Logger.saveLog();
   }
 
-  protected override void innerLog(String logString, Object logObject, LoggingLevel logLevel) {
+  protected override void innerLog(String logString, Object logObject, System.LoggingLevel logLevel) {
     logString = logString + '\n' + this.getLogStringFromObject(logObject);
     Logger.newEntry(logLevel, this.getBaseLoggingMessage() + logString);
   }

--- a/plugins/NebulaLogger/tests/RollupNebulaLoggerAdapterTest.cls
+++ b/plugins/NebulaLogger/tests/RollupNebulaLoggerAdapterTest.cls
@@ -6,7 +6,7 @@ private class RollupNebulaLoggerAdapterTest {
     String testString = 'Test String';
 
     Test.startTest();
-    RollupLogger.Instance.log(testString, new Account(), LoggingLevel.INFO);
+    RollupLogger.Instance.log(testString, new Account(), System.LoggingLevel.INFO);
     RollupLogger.Instance.save();
     Test.stopTest();
 

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaYwAAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaZBAA0">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaYwAAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OaZBAA0">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -27,6 +27,8 @@
         "apex-rollup-namespaced@1.1.10": "04t6g000008OaOBAA0",
         "apex-rollup-namespaced@1.1.11": "04t6g000008OaOzAAK",
         "apex-rollup-namespaced@1.1.12": "04t6g000008OaUZAA0",
-        "apex-rollup-namespaced@1.1.13": "04t6g000008OaYwAAK"
-    }
+        "apex-rollup-namespaced@1.1.13": "04t6g000008OaYwAAK",
+        "apex-rollup-namespaced@1.1.14": "04t6g000008OaZBAA0"
+    },
+    "target-dev-hub": "tester@sheandjim.com"
 }

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -29,6 +29,5 @@
         "apex-rollup-namespaced@1.1.12": "04t6g000008OaUZAA0",
         "apex-rollup-namespaced@1.1.13": "04t6g000008OaYwAAK",
         "apex-rollup-namespaced@1.1.14": "04t6g000008OaZBAA0"
-    },
-    "target-dev-hub": "tester@sheandjim.com"
+    }
 }

--- a/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js
+++ b/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.js
@@ -209,7 +209,7 @@ export default class RollupForceRecalculation extends LightningElement {
       let timeoutId;
       if (this._resolvedBatchStatuses.includes(this.rollupStatus) === false && this._validateAsyncJob(jobId)) {
         // some arbitrary wait time - for a huge batch job, it could take ages to resolve
-        const waitTimeMs = 3000;
+        const waitTimeMs = 10000;
         /* eslint-disable-next-line */
         timeoutId = setTimeout(() => this._getBatchJobStatus(jobId), waitTimeMs);
       } else {

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -344,7 +344,7 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
   }
 
   global virtual String runCalc() {
-    this.logger.log('no-op!', this.getTypeName(), LoggingLevel.INFO);
+    this.logger.log('no-op!', this.getTypeName(), System.LoggingLevel.INFO);
     return 'no-op';
   }
 
@@ -531,7 +531,7 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
     }
     List<Rollup__mdt> matchingMetadata = (List<Rollup__mdt>) JSON.deserialize(serializedMetadata, List<Rollup__mdt>.class);
     updateLoggingControl(matchingMetadata);
-    RollupLogger.Instance.log('bulk full recalc called with data:', matchingMetadata, LoggingLevel.INFO);
+    RollupLogger.Instance.log('bulk full recalc called with data:', matchingMetadata, System.LoggingLevel.INFO);
 
     String delimiter = ' ||| ';
     String possibleParentId;
@@ -779,7 +779,7 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
       }
 
       flowInput.rollupOperation = flowInput.rollupOperation.toUpperCase();
-      RollupLogger.Instance.log('processing invocable data:', flowInput, LoggingLevel.INFO);
+      RollupLogger.Instance.log('processing invocable data:', flowInput, System.LoggingLevel.INFO);
 
       if (
         flowInput.parentRecordIdForEmptyChildrenCollections != null &&
@@ -882,7 +882,7 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
             roll.rollupControl.ShouldRunAs__c = RollupMetaPicklists.ShouldRunAs.Synchronous;
           }
         }
-        RollupLogger.Instance.log(logMessage, rollupConductor, LoggingLevel.INFO);
+        RollupLogger.Instance.log(logMessage, rollupConductor, System.LoggingLevel.INFO);
       }
     }
 
@@ -1907,9 +1907,9 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
         control.IsRollupLoggingEnabled__c = true;
         RollupLogger.Instance.updateRollupControl(control);
       }
-      RollupLogger.Instance.log('exceeded limits:', limitTester, LoggingLevel.WARN);
+      RollupLogger.Instance.log('exceeded limits:', limitTester, System.LoggingLevel.WARN);
       if (isLoggingCurrentlyDisabled) {
-        RollupLogger.Instance.log('disabling logging again', LoggingLevel.INFO);
+        RollupLogger.Instance.log('disabling logging again', System.LoggingLevel.INFO);
         control.isRollupLoggingEnabled__c = false;
         RollupLogger.Instance.updateRollupControl(control);
       }
@@ -2259,7 +2259,7 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
         fullRecalc.isNoOp = wrappedMeta.recordCount == 0;
       }
       fullRecalc.queryCount = wrappedMeta.recordCount;
-      RollupLogger.Instance.log('full recalc prepared:', fullRecalc, LoggingLevel.INFO);
+      RollupLogger.Instance.log('full recalc prepared:', fullRecalc, System.LoggingLevel.INFO);
       fullRecalcRollups.add(fullRecalc);
       CACHED_FULL_RECALCS.add(fullRecalc);
     }
@@ -2467,7 +2467,7 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
   }
 
   private static void logAndThrowFlowException(Exception ex, String logString) {
-    RollupLogger.Instance.log(logString + ':', ex, LoggingLevel.ERROR);
+    RollupLogger.Instance.log(logString + ':', ex, System.LoggingLevel.ERROR);
     RollupLogger.Instance.save();
     throw ex;
   }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -1865,7 +1865,7 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
             (SELECT Id, FieldName__c, NullSortOrder__c, Ranking__c, SortOrder__c FROM RollupOrderBys__r ORDER BY Ranking__c, DeveloperName)
           FROM Rollup__mdt
           WHERE RollupControl__r.ShouldAbortRun__c = FALSE
-          ORDER BY CalcItem__c, LookupObject__c
+          ORDER BY LookupObject__c
         ];
         // do the transforms
         for (Rollup__mdt meta : cachedMetadata) {

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -667,7 +667,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       this.setupCalcItemData(roll);
       // for each iteration, ensure we're not operating beyond the bounds of our governor limits
       if (this.getIsTimingOut(roll.rollupControl)) {
-        this.deferredRollups.add(roll);
+        this.addProcessorToDeferredRollups(roll);
         continue;
       }
 
@@ -1239,7 +1239,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
 
     Map<String, List<SObject>> oldLookupItems = new Map<String, List<SObject>>();
-    Map<String, SObject> unprocessedCalcItems = new Map<String, SObject>();
     RollupCalculator calc;
     for (Integer index = lookupItems.size() - 1; index >= 0; index--) {
       SObject lookupRecord = lookupItems[index];
@@ -1252,7 +1251,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         List<SObject> localCalcItems = bag.getAll();
 
         if (this.getIsTimingOut(this.rollupControl) || (this.isValidAdditionalCalcItemRetrieval(roll) && bag.hasQueriedForAdditionalItems == false)) {
-          unprocessedCalcItems.putAll(localCalcItems);
+          this.addProcessorToDeferredRollups(roll);
           lookupItems.remove(index);
           continue;
         }
@@ -1278,21 +1277,13 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
 
     this.removeRolledUpValuesFromReparentedRecords(lookupItems, oldLookupItems, recordsToUpdate, roll);
-    this.deferCalculationsWhenApproachingLimits(roll, unprocessedCalcItems.values());
     this.handleFullRecalculators(roll);
 
     return recordsToUpdate.values();
   }
 
-  private void deferCalculationsWhenApproachingLimits(RollupAsyncProcessor roll, List<SObject> unprocessedCalcItems) {
-    if (unprocessedCalcItems.isEmpty() == false) {
-      roll.calcItems = unprocessedCalcItems;
-      this.addProcessorToDeferredRollups(roll);
-    }
-  }
-
   private void populateReparentedItems(RollupAsyncProcessor roll, List<SObject> localCalcItems, Map<String, List<SObject>> oldLookupItems) {
-    if (roll.oldCalcItems?.isEmpty() == true || this.isEmptyReparentingSet(roll.op)) {
+    if (roll.oldCalcItems?.isEmpty() != false || this.isEmptyReparentingSet(roll.op)) {
       return;
     }
     for (Integer index = localCalcItems.size() - 1; index >= 0; index--) {

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -224,7 +224,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   public virtual void execute(Database.BatchableContext context, List<SObject> scope) {
-    this.logger.log('starting batch chunk', this, LoggingLevel.INFO);
+    this.logger.log('starting batch chunk', this, System.LoggingLevel.INFO);
 
     if (this.getTypeName() == RollupAsyncProcessor.class.getName()) {
       this.lookupItems = scope;
@@ -240,7 +240,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
 
     this.performWork();
-    this.logger.log('batch chunk end', LoggingLevel.INFO);
+    this.logger.log('batch chunk end', System.LoggingLevel.INFO);
     this.logger.save();
   }
 
@@ -251,7 +251,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     if (context == null) {
       context = new AdditionalContext(this.getNoProcessId());
     }
-    this.logger.log('finished successfully', context, LoggingLevel.INFO);
+    this.logger.log('finished successfully', context, System.LoggingLevel.INFO);
     this.logger.save();
   }
 
@@ -478,7 +478,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
   protected virtual String beginAsyncRollup() {
     this.isTimingOut = false;
-    this.logger.log('about to start for ' + this.getTypeName(), this, LoggingLevel.INFO);
+    this.logger.log('about to start for ' + this.getTypeName(), this, System.LoggingLevel.INFO);
     return this.startAsyncWork();
   }
 
@@ -617,7 +617,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         if (this.childToUnexpectedFullRecalc.containsKey(rollup.calcItemType)) {
           this.childToUnexpectedFullRecalc.get(rollup.calcItemType).addMetadata(rollup.metadata);
         } else {
-          this.logger.log(this.getTypeName() + ': Populating unexpected full recalc for ' + outstandingItemCount + ' items', LoggingLevel.INFO);
+          this.logger.log(this.getTypeName() + ': Populating unexpected full recalc for ' + outstandingItemCount + ' items', System.LoggingLevel.INFO);
           RollupFullRecalcProcessor fullBatchProcessor = new RollupFullBatchRecalculator(
             query.substringBeforeLast('\nLIMIT'),
             this.invokePoint,
@@ -689,7 +689,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       }
 
       List<SObject> localLookupItems = this.getLookupItems(calcItemsByLookupField, updatedLookupRecords, roll);
-      this.logger.log('starting rollup for:', roll, LoggingLevel.INFO);
+      this.logger.log('starting rollup for:', roll, System.LoggingLevel.INFO);
       updatedLookupRecords.putAll(this.getUpdatedLookupItemsByRollup(roll, calcItemsByLookupField, localLookupItems));
     }
 
@@ -798,7 +798,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
   private Boolean getIsTimingOut(RollupControl__mdt control) {
     if (this.isTimingOut == false && hasExceededCurrentRollupLimits(control)) {
-      this.logger.log(this.getTypeName() + ': starting to time out ...', LoggingLevel.WARN);
+      this.logger.log(this.getTypeName() + ': starting to time out ...', System.LoggingLevel.WARN);
       this.isTimingOut = true;
     }
     return this.isTimingOut;
@@ -977,7 +977,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         isAllowedToContinue +
         ' with stackDepth: ' +
         this.stackDepth,
-      LoggingLevel.INFO
+      System.LoggingLevel.WARN
     );
 
     Boolean isDeferralAllowed = this.getIsDeferralAllowed() && isAllowedToContinue;
@@ -992,13 +992,13 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       this.rollups.clear();
       this.rollups.addAll(this.deferredRollups);
       this.deferredRollups.clear();
-      this.logger.log('deferred rollups remaining:', this.rollups, LoggingLevel.INFO);
+      this.logger.log('deferred rollups remaining:', this.rollups, System.LoggingLevel.WARN);
       this.getAsyncRollup()?.beginAsyncRollup();
       // for synchronous runs with a timeout, we need to ensure this.rollups is re-cleared here
       // to prevent re-running through the same logic in runCalc()
       this.rollups.clear();
     } else if (this.rollups.isEmpty() == false) {
-      this.logger.log('deferral was explicitly disallowed for rollups:', this.rollups, LoggingLevel.ERROR);
+      this.logger.log('deferral was explicitly disallowed for rollups:', this.rollups, System.LoggingLevel.ERROR);
       this.deferredRollups.clear();
     }
   }
@@ -1402,7 +1402,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
         oldLookupsRollup.calcItems = reparentedCalcItems;
         oldLookupsRollup.oldCalcItems = roll.oldCalcItems;
-        this.logger.log('reparenting operation', oldLookupsRollup, LoggingLevel.DEBUG);
+        this.logger.log('reparenting operation', oldLookupsRollup, System.LoggingLevel.DEBUG);
         CalcItemBag bag = new CalcItemBag(reparentedCalcItems);
         bag.hasQueriedForAdditionalItems = true;
         calc = this.getCalculator(calc, oldLookupsRollup, bag, lookupRecord, priorVal, key, roll.lookupFieldOnCalcItem);
@@ -1421,7 +1421,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     List<SObject> localCalcItems
   ) {
     String logKey = parentUpdateType.name().toLowerCase();
-    this.logger.log(logKey + ' record prior to rolling up:', lookupRecord, LoggingLevel.DEBUG);
+    this.logger.log(logKey + ' record prior to rolling up:', lookupRecord, System.LoggingLevel.DEBUG);
     Object newVal = calc.getReturnValue();
     if (this.rollupControl.ShouldSkipResettingParentFields__c == true && ((localCalcItems.isEmpty() == false && newVal == null) || localCalcItems.isEmpty())) {
       newVal = priorVal;
@@ -1431,7 +1431,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       this.getDML().updateField(roll.opFieldOnLookupObject, lookupRecord, newVal);
     }
     recordsToUpdate.put(key, lookupRecord);
-    this.logger.log(logKey + ' record after rolling up:', lookupRecord, LoggingLevel.DEBUG);
+    this.logger.log(logKey + ' record after rolling up:', lookupRecord, System.LoggingLevel.DEBUG);
   }
 
   private void cleanup() {

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -246,11 +246,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     BatchEndSnapshot snapshot = new BatchEndSnapshot();
     snapshot.currentHeapUsage = Limits.getHeapSize();
     snapshot.previouslyResetParentsSize = this.previouslyResetParents.size();
-    this.logger.log(
-      'batch chunk end',
-      snapshot,
-      System.LoggingLevel.INFO
-    );
+    this.logger.log('batch chunk end', snapshot, System.LoggingLevel.INFO);
     this.logger.save();
   }
 
@@ -507,9 +503,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   protected String startBatchProcessor() {
-    if (System.isBatch()) {
-      return new QueueableProcessor(this).startAsyncWork();
-    }
     return Database.executeBatch(this, this.rollupControl.BatchChunkSize__c.intValue());
   }
 
@@ -716,6 +709,17 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       updatedLookupRecords.putAll(this.getUpdatedLookupItemsByRollup(roll, calcItemsByLookupField, localLookupItems));
     }
 
+    // full batch recalc housekeeping - allow next batch chunk to reference previously reset parents
+    // this might look inefficient - and it probably is! - but this particular loop needs to happen
+    // after ALL of the rollups in the loop above have completed
+    for (SObject lookupRecord : updatedLookupRecords.values()) {
+      for (RollupAsyncProcessor roll : rollups) {
+        if (lookupRecord.getSObjectType() == roll.lookupObj) {
+          this.storeParentResetField(roll.lookupFieldOnLookupObject, lookupRecord);
+        }
+      }
+    }
+
     if (this.isTimingOut) {
       this.getDML().forceSyncUpdate();
     }
@@ -789,7 +793,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     return resetVal;
   }
 
-  private void storeParentResetField(String lookupField, SObject parent, String rollupField) {
+  private void storeParentResetField(Schema.SObjectField lookupField, SObject parent) {
     String resetKey = String.valueOf(parent.get(lookupField));
     if (resetKey != null) {
       this.previouslyResetParents.add(resetKey);
@@ -1239,7 +1243,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       for (SObject lookupItem : lookupItems) {
         if (lookupItem.getSObjectType() == roll.lookupObj) {
           recordsToUpdate.put(String.valueOf(lookupItem.get(roll.lookupFieldOnLookupObject)), lookupItem);
-          this.storeParentResetField('' + roll.lookupFieldOnLookupObject, lookupItem, '' + roll.opFieldOnLookupObject);
+          this.storeParentResetField(roll.lookupFieldOnLookupObject, lookupItem);
         }
       }
       return recordsToUpdate.values();
@@ -1251,6 +1255,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     if (roll.isFullRecalc && roll.op.name().contains('DELETE')) {
       rollupOp = this.getOpMap().get(roll.op.name().substringAfter('_'));
     }
+    Object fallbackValue = this.getDefaultValue(roll.metadata);
     for (Integer index = lookupItems.size() - 1; index >= 0; index--) {
       SObject lookupRecord = lookupItems[index];
       if (lookupRecord.getSObjectType() != roll.lookupObj) {
@@ -1276,14 +1281,14 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
           Object priorVal = lookupRecord.get(roll.opFieldOnLookupObject);
           Object priorValToUse = roll.isFullRecalc &&
             this.parentRollupFieldHasBeenReset('' + roll.lookupFieldOnLookupObject, lookupRecord, '' + roll.lookupObj, '' + roll.opFieldOnLookupObject) == false
-            ? this.getDefaultValue(roll.metadata)
+            ? fallbackValue
             : priorVal;
           calc = this.getCalculator(rollupOp, calc, roll, bag, lookupRecord, priorValToUse, key, roll.lookupFieldOnCalcItem);
           this.conditionallyPerformUpdate(priorVal, calc, lookupRecord, roll, recordsToUpdate, ParentUpdateType.LOOKUP, localCalcItems);
         }
       } else {
         this.logger.log('About to reset parent field for', lookupRecord, System.LoggingLevel.DEBUG);
-        this.getDML().updateField(roll.opFieldOnLookupObject, lookupRecord, this.getDefaultValue(roll.metadata));
+        this.getDML().updateField(roll.opFieldOnLookupObject, lookupRecord, fallbackValue);
       }
     }
 
@@ -1437,7 +1442,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       this.getDML().updateField(roll.opFieldOnLookupObject, lookupRecord, newVal);
     }
     recordsToUpdate.put(key, lookupRecord);
-    this.previouslyResetParents.add(String.valueOf(lookupRecord.get(roll.lookupFieldOnLookupObject)));
     this.logger.log(logKey + ' record after rolling up:', lookupRecord, System.LoggingLevel.DEBUG);
   }
 

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -187,7 +187,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         numberToReturn = 1;
       } else if (that.shouldSortToFront == false && this.shouldSortToFront) {
         numberToReturn = -1;
-      } else if (this.op != null && that.op != null) {
+      } else if (this.op != null && that.op != null && this.op != that.op) {
         Boolean thisDelete = this.op.name().contains('DELETE');
         Boolean thatDelete = that.op.name().contains('DELETE');
         Boolean thisUpdate = this.op.name().contains('UPDATE');
@@ -237,6 +237,9 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       }
     } else {
       this.calcItems = scope;
+    }
+    if (RollupLogger.isPluginParamEnabled('ExtraDebugging')) {
+      this.logger.log('Current children', scope, LoggingLevel.INFO);
     }
 
     this.performWork();
@@ -487,6 +490,9 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   protected String startBatchProcessor() {
+    if (System.isBatch()) {
+      return new QueueableProcessor(this).startAsyncWork();
+    }
     return Database.executeBatch(this, this.rollupControl.BatchChunkSize__c.intValue());
   }
 

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -69,10 +69,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     set;
   }
 
-  private final Map<Schema.SObjectType, Set<String>> previouslyResetParents {
+  private final Set<String> previouslyResetParents {
     get {
       if (previouslyResetParents == null) {
-        previouslyResetParents = new Map<Schema.SObjectType, Set<String>>();
+        previouslyResetParents = new Set<String>();
       }
       return previouslyResetParents;
     }
@@ -121,7 +121,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     );
   }
 
-  // Conductor constructors - "outer" rollups that orchestrate the proceedings for inner rollups
+  /**
+   * Conductor constructors - "outer" rollups that orchestrate the proceedings for inner rollups.
+   * These rollups tend to be the ones using the lazy-loaded properties above
+   */
   public RollupAsyncProcessor(InvocationPoint invokePoint) {
     super(invokePoint);
   }
@@ -138,7 +141,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     this.isFullRecalc = innerRollup.isFullRecalc;
     this.isCDCUpdate = innerRollup.isCDCUpdate;
     this.fullRecalcProcessor = innerRollup.fullRecalcProcessor;
-    this.fullRecalcProcessor?.previouslyResetParents.clear();
     this.stackDepth = innerRollup.stackDepth;
     this.calcItemReplacer = innerRollup.calcItemReplacer;
     this.lookupItems = innerRollup.lookupItems;
@@ -238,12 +240,17 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     } else {
       this.calcItems = scope;
     }
-    if (RollupLogger.isPluginParamEnabled('ExtraDebugging')) {
-      this.logger.log('Current children', scope, LoggingLevel.INFO);
-    }
 
     this.performWork();
-    this.logger.log('batch chunk end', System.LoggingLevel.INFO);
+
+    BatchEndSnapshot snapshot = new BatchEndSnapshot();
+    snapshot.currentHeapUsage = Limits.getHeapSize();
+    snapshot.previouslyResetParentsSize = this.previouslyResetParents.size();
+    this.logger.log(
+      'batch chunk end',
+      snapshot,
+      System.LoggingLevel.INFO
+    );
     this.logger.save();
   }
 
@@ -479,6 +486,16 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
   }
 
+  private class BatchEndSnapshot {
+    public Long currentHeapUsage { get; set; }
+    public Long heapLimit {
+      get {
+        return 12000000;
+      }
+    }
+    public Long previouslyResetParentsSize { get; set; }
+  }
+
   protected virtual String beginAsyncRollup() {
     this.isTimingOut = false;
     this.logger.log('about to start for ' + this.getTypeName(), this, System.LoggingLevel.INFO);
@@ -699,15 +716,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       updatedLookupRecords.putAll(this.getUpdatedLookupItemsByRollup(roll, calcItemsByLookupField, localLookupItems));
     }
 
-    // full batch recalc housekeeping - allow next batch chunk to reference previously reset parents
-    for (SObject lookupRecord : updatedLookupRecords.values()) {
-      for (RollupAsyncProcessor roll : rollups) {
-        if (lookupRecord.getSObjectType() == roll.lookupObj) {
-          this.storeParentResetField('' + roll.lookupFieldOnLookupObject, lookupRecord);
-        }
-      }
-    }
-
     if (this.isTimingOut) {
       this.getDML().forceSyncUpdate();
     }
@@ -753,7 +761,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   protected Boolean parentRollupFieldHasBeenReset(String parentKeyField, SObject parent, String parentTypeName, String parentRollupField) {
-    return this.previouslyResetParents.get(parent.getSObjectType())?.contains(String.valueOf(parent.get(parentKeyField))) == true ||
+    return this.previouslyResetParents.contains(String.valueOf(parent.get(parentKeyField))) ||
       this.uniqueParentFields.contains(parentTypeName + parentRollupField);
   }
 
@@ -781,10 +789,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     return resetVal;
   }
 
-  private void storeParentResetField(String lookupField, SObject parent) {
+  private void storeParentResetField(String lookupField, SObject parent, String rollupField) {
     String resetKey = String.valueOf(parent.get(lookupField));
     if (resetKey != null) {
-      this.previouslyResetParents.get(parent.getSObjectType()).add(resetKey);
+      this.previouslyResetParents.add(resetKey);
       this.fullRecalcProcessor?.trackParentRecord(parent);
     }
   }
@@ -833,11 +841,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       }
     }
     rollupsToProcess.addAll(this.transformFullRecalcRollups());
-    for (RollupAsyncProcessor roll : rollupsToProcess) {
-      if (roll.lookupObj != null && this.previouslyResetParents.containsKey(roll.lookupObj) == false) {
-        this.previouslyResetParents.put(roll.lookupObj, new Set<String>());
-      }
-    }
   }
 
   private void handleMultipleDMLRollupsEnqueuedInTheSameTransaction(List<Rollup> rolls) {
@@ -929,7 +932,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   private List<SObject> getLookupItems(Map<String, CalcItemBag> calcItemsByLookupField, Map<String, SObject> updatedLookupRecords, RollupAsyncProcessor roll) {
     List<SObject> localLookupItems = new List<SObject>();
     Set<String> lookupItemKeys = new Set<String>(calcItemsByLookupField.keySet());
-    this.previouslyResetParents.get(roll.lookupObj).retainAll(lookupItemKeys);
     if (this.fullRecalcProcessor != null) {
       lookupItemKeys.addAll(this.fullRecalcProcessor.getRecordIdentifiers());
     }
@@ -992,7 +994,6 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     this.isTimingOut = false;
     this.lookupObjectToUniqueFieldNames = null;
     this.calcObjectToUniqueFieldNames = null;
-    this.fullRecalcProcessor?.previouslyResetParents.clear();
 
     if (isDeferralAllowed) {
       this.rollups.clear();
@@ -1238,7 +1239,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       for (SObject lookupItem : lookupItems) {
         if (lookupItem.getSObjectType() == roll.lookupObj) {
           recordsToUpdate.put(String.valueOf(lookupItem.get(roll.lookupFieldOnLookupObject)), lookupItem);
-          this.storeParentResetField('' + roll.lookupFieldOnLookupObject, lookupItem);
+          this.storeParentResetField('' + roll.lookupFieldOnLookupObject, lookupItem, '' + roll.opFieldOnLookupObject);
         }
       }
       return recordsToUpdate.values();
@@ -1246,6 +1247,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
 
     Map<String, List<SObject>> oldLookupItems = new Map<String, List<SObject>>();
     RollupCalculator calc;
+    Op rollupOp = roll.op;
+    if (roll.isFullRecalc && roll.op.name().contains('DELETE')) {
+      rollupOp = this.getOpMap().get(roll.op.name().substringAfter('_'));
+    }
     for (Integer index = lookupItems.size() - 1; index >= 0; index--) {
       SObject lookupRecord = lookupItems[index];
       if (lookupRecord.getSObjectType() != roll.lookupObj) {
@@ -1271,9 +1276,9 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
           Object priorVal = lookupRecord.get(roll.opFieldOnLookupObject);
           Object priorValToUse = roll.isFullRecalc &&
             this.parentRollupFieldHasBeenReset('' + roll.lookupFieldOnLookupObject, lookupRecord, '' + roll.lookupObj, '' + roll.opFieldOnLookupObject) == false
-            ? null
+            ? this.getDefaultValue(roll.metadata)
             : priorVal;
-          calc = this.getCalculator(calc, roll, bag, lookupRecord, priorValToUse, key, roll.lookupFieldOnCalcItem);
+          calc = this.getCalculator(rollupOp, calc, roll, bag, lookupRecord, priorValToUse, key, roll.lookupFieldOnCalcItem);
           this.conditionallyPerformUpdate(priorVal, calc, lookupRecord, roll, recordsToUpdate, ParentUpdateType.LOOKUP, localCalcItems);
         }
       } else {
@@ -1289,7 +1294,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   private void populateReparentedItems(RollupAsyncProcessor roll, List<SObject> localCalcItems, Map<String, List<SObject>> oldLookupItems) {
-    if (roll.oldCalcItems?.isEmpty() != false || this.isEmptyReparentingSet(roll.op)) {
+    if (roll.oldCalcItems == null || roll.oldCalcItems.isEmpty() || this.isEmptyReparentingSet(roll.op)) {
       return;
     }
     for (Integer index = localCalcItems.size() - 1; index >= 0; index--) {
@@ -1337,6 +1342,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
   }
 
   private RollupCalculator getCalculator(
+    Op operation,
     RollupCalculator rollupCalc,
     RollupAsyncProcessor roll,
     CalcItemBag bag,
@@ -1345,19 +1351,13 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     String lookupRecordKey,
     SObjectField lookupKeyField
   ) {
-    Rollup.Op rollupOp = roll.op;
-    if (roll.isFullRecalc && roll.op.name().contains('DELETE')) {
-      rollupOp = this.getOpMap().get(roll.op.name().substringAfter('_'));
-    }
     if (rollupCalc == null) {
-      rollupCalc = RollupCalculator.Factory.getCalculator(rollupOp, roll.opFieldOnCalcItem, roll.opFieldOnLookupObject, roll.metadata, lookupKeyField);
+      rollupCalc = RollupCalculator.Factory.getCalculator(operation, roll.opFieldOnCalcItem, roll.opFieldOnLookupObject, roll.metadata, lookupKeyField);
       rollupCalc.setEvaluator(roll.eval);
       rollupCalc.setCDCUpdate(this.isCDCUpdate);
       rollupCalc.setFullRecalc(roll.isFullRecalc);
     }
-    rollupCalc.setHasAlreadyRetrievedCalcItems(
-      bag.hasQueriedForAdditionalItems && this.previouslyResetParents.get(roll.lookupObj).contains(lookupRecordKey) == false
-    );
+    rollupCalc.setHasAlreadyRetrievedCalcItems(bag.hasQueriedForAdditionalItems && this.previouslyResetParents.contains(lookupRecordKey) == false);
     rollupCalc.setDefaultValues(lookupRecordKey, priorVal);
     rollupCalc.setMultiCurrencyInfo(lookupRecord);
     rollupCalc.performRollup(bag.getAll(), roll.oldCalcItems);
@@ -1411,7 +1411,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         this.logger.log('reparenting operation', oldLookupsRollup, System.LoggingLevel.DEBUG);
         CalcItemBag bag = new CalcItemBag(reparentedCalcItems);
         bag.hasQueriedForAdditionalItems = true;
-        calc = this.getCalculator(calc, oldLookupsRollup, bag, lookupRecord, priorVal, key, roll.lookupFieldOnCalcItem);
+        calc = this.getCalculator(deleteOp, calc, oldLookupsRollup, bag, lookupRecord, priorVal, key, roll.lookupFieldOnCalcItem);
         this.conditionallyPerformUpdate(priorVal, calc, lookupRecord, roll, recordsToUpdate, ParentUpdateType.REPARENTED, reparentedCalcItems);
       }
     }
@@ -1437,6 +1437,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
       this.getDML().updateField(roll.opFieldOnLookupObject, lookupRecord, newVal);
     }
     recordsToUpdate.put(key, lookupRecord);
+    this.previouslyResetParents.add(String.valueOf(lookupRecord.get(roll.lookupFieldOnLookupObject)));
     this.logger.log(logKey + ' record after rolling up:', lookupRecord, System.LoggingLevel.DEBUG);
   }
 

--- a/rollup/core/classes/RollupDeferredFullRecalcProcessor.cls
+++ b/rollup/core/classes/RollupDeferredFullRecalcProcessor.cls
@@ -22,7 +22,7 @@ public without sharing virtual class RollupDeferredFullRecalcProcessor extends R
 
   protected List<SObject> getCalcItems() {
     if (QUERY_TO_CALC_ITEMS.containsKey(this.queryString)) {
-      this.logger.log('returning pre-queried records from cache', LoggingLevel.FINE);
+      this.logger.log('returning pre-queried records from cache', System.LoggingLevel.FINE);
       return QUERY_TO_CALC_ITEMS.get(this.queryString);
     }
     List<SObject> localCalcItems = this.preStart().get();

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -126,7 +126,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
           }
         }
       }
-      addLog(this, matches, calcItem, LoggingLevel.FINEST);
+      addLog(this, matches, calcItem, System.LoggingLevel.FINEST);
       return matches;
     }
 
@@ -240,8 +240,8 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       this.calcItemType = calcItemSObjectType;
       this.validRelationshipNames = this.getValidRelationshipNames(calcItemSObjectType);
       this.createConditions(calcItemSObjectType, whereClause);
-      RollupLogger.Instance.log('where clause for eval: ' + this.whereClause, LoggingLevel.FINER);
-      RollupLogger.Instance.log('conditionals', this.whereConditions, LoggingLevel.FINER);
+      RollupLogger.Instance.log('where clause for eval: ' + this.whereClause, System.LoggingLevel.FINER);
+      RollupLogger.Instance.log('conditionals', this.whereConditions, System.LoggingLevel.FINER);
     }
 
     public override String toString() {
@@ -296,7 +296,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
       try {
         this.whereConditions.addAll(this.recursivelyCreateConditions(localWhereClause));
       } catch (Exception ex) {
-        RollupLogger.Instance.log('an error occurred in RollupEvaluator:', ex, LoggingLevel.ERROR);
+        RollupLogger.Instance.log('an error occurred in RollupEvaluator:', ex, System.LoggingLevel.ERROR);
         RollupLogger.Instance.save();
         throw new IllegalArgumentException(
           'Where clause entered incorrectly: ' + whereClause + '\nException: ' + ex.getMessage() + '\n' + ex.getStackTraceString()
@@ -870,7 +870,7 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
     return relationshipField.endsWith('__r') ? relationshipField.substringBeforeLast('__r') + '__c' : relationshipField + 'Id';
   }
 
-  private static void addLog(RollupLogger.ToStringObject clazz, Boolean matches, Object item, LoggingLevel logLevel) {
+  private static void addLog(RollupLogger.ToStringObject clazz, Boolean matches, Object item, System.LoggingLevel logLevel) {
     if (matches == false) {
       RollupLogger.Instance.log('Removing non-match for: ' + item, clazz, logLevel);
     }

--- a/rollup/core/classes/RollupFinalizer.cls
+++ b/rollup/core/classes/RollupFinalizer.cls
@@ -26,7 +26,7 @@ public without sharing class RollupFinalizer implements Finalizer {
     if (wasCalled == false) {
       // a finalizer can be re-queued up to five times, but we view this as a one-time "get out of jail free" logger
       wasCalled = true;
-      RollupLogger.Instance.log('finalizer logging failure from:', fc?.getException(), LoggingLevel.ERROR);
+      RollupLogger.Instance.log('finalizer logging failure from:', fc?.getException(), System.LoggingLevel.ERROR);
       RollupLogger.Instance.save();
     }
   }

--- a/rollup/core/classes/RollupFullRecalcProcessor.cls
+++ b/rollup/core/classes/RollupFullRecalcProcessor.cls
@@ -74,7 +74,7 @@ global abstract without sharing class RollupFullRecalcProcessor extends RollupAs
       }
       this.setCurrentJobId(conductor.startAsyncWork());
     } else if (this.postProcessor != null) {
-      this.logger.log('Starting post-full recalc processor', this.postProcessor, LoggingLevel.INFO);
+      this.logger.log('Starting post-full recalc processor', this.postProcessor, System.LoggingLevel.INFO);
       // chain jobs together so that if recalc job is being tracked within the Recalc Rollups app,
       // job continuity is established between the full recalc and then any downstream job that runs
       // (as the postProcessor)

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -25,10 +25,6 @@ global without sharing virtual class RollupLogger implements ILogger {
     private set;
   }
 
-  public static Boolean isPluginParamEnabled(String devNameOrId) {
-    return PLUGIN.getParameterInstance(devNameOrId)?.Value__c == 'true';
-  }
-
   public interface ToStringObject {
   }
 

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,8 +1,8 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.6.14';
-  private static final LoggingLevel FALLBACK_LOGGING_LEVEL = LoggingLevel.DEBUG;
+  private static final String CURRENT_VERSION_NUMBER = 'v1.6.15-beta';
+  private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 
   private final System.LoggingLevel currentLoggingLevel;
@@ -29,17 +29,17 @@ global without sharing virtual class RollupLogger implements ILogger {
   }
 
   public interface ILogger {
-    void log(String logString, LoggingLevel logLevel);
-    void log(String logString, Object logObject, LoggingLevel logLevel);
+    void log(String logString, System.LoggingLevel logLevel);
+    void log(String logString, Object logObject, System.LoggingLevel logLevel);
     void save();
     ILogger updateRollupControl(RollupControl__mdt control);
   }
 
-  public void log(String logString, LoggingLevel logLevel) {
+  public void log(String logString, System.LoggingLevel logLevel) {
     this.log(logString, null, logLevel);
   }
 
-  public virtual void log(String logString, Object logObject, LoggingLevel logLevel) {
+  public virtual void log(String logString, Object logObject, System.LoggingLevel logLevel) {
     if (logLevel.ordinal() >= this.currentLoggingLevel.ordinal()) {
       this.innerLog(logString, logObject, logLevel);
     }
@@ -58,7 +58,7 @@ global without sharing virtual class RollupLogger implements ILogger {
   }
 
   @SuppressWarnings('PMD.AvoidDebugStatements')
-  protected virtual void innerLog(String logString, Object logObject, LoggingLevel logLevel) {
+  protected virtual void innerLog(String logString, Object logObject, System.LoggingLevel logLevel) {
     String appended = this.getLogStringFromObject(logObject);
     List<String> messages = new List<String>{ logString };
     if (String.isNotBlank(appended)) {
@@ -82,12 +82,12 @@ global without sharing virtual class RollupLogger implements ILogger {
     return 'LoggingDebugLevel';
   }
 
-  protected LoggingLevel getLogLevel() {
-    LoggingLevel toReturn = FALLBACK_LOGGING_LEVEL;
+  protected System.LoggingLevel getLogLevel() {
+    System.LoggingLevel toReturn = FALLBACK_LOGGING_LEVEL;
     RollupPluginParameter__mdt loggingLevelParamater = this.getLoggingLevelParameter();
     String logLevelNameToSearch = loggingLevelParamater != null ? loggingLevelParamater.Value__c : toReturn.name();
     try {
-      toReturn = LoggingLevel.valueOf(logLevelNameToSearch);
+      toReturn = System.LoggingLevel.valueOf(logLevelNameToSearch);
     } catch (Exception ex) {
       toReturn = FALLBACK_LOGGING_LEVEL;
     }
@@ -154,7 +154,7 @@ global without sharing virtual class RollupLogger implements ILogger {
 
     ILogger combinedLogger = new CombinedLogger(loggers, Rollup.getDefaultControl());
     for (String potentialError : potentialErrorMessages) {
-      combinedLogger.log(potentialError, LoggingLevel.WARN);
+      combinedLogger.log(potentialError, System.LoggingLevel.WARN);
     }
 
     return combinedLogger;
@@ -171,15 +171,15 @@ global without sharing virtual class RollupLogger implements ILogger {
       this.control = control;
     }
 
-    public void log(String logString, LoggingLevel logLevel) {
+    public void log(String logString, System.LoggingLevel logLevel) {
       this.log(logString, null, logLevel);
     }
 
-    public void log(String logString, Object logObject, LoggingLevel logLevel) {
+    public void log(String logString, Object logObject, System.LoggingLevel logLevel) {
       if (this.control.IsRollupLoggingEnabled__c == false && this.hasDisabledMessageBeenLogged == false) {
         this.hasDisabledMessageBeenLogged = true;
         this.control.IsRollupLoggingEnabled__c = true;
-        this.log('logging isn\'t enabled, no further output', LoggingLevel.WARN);
+        this.log('logging isn\'t enabled, no further output', System.LoggingLevel.WARN);
         this.control.IsRollupLoggingEnabled__c = false;
       } else if (this.control.IsRollupLoggingEnabled__c) {
         for (ILogger logger : this.loggers) {
@@ -198,7 +198,7 @@ global without sharing virtual class RollupLogger implements ILogger {
 
     public CombinedLogger updateRollupControl(RollupControl__mdt control) {
       this.control = control;
-      this.log('updating control record', control, LoggingLevel.INFO);
+      this.log('updating control record', control, System.LoggingLevel.INFO);
       return this;
     }
   }

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.6.15-beta';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.6.15';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -25,6 +25,10 @@ global without sharing virtual class RollupLogger implements ILogger {
     private set;
   }
 
+  public static Boolean isPluginParamEnabled(String devNameOrId) {
+    return PLUGIN.getParameterInstance(devNameOrId)?.Value__c == 'true';
+  }
+
   public interface ToStringObject {
   }
 

--- a/rollup/core/classes/RollupParentResetProcessor.cls
+++ b/rollup/core/classes/RollupParentResetProcessor.cls
@@ -41,7 +41,7 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
     this.objIds.addAll(this.recordIds);
     String processId = this.getNoProcessId();
     if (isValidRun == false || this.rollupControl.ShouldSkipResettingParentFields__c == true) {
-      this.logger.log('Parent reset processor no-op', LoggingLevel.INFO);
+      this.logger.log('Parent reset processor no-op', System.LoggingLevel.INFO);
       return processId;
     }
     Boolean isOverLimit = this.getNumberOfItems() > maxQueryRows;
@@ -63,7 +63,7 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
     if (parentItems.isEmpty()) {
       return;
     }
-    this.logger.log('resetting parent fields for: ' + parentItems.size() + ' items', LoggingLevel.INFO);
+    this.logger.log('resetting parent fields for: ' + parentItems.size() + ' items', System.LoggingLevel.INFO);
     Map<String, Schema.SObjectField> parentFields = parentItems.get(0).getSObjectType().getDescribe().fields.getMap();
     for (SObject parentItem : parentItems) {
       for (Rollup__mdt rollupMeta : this.rollupMetas) {

--- a/rollup/core/classes/RollupQueryBuilder.cls
+++ b/rollup/core/classes/RollupQueryBuilder.cls
@@ -116,7 +116,7 @@ public without sharing class RollupQueryBuilder {
         }
       }
     } catch (Exception ex) {
-      RollupLogger.Instance.log('exception occurred while converting polymorphic where clause:', ex, LoggingLevel.WARN);
+      RollupLogger.Instance.log('exception occurred while converting polymorphic where clause:', ex, System.LoggingLevel.WARN);
     }
     return optionalWhereClause;
   }

--- a/rollup/core/classes/RollupRepository.cls
+++ b/rollup/core/classes/RollupRepository.cls
@@ -68,7 +68,7 @@ public without sharing class RollupRepository implements RollupLogger.ToStringOb
     try {
       countAmount = Database.countQueryWithBinds(this.args.query, this.args.bindVars, this.accessLevel);
     } catch (Exception ex) {
-      RollupLogger.Instance.log('an error occurred while trying to get count query', ex, LoggingLevel.WARN);
+      RollupLogger.Instance.log('an error occurred while trying to get count query', ex, System.LoggingLevel.WARN);
       // not all count queries are valid, particularly those with polymorphic fields referencing parent fields
       // return a sentinel value instead, to be checked for downstream
       countAmount = SENTINEL_COUNT_VALUE;
@@ -82,7 +82,7 @@ public without sharing class RollupRepository implements RollupLogger.ToStringOb
   }
 
   private void createQueryLog(String message) {
-    RollupLogger.Instance.Log(message, this, LoggingLevel.DEBUG);
+    RollupLogger.Instance.Log(message, this, System.LoggingLevel.DEBUG);
   }
 
   private System.AccessLevel transformPermissionLevel(RunAsMode currentRunAs) {

--- a/rollup/core/classes/RollupSObjectUpdater.cls
+++ b/rollup/core/classes/RollupSObjectUpdater.cls
@@ -60,7 +60,7 @@ global without sharing virtual class RollupSObjectUpdater {
     // typically I wouldn't advocate for the use of a guard clause here since an empty list
     // getting updated is a no-op, but the addition of the logging item is annoying ...
     if (recordsToUpdate.isEmpty() == false) {
-      RollupLogger.Instance.log('updating ' + recordsToUpdate.size() + ' records', LoggingLevel.INFO);
+      RollupLogger.Instance.log('updating ' + recordsToUpdate.size() + ' records', System.LoggingLevel.INFO);
       recordsToUpdate.sort(SORTER);
       Database.DMLOptions dmlOptions = new Database.DMLOptions();
       dmlOptions.AllowFieldTruncation = true;
@@ -128,7 +128,7 @@ global without sharing virtual class RollupSObjectUpdater {
 
   private void dispatch(List<SObject> updatedRecords) {
     if (updatedRecords.isEmpty() == false && this.dispatchers.isEmpty() == false) {
-      RollupLogger.Instance.log('dispatching updated records to: ' + this.getLogString(this.dispatchers), LoggingLevel.FINE);
+      RollupLogger.Instance.log('dispatching updated records to: ' + this.getLogString(this.dispatchers), System.LoggingLevel.FINE);
       for (IDispatcher dispatcher : this.dispatchers) {
         dispatcher.dispatch(updatedRecords);
       }

--- a/rollup/core/customMetadata/RollupPluginParameter.LoggingDebugLevel.md-meta.xml
+++ b/rollup/core/customMetadata/RollupPluginParameter.LoggingDebugLevel.md-meta.xml
@@ -1,10 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomMetadata
+  xmlns="http://soap.sforce.com/2006/04/metadata"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+>
     <label>Logging Debug Level</label>
     <protected>false</protected>
     <values>
         <field>Description__c</field>
-        <value xsi:type="xsd:string">Conforms to the standard LoggingLevel enum - valid values are ERROR, WARN, INFO, DEBUG, FINE, FINER, FINEST. FINEST provides the highest level of detail; ERROR provides the least.</value>
+        <value
+      xsi:type="xsd:string"
+    >Conforms to the standard System.LoggingLevel enum - valid values are ERROR, WARN, INFO, DEBUG, FINE, FINER, FINEST. FINEST provides the highest level of detail; ERROR provides the least.</value>
     </values>
     <values>
         <field>RollupPlugin__c</field>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -106,6 +106,5 @@
         "apex-rollup@1.6.13": "04t6g000008OaUUAA0",
         "apex-rollup@1.6.14": "04t6g000008OaYrAAK",
         "apex-rollup@1.6.15": "04t6g000008OaZ6AAK"
-    },
-    "target-dev-hub": "tester@sheandjim.com"
+    }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,8 +5,8 @@
             "package": "apex-rollup",
             "path": "rollup",
             "scopeProfiles": true,
-            "versionName": "Fixes an issue where rollups to multiple parents running in an unordered fashion could accidentally reset parents between bulk full recalc batches",
-            "versionNumber": "1.6.14.0",
+            "versionName": "Continued bulk full recalc work",
+            "versionNumber": "1.6.15.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -104,6 +104,8 @@
         "apex-rollup@1.6.11": "04t6g000008OaO6AAK",
         "apex-rollup@1.6.12": "04t6g000008OaOuAAK",
         "apex-rollup@1.6.13": "04t6g000008OaUUAA0",
-        "apex-rollup@1.6.14": "04t6g000008OaYrAAK"
-    }
+        "apex-rollup@1.6.14": "04t6g000008OaYrAAK",
+        "apex-rollup@1.6.15": "04t6g000008OaZ6AAK"
+    },
+    "target-dev-hub": "tester@sheandjim.com"
 }


### PR DESCRIPTION
* Standardizes prefixing `System` namespace for logging levels, which was inconsistent
* updates polling time in Full Recalc app from 3 seconds to 10 seconds between polls to minimize number of logs produced while waiting for full recalcs to finish
* fixes an inconsistency across batch full recalc runs where state tracking could fail if parents present in disparate batch chunks - say, chunks 1, 3, 5, etc... - had children qualify in only some of those batches. This has been a complicated and pernicious issue, and in many ways is a return to some prior version of the parent tracking present in prior versions of Apex Rollup. I've added some logging to the end of each batch chunk to monitor how this affects LDV orgs 