### PR TITLE
v1.6.23 - Configurable Errors Thrown On Save

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OavAAAS">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OawIAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OavAAAS">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OawIAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupSObjectUpdaterTests.cls
+++ b/extra-tests/classes/RollupSObjectUpdaterTests.cls
@@ -65,7 +65,7 @@ public class RollupSObjectUpdaterTests {
     RollupPlugin.parameterMock = new RollupPluginParameter__mdt(Value__c = DispatcherMock.class.getName());
     RollupSObjectUpdater updater = new RollupSObjectUpdater();
 
-    updater.doUpdate(new List<SObjecT>{ new Account() });
+    updater.doUpdate(new List<SObject>{ new Account() });
 
     System.assertEquals(true, dispatcherMockWasCalled);
   }
@@ -139,6 +139,22 @@ public class RollupSObjectUpdaterTests {
     updater.doUpdate(new List<SObject>{ new Account() });
 
     System.assertNotEquals(initial, RollupSettings__c.getInstance());
+  }
+
+  @IsTest
+  static void shouldThrowWhenControlValueEnabledForFailedSaves() {
+    RollupSObjectUpdater updater = new RollupSObjectUpdater();
+    updater.addRollupControl(new RollupControl__mdt(ShouldThrowOnSaveErrors__c = true));
+
+    String message = '';
+    try {
+      updater.doUpdate(new List<SObject>{ new Account() });
+      Assert.fail('Error should be thrown for account without Id');
+    } catch (System.DmlException ex) {
+      message = ex.getMessage();
+    }
+
+    Assert.areEqual('Update failed. First exception on row 0; first error: MISSING_ARGUMENT, Id not specified in an update call: []', message);
   }
 
   public class MockUpdater implements RollupSObjectUpdater.IUpdater {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.6.22",
+  "version": "1.6.23",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OavFAAS">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OawNAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OavFAAS">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OawNAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -25,6 +25,6 @@
         "apex-rollup-namespaced@1.1.13": "04t6g000008OaYwAAK",
         "apex-rollup-namespaced@1.1.14": "04t6g000008OaZBAA0",
         "apex-rollup-namespaced@1.1.16": "04t6g000008OaZaAAK",
-        "apex-rollup-namespaced@1.1.17": "04t6g000008OavFAAS"
+        "apex-rollup-namespaced@1.1.17": "04t6g000008OawNAAS"
     }
 }

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.6.22';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.6.23';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupSObjectUpdater.cls
+++ b/rollup/core/classes/RollupSObjectUpdater.cls
@@ -64,8 +64,7 @@ global without sharing virtual class RollupSObjectUpdater {
       recordsToUpdate.sort(SORTER);
       Database.DMLOptions dmlOptions = new Database.DMLOptions();
       dmlOptions.AllowFieldTruncation = true;
-      // TODO - possibly add configuration for this option as per #523
-      dmlOptions.OptAllOrNone = false;
+      dmlOptions.OptAllOrNone = this.rollupControl.ShouldThrowOnSaveErrors__c;
       if (this.rollupControl.ShouldDuplicateRulesBeIgnored__c != false) {
         dmlOptions.DuplicateRuleHeader.AllowSave = true;
       }

--- a/rollup/core/customMetadata/RollupControl.Org_Defaults.md-meta.xml
+++ b/rollup/core/customMetadata/RollupControl.Org_Defaults.md-meta.xml
@@ -31,12 +31,12 @@
         <value xsi:type="xsd:double">50.0</value>
     </values>
     <values>
-        <field>MaxQueryRows__c</field>
-        <value xsi:type="xsd:double">25000.0</value>
-    </values>
-    <values>
         <field>MaxParentRowsUpdatedAtOnce__c</field>
         <value xsi:type="xsd:double">5000.0</value>
+    </values>
+    <values>
+        <field>MaxQueryRows__c</field>
+        <value xsi:type="xsd:double">25000.0</value>
     </values>
     <values>
         <field>MaxRollupRetries__c</field>
@@ -68,6 +68,10 @@
     </values>
     <values>
         <field>ShouldSkipResettingParentFields__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>ShouldThrowOnSaveErrors__c</field>
         <value xsi:type="xsd:boolean">false</value>
     </values>
     <values>

--- a/rollup/core/layouts/RollupControl__mdt-Rollup Control Layout.layout-meta.xml
+++ b/rollup/core/layouts/RollupControl__mdt-Rollup Control Layout.layout-meta.xml
@@ -26,6 +26,10 @@
                 <behavior>Edit</behavior>
                 <field>IsDevEdOrTrialOrg__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>IsMergeReparentingEnabled__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
@@ -37,16 +41,16 @@
                 <field>ShouldDuplicateRulesBeIgnored__c</field>
             </layoutItems>
             <layoutItems>
+                <behavior>Edit</behavior>
+                <field>ShouldThrowOnSaveErrors__c</field>
+            </layoutItems>
+            <layoutItems>
                 <behavior>Required</behavior>
                 <field>ShouldRunAs__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>ShouldRunSingleRecordsSynchronously__c</field>
-            </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>IsMergeReparentingEnabled__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>

--- a/rollup/core/objects/RollupControl__mdt/fields/ShouldThrowOnSaveErrors__c.field-meta.xml
+++ b/rollup/core/objects/RollupControl__mdt/fields/ShouldThrowOnSaveErrors__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ShouldThrowOnSaveErrors__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description
+  >By default, errors when saving parent records are logged but execution does not halt. Set this to true to throw errors for validations rules and other exceptions.</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText
+  >By default, errors when saving parent records are logged but execution does not halt. Set this to true to throw errors for validations rules and other exceptions.</inlineHelpText>
+    <label>Should Throw On Save Errors</label>
+    <type>Checkbox</type>
+</CustomField>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -105,6 +105,7 @@
         "apex-rollup@1.6.19": "04t6g000008Oal4AAC",
         "apex-rollup@1.6.20": "04t6g000008OanPAAS",
         "apex-rollup@1.6.21": "04t6g000008OatsAAC",
-        "apex-rollup@1.6.22": "04t6g000008OavAAAS"
+        "apex-rollup@1.6.22": "04t6g000008OavAAAS",
+        "apex-rollup@1.6.23": "04t6g000008OawIAAS"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,8 +5,8 @@
             "package": "apex-rollup",
             "path": "rollup",
             "scopeProfiles": true,
-            "versionName": "Fixes grandparent rollup logic for deletes with COUNT_DISTINCT",
-            "versionNumber": "1.6.22.0",
+            "versionName": "Adds support for exceptions to be thrown when parent-level saves errors occur",
+            "versionNumber": "1.6.23.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
* Fixes an issue long-discussed in #523 that allows subscribers to throw errors on save with Apex Rollup instead of logging a WARN message