### PR TITLE
Feature/promote rollup logger visibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -980,6 +980,7 @@ public class RollupLogger {
     void log(String logString, System.LoggingLevel logLevel);
     void log(String logString, Object logObject, System.LoggingLevel logLevel);
     void save();
+    ILogger updateRollupControl(RollupControl__mdt control);
   }
 }
 

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -23,10 +23,10 @@ global without sharing virtual class RollupLogger implements ILogger {
     private set;
   }
 
-  public interface ToStringObject {
+  global interface ToStringObject {
   }
 
-  public interface ILogger {
+  global interface ILogger {
     void log(String logString, System.LoggingLevel logLevel);
     void log(String logString, Object logObject, System.LoggingLevel logLevel);
     void save();
@@ -37,13 +37,13 @@ global without sharing virtual class RollupLogger implements ILogger {
     this.log(logString, null, logLevel);
   }
 
-  public virtual void log(String logString, Object logObject, System.LoggingLevel logLevel) {
+  global virtual void log(String logString, Object logObject, System.LoggingLevel logLevel) {
     if (logLevel.ordinal() >= this.currentLoggingLevel.ordinal()) {
       this.innerLog(logString, logObject, logLevel);
     }
   }
 
-  public virtual void save() {
+  global virtual void save() {
     // this is a no-op by default; sub-classes can opt in if they need to perform DML
   }
 


### PR DESCRIPTION
Hi James 👋🏼 I'm a big fan of your work in general, and this package specifically. 

My organization uses the namespaced version of the rollup package, and we recently discovered that we cannot currently utilize the logger plugin functionality detailed in the [readme](https://github.com/jamessimone/apex-rollup?tab=readme-ov-file#rollup-logging-plugins), because the types aren't visible. I assume this isn't a problem for most users w/the non-namespaced package.

This PR fixes this, by updating the visibilities of the `RollupLogger`'s virtual methods, and its inner `ILogger` interface to be `global`. I didn't update the other `public` methods in this class, since they're not strictly necessary for what I'd like to accomplish -- but I'd be open to changing that if you think that would be helpful for others.

Here are the errors I received when trying to create my own plugin, using the latest version of the namespaced package (`1.1.17.0`):

#### When extending `please.RollupLogger`:
```
| Type  Name             Problem                                                                                                              Line:Column 
| ───── ──────────────── ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────── ─────────── 
| Error RollupLogAdapter @Override specified for non-overriding method: void RollupLogAdapter.log(String, Object, System.LoggingLevel) (7:26) 7:26        
| Error RollupLogAdapter @Override specified for non-overriding method: void RollupLogAdapter.save() (16:26)                                  16:26      
```

#### When implementing `please.RollupLogger.ILogger`:
```
Type  Name             Problem                                                  Line:Column 
| ───── ──────────────── ──────────────────────────────────────────────────────── ─────────── 
| Error RollupLogAdapter Type is not visible: please.RollupLogger.ILogger (21:14) 21:14      
```

Thanks for your consideration, and please let me know if you have any questions.