### PR TITLE
v1.6.32 - Adds Rollup.runFromApex overload

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,12 +453,15 @@ global static void runFromCDCTrigger()
 
 // imperatively from Apex, relying on CMDT for additional rollup info
 // if you are actually using this from WITHIN a trigger, the second argument should
-// ALWAYS be the "Trigger.operationType" static variable
-global static void runFromApex(List<SObject> calcItems, TriggerOperation rollupContext)
+// ALWAYS be the "Trigger.operationType" static variable (unless you're unit testing)
+global static void runFromApex(List<SObject> children, TriggerOperation rollupContext)
+
+// overload of the above, with support for the Trigger.oldMap variable (or your unit-tested approximation thereof)
+global static void runFromApex(List<SObject> children, Map<Id, SObject> oldChildrenMap, TriggerOperation rollupContext)
 
 // for more info on how this method differs from the one above it, check out the "Parent Level Merges" section!
 // for anything OTHER than merge situations use of this method is an anti-pattern
-global static Rollup runFromApex(List<Rollup__mdt> rollupMetadata, Evaluator eval, List<SObject> calcItems, Map<Id, SObject> oldCalcItems)
+global static Rollup runFromApex(List<Rollup__mdt> rollupMetadata, Evaluator eval, List<SObject> children, Map<Id, SObject> oldChildrenMap)
 
 // imperatively from Apex with arguments taking the place of values previously supplied by CMDT
 // can be used in conjunction with "batch" to group rollup operations (as seen in the example preceding this section)

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ObblAAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ObbvAAC">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ObblAAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ObbvAAC">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -1625,7 +1625,6 @@ private class RollupIntegrationTests {
       new ContactPointAddress(Id = RollupTestUtils.createId(ContactPointAddress.SObjectType), ParentId = acc.Id, PreferenceRank = 10)
     };
 
-    Rollup.records = cpas;
     Rollup.rollupMetadata = new List<Rollup__mdt>{
       new Rollup__mdt(
         RollupFieldOnCalcItem__c = 'PreferenceRank',
@@ -1640,6 +1639,42 @@ private class RollupIntegrationTests {
 
     Test.startTest();
     Rollup.runFromApex(cpas, TriggerOperation.AFTER_INSERT);
+    Test.stopTest();
+
+    acc = [SELECT AnnualRevenue FROM Account];
+    System.assertEquals(15, acc.AnnualRevenue);
+  }
+
+  @IsTest
+  static void shouldRunWithOldRecordsDirectlyFromApex() {
+    Account acc = [SELECT Id FROM Account];
+
+    List<ContactPointAddress> cpas = new List<ContactPointAddress>{
+      new ContactPointAddress(Id = RollupTestUtils.createId(ContactPointAddress.SObjectType), ParentId = acc.Id, PreferenceRank = 5),
+      new ContactPointAddress(Id = RollupTestUtils.createId(ContactPointAddress.SObjectType), ParentId = acc.Id, PreferenceRank = 10)
+    };
+
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        RollupFieldOnCalcItem__c = 'PreferenceRank',
+        LookupObject__c = 'Account',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'SUM',
+        CalcItem__c = 'ContactPointAddress'
+      )
+    };
+
+    Test.startTest();
+    Rollup.runFromApex(
+      cpas,
+      new Map<Id, SObject>{
+        cpas[0].Id => new ContactPointAddress(Id = cpas[0].Id, ParentId = acc.Id, PreferenceRank = 0),
+        cpas[1].Id => new ContactPointAddress(Id = cpas[1].Id, ParentId = acc.Id, PreferenceRank = 0)
+      },
+      TriggerOperation.AFTER_UPDATE
+    );
     Test.stopTest();
 
     acc = [SELECT AnnualRevenue FROM Account];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.6.31",
+  "version": "1.6.32",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ObbqAAC">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Obc0AAC">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008ObbqAAC">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Obc0AAC">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Fixes issue where sync rollups with lowercase field names in where clauses would not start up properly",
-            "versionNumber": "1.1.24.0",
+            "versionName": "Adds imperative Apex method Rollup.runFromApex for new and old record code paths",
+            "versionNumber": "1.1.25.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -27,6 +27,7 @@
         "apex-rollup-namespaced@1.1.21": "04t6g000008ObLCAA0",
         "apex-rollup-namespaced@1.1.22": "04t6g000008ObNDAA0",
         "apex-rollup-namespaced@1.1.23": "04t6g000008ObNSAA0",
-        "apex-rollup-namespaced@1.1.24": "04t6g000008ObbqAAC"
+        "apex-rollup-namespaced@1.1.24": "04t6g000008ObbqAAC",
+        "apex-rollup-namespaced@1.1.25": "04t6g000008Obc0AAC"
     }
 }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -5,7 +5,7 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
    * but this keeps things much simpler
    */
   @TestVisible
-  private static Boolean shouldRun = false;
+  private static Boolean shouldRun;
   @TestVisible
   private static TriggerOperation apexContext;
   @TestVisible
@@ -1699,12 +1699,9 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
    * - TriggerOperation.BEFORE_DELETE
    * - TriggerOperation.AFTER_UNDELETE
    *
-   * Note that while it's an anti-pattern to call this from directly within a Trigger,
-   * because `runFromTrigger()` coupled with CMDT is the better option,
-   * you should pass: `Trigger.operationType` for the second argument if you do.
    */
-  global static void runFromApex(List<SObject> calcItems, TriggerOperation rollupContext) {
-    shouldRun = true;
+  global static void runFromApex(List<SObject> calcItems, System.TriggerOperation rollupContext) {
+    shouldRun = shouldRun ?? true;
     records = calcItems;
     apexContext = rollupContext;
 
@@ -1713,6 +1710,12 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
     records = null;
     shouldRun = false;
     apexContext = null;
+  }
+
+  global static void runFromApex(List<SObject> children, Map<Id, SObject> oldChildrenMap, System.TriggerOperation rollupContext) {
+    oldChildrenMap = oldChildrenMap;
+    runFromApex(children, rollupContext);
+    oldChildrenMap = null;
   }
 
   global static Rollup runFromApex(List<Rollup__mdt> localMetas, Evaluator eval, List<SObject> calcItems, Map<Id, SObject> oldCalcItems) {
@@ -2828,7 +2831,7 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
    * because the underlying SObject can't be modified till afterwards
    */
   private static Boolean shouldRunFromTrigger() {
-    shouldRun = shouldRun || Trigger.isExecuting;
+    shouldRun = Trigger.isExecuting || (shouldRun ?? false);
     if (Trigger.operationType != null && isCDC == false) {
       apexContext = Trigger.operationType;
     }

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.6.31';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.6.32';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -104,6 +104,7 @@
         "apex-rollup@1.6.28": "04t6g000008ObN8AAK",
         "apex-rollup@1.6.29": "04t6g000008ObNNAA0",
         "apex-rollup@1.6.30": "04t6g000008ObVhAAK",
-        "apex-rollup@1.6.31": "04t6g000008ObblAAC"
+        "apex-rollup@1.6.31": "04t6g000008ObblAAC",
+        "apex-rollup@1.6.32": "04t6g000008ObbvAAC"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,8 +5,8 @@
             "package": "apex-rollup",
             "path": "rollup",
             "scopeProfiles": true,
-            "versionName": "Fixes issue where sync rollups with lowercase field names in where clauses would not start up properly",
-            "versionNumber": "1.6.31.0",
+            "versionName": "Adds imperative Apex method Rollup.runFromApex for new and old record code paths",
+            "versionNumber": "1.6.32.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -101,7 +101,6 @@
         "Apex Rollup - Rollup Callback@0.0.3-0": "04t6g000008Sis0AAC",
         "Nebula Logger - Core@4.8.0-NEXT-ignore-origin-method": "04t5Y0000015lslQAA",
         "apex-rollup": "0Ho6g000000TNcOCAW",
-        "apex-rollup@1.6.27": "04t6g000008ObL7AAK",
         "apex-rollup@1.6.28": "04t6g000008ObN8AAK",
         "apex-rollup@1.6.29": "04t6g000008ObNNAA0",
         "apex-rollup@1.6.30": "04t6g000008ObVhAAK",


### PR DESCRIPTION
Adds overload for `Rollup.runFromApex(List<SObject> children, Map<Id, SObject> oldChildrenMap, System.TriggerOperation rollupContext)` requested by @arbokrad