### PR TITLE
v1.6.37 - RollupCalcItemReplacer bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OfMeAAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OfSEAA0">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OfMeAAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OfSEAA0">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/extra-tests/classes/RollupCalcItemReplacerTests.cls
+++ b/extra-tests/classes/RollupCalcItemReplacerTests.cls
@@ -177,4 +177,22 @@ private class RollupCalcItemReplacerTests {
 
     System.assertEquals(ACC_ANNUAL_REVENUE, acc.AnnualRevenue);
   }
+
+  @IsTest
+  static void exclusiveWhereClauseWithMultipleMetadataRecordsDoesNotBlowUpList() {
+    Account acc = [SELECT Id FROM Account];
+    RollupCalcItemReplacer replacer = new RollupCalcItemReplacer(
+      new RollupControl__mdt(IsRollupLoggingEnabled__c = true, ReplaceCalcItemsAsyncWhenOverCount__c = 3)
+    );
+
+    List<SObject> records = replacer.replace(
+      new List<Account>{ acc, acc },
+      new List<Rollup__mdt>{
+        new Rollup__mdt(CalcItemWhereClause__c = 'Id != \'' + acc.Id + '\' AND Owner.Name = null', CalcItem__c = 'Account'),
+        new Rollup__mdt(CalcItemWhereClause__c = 'AnnualRevenue = null', CalcItem__c = 'Account')
+      }
+    );
+
+    Assert.areEqual(0, records.size());
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.6.36",
+  "version": "1.6.37",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OfMjAAK">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OfSJAA0">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OfMjAAK">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OfSJAA0">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Fixes Rollup Order By issue when called from RollupFlowBulkProcessor",
-            "versionNumber": "1.1.29.0",
+            "versionName": "Fixes mutually exclusive polymorphic where clauses replacing children in RollupCalcItemReplacer",
+            "versionNumber": "1.1.30.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -32,6 +32,7 @@
         "apex-rollup-namespaced@1.1.26": "04t6g000008ObeVAAS",
         "apex-rollup-namespaced@1.1.27": "04t6g000008OfJkAAK",
         "apex-rollup-namespaced@1.1.28": "04t6g000008OfKnAAK",
-        "apex-rollup-namespaced@1.1.29": "04t6g000008OfMjAAK"
+        "apex-rollup-namespaced@1.1.29": "04t6g000008OfMjAAK",
+        "apex-rollup-namespaced@1.1.30": "04t6g000008OfSJAA0"
     }
 }

--- a/rollup/core/classes/RollupCalcItemReplacer.cls
+++ b/rollup/core/classes/RollupCalcItemReplacer.cls
@@ -174,6 +174,9 @@ public without sharing class RollupCalcItemReplacer {
       Map<String, Schema.SObjectField> fieldMap = calcItems[0].getSObjectType().getDescribe(SObjectDescribeOptions.DEFERRED).fields.getMap();
       for (Rollup__mdt meta : this.metaToEval.keySet()) {
         calcItems = this.replaceCalcItemsWithPolymorphicWhereClauses(calcItems, meta, fieldMap);
+        if (calcItems.isEmpty()) {
+          break;
+        }
       }
     }
     return calcItems;

--- a/rollup/core/classes/RollupDateLiteral.cls
+++ b/rollup/core/classes/RollupDateLiteral.cls
@@ -344,7 +344,7 @@ public without sharing abstract class RollupDateLiteral {
   private class NextWeekLiteral extends RollupDateLiteral {
     public NextWeekLiteral() {
       this.ref = getRelativeDatetime(System.today().toStartOfWeek().addDays(7), START_TIME);
-      this.bound = getRelativeDatetime(this.ref.addDays(6).date(), END_TIME);
+      this.bound = getRelativeDatetime(this.ref.addDays(6).dateGmt(), END_TIME);
     }
   }
 

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -1,7 +1,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.6.36';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.6.37';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,8 +5,8 @@
             "package": "apex-rollup",
             "path": "rollup",
             "scopeProfiles": true,
-            "versionName": "Fixes Rollup Order By issue when called from RollupFlowBulkProcessor",
-            "versionNumber": "1.6.36.0",
+            "versionName": "Fixes mutually exclusive polymorphic where clauses replacing children in RollupCalcItemReplacer",
+            "versionNumber": "1.6.37.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -106,6 +106,7 @@
         "apex-rollup@1.6.33": "04t6g000008ObeQAAS",
         "apex-rollup@1.6.34": "04t6g000008OfJfAAK",
         "apex-rollup@1.6.35": "04t6g000008OfKiAAK",
-        "apex-rollup@1.6.36": "04t6g000008OfMeAAK"
+        "apex-rollup@1.6.36": "04t6g000008OfMeAAK",
+        "apex-rollup@1.6.37": "04t6g000008OfSEAA0"
     }
 }


### PR DESCRIPTION
* Fixes error reported interally with polymorphic where clause replacements being mutually exclusive with the current list of items