### PR TITLE
v1.7.6 - Better INCLUDES Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OfqTAAS">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Ofr7AAC">
   <img alt="Deploy to Salesforce" src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OfqTAAS">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Ofr7AAC">
   <img alt="Deploy to Salesforce Sandbox" src="./media/deploy-package-to-sandbox.png">
 </a>
 <br/>

--- a/extra-tests/classes/RollupEvaluatorTests.cls
+++ b/extra-tests/classes/RollupEvaluatorTests.cls
@@ -548,6 +548,16 @@ private class RollupEvaluatorTests {
   }
 
   @IsTest
+  static void shouldReturnFalseForEmptyIncludesList() {
+    QuickText qt = new QuickText();
+
+    String whereClause = 'Channel INCLUDES (\'1\')';
+
+    Rollup.Evaluator eval = new RollupEvaluator.WhereFieldEvaluator(whereClause, QuickText.SObjectType);
+    System.assertEquals(false, eval.matches(qt));
+  }
+
+  @IsTest
   static void shouldCorrectlyIdentifyIncludesForMultiSelectPicklistsWithSpaces() {
     // QuickText.Channel is the only multi-select picklist in a vanilla Salesforce org
     QuickText one = new QuickText(Channel = 'AAA;BBB;CCC');

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -3126,4 +3126,75 @@ private class RollupTests {
     acc = [SELECT AnnualRevenue FROM Account WHERE Id = :acc.Id];
     Assert.areEqual(opp.Amount, acc.AnnualRevenue);
   }
+
+  @IsTest
+  static void includesWhereClausesWorkOnUpdateMultipleChildren() {
+    Account acc = [SELECT Id, Phone FROM Account];
+    acc.AnnualRevenue = 2;
+    RollupAsyncProcessor.stubParentRecords = new List<SObject>{ acc };
+
+    Rollup.onlyUseMockMetadata = true;
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'QuickText',
+        LookupFieldOnCalcItem__c = 'Name',
+        RollupFieldOnCalcItem__c = 'Channel',
+        LookupObject__c = 'Account',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'COUNT',
+        CalcItemWhereClause__c = 'Channel INCLUDES (\'A\')',
+        IsFullRecordSet__c = true
+      )
+    };
+    List<QuickText> quickTexts = new List<QuickText>{
+      new QuickText(Channel = 'A', Name = acc.Id, Id = RollupTestUtils.createId(QuickText.SObjectType)),
+      new QuickText(Name = acc.Id, Id = RollupTestUtils.createId(QuickText.SObjectType))
+    };
+
+    Test.startTest();
+    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
+    Rollup.shouldRun = true;
+    Rollup.records = quickTexts;
+    Rollup.oldRecordsMap = new Map<Id, QuickText>{
+      quickTexts[0].Id => quickTexts[0],
+      quickTexts[1].Id => new QuickText(Channel = 'A', Id = quickTexts[1].Id, Name = acc.Id)
+    };
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Assert.areEqual(1, acc.AnnualRevenue);
+  }
+
+  @IsTest
+  static void includesWhereClausesWorkOnUpdateWithOnlyOneMatch() {
+    Account acc = [SELECT Id, Phone FROM Account];
+    acc.AnnualRevenue = 1;
+    RollupAsyncProcessor.stubParentRecords = new List<SObject>{ acc };
+
+    Rollup.onlyUseMockMetadata = true;
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'QuickText',
+        LookupFieldOnCalcItem__c = 'Name',
+        RollupFieldOnCalcItem__c = 'Channel',
+        LookupObject__c = 'Account',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'COUNT',
+        CalcItemWhereClause__c = 'Channel INCLUDES (\'A\')'
+      )
+    };
+    List<QuickText> quickTexts = new List<QuickText>{ new QuickText(Name = acc.Id, Id = RollupTestUtils.createId(QuickText.SObjectType)) };
+
+    Test.startTest();
+    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
+    Rollup.shouldRun = true;
+    Rollup.records = quickTexts;
+    Rollup.oldRecordsMap = new Map<Id, QuickText>{ quickTexts[0].Id => new QuickText(Channel = 'A', Id = quickTexts[0].Id, Name = acc.Id) };
+    Rollup.runFromTrigger();
+    Test.stopTest();
+
+    Assert.areEqual(null, acc.AnnualRevenue);
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OfqYAAS">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OfrCAAS">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OfqYAAS">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OfrCAAS">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "TODO",
-            "versionNumber": "1.2.4.0",
+            "versionName": "Better support for INCLUDES in where clauses",
+            "versionNumber": "1.2.5.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -29,6 +29,7 @@
         "apex-rollup-namespaced@1.2.1": "04t6g000008OfWVAA0",
         "apex-rollup-namespaced@1.2.2": "04t6g000008OfXYAA0",
         "apex-rollup-namespaced@1.2.3": "04t6g000008Off4AAC",
-        "apex-rollup-namespaced@1.2.4": "04t6g000008OfqYAAS"
+        "apex-rollup-namespaced@1.2.4": "04t6g000008OfqYAAS",
+        "apex-rollup-namespaced@1.2.5": "04t6g000008OfrCAAS"
     }
 }

--- a/rollup/core/classes/RollupDateLiteral.cls
+++ b/rollup/core/classes/RollupDateLiteral.cls
@@ -292,15 +292,8 @@ public without sharing abstract class RollupDateLiteral {
 
   private Date getTimezoneSafeEndOfMonth(Datetime startOfMonthRef) {
     // Not every timezone returns the last day of the month when adding a month initially
-    // so we walk the date forward till the month changes, then walk it back one day
-    Date possibleEndOfMonth = startOfMonthRef.addMonths(1).date();
-    while (possibleEndOfMonth.day() != 1 && possibleEndOfMonth.month() == startOfMonthRef.month()) {
-      possibleEndOfMonth = possibleEndOfMonth.addDays(1);
-    }
-    if (possibleEndOfMonth.day() == 1) {
-      possibleEndOfMonth = possibleEndOfMonth.addDays(-1);
-    }
-    return possibleEndOfMonth;
+
+    return Date.newinstance(startOfMonthRef.year(), startOfMonthRef.month() + 1, 1).addDays(-1);
   }
 
   private class FiscalInfo {

--- a/rollup/core/classes/RollupEvaluator.cls
+++ b/rollup/core/classes/RollupEvaluator.cls
@@ -667,9 +667,9 @@ public without sharing abstract class RollupEvaluator implements Rollup.Evaluato
           when 'includes', '!includes' {
             isEqual = false;
             for (String value : this.values) {
-              List<String> splitValues = value.split(';');
+              List<String> splitValues = value?.split(';') ?? new List<String>();
               for (String splitValue : splitValues) {
-                isEqual = storedValue.containsIgnoreCase(splitValue);
+                isEqual = storedValue?.containsIgnoreCase(splitValue) == true;
                 if (isEqual == false) {
                   break;
                 }

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -2,7 +2,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.7.5';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.7.6';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupState.cls
+++ b/rollup/core/classes/RollupState.cls
@@ -239,6 +239,11 @@ public without sharing virtual class RollupState implements System.Queueable, Sy
     ];
     CACHED_STATES.put(cacheKey, states);
     Database.delete(states, false, System.AccessLevel.SYSTEM_MODE);
+    try {
+      Database.emptyRecycleBin(states);
+    } catch (Exception ex) {
+      RollupLogger.Instance.log('Error hard deleting state, continuing execution', ex, System.LoggingLevel.WARN);
+    }
     return states;
   }
 

--- a/rollup/core/classes/RollupState.cls
+++ b/rollup/core/classes/RollupState.cls
@@ -240,7 +240,9 @@ public without sharing virtual class RollupState implements System.Queueable, Sy
     CACHED_STATES.put(cacheKey, states);
     Database.delete(states, false, System.AccessLevel.SYSTEM_MODE);
     try {
-      Database.emptyRecycleBin(states);
+      if (states.isEmpty() == false) {
+        Database.emptyRecycleBin(states);
+      }
     } catch (Exception ex) {
       RollupLogger.Instance.log('Error hard deleting state, continuing execution', ex, System.LoggingLevel.WARN);
     }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,8 +5,8 @@
             "package": "apex-rollup",
             "path": "rollup",
             "scopeProfiles": true,
-            "versionName": "TODO",
-            "versionNumber": "1.7.5.0",
+            "versionName": "Better support for INCLUDES in where clauses",
+            "versionNumber": "1.7.6.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -111,6 +111,7 @@
         "apex-rollup@1.7.2": "04t6g000008OfXTAA0",
         "apex-rollup@1.7.3": "04t6g000008OfdwAAC",
         "apex-rollup@1.7.4": "04t6g000008OfezAAC",
-        "apex-rollup@1.7.5": "04t6g000008OfqTAAS"
+        "apex-rollup@1.7.5": "04t6g000008OfqTAAS",
+        "apex-rollup@1.7.6": "04t6g000008Ofr7AAC"
     }
 }


### PR DESCRIPTION
* Fixes #656 by adding better `INCLUDES` support in where clauses
* Updates `RollupDateLiteral` code path with suggestion from @surajp 
* Hard delete `RollupState__c` records at the end of bulk full recalcs thanks to community suggestions