### PR TITLE
v1.7.10 - RollupRelationshipFieldFinder bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OfsPAAS">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OftNAAS">
   <img alt="Deploy to Salesforce" src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OfsPAAS">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008OftNAAS">
   <img alt="Deploy to Salesforce Sandbox" src="./media/deploy-package-to-sandbox.png">
 </a>
 <br/>

--- a/extra-tests/classes/RollupFlowFullRecalcDispatcherTests.cls
+++ b/extra-tests/classes/RollupFlowFullRecalcDispatcherTests.cls
@@ -73,6 +73,46 @@ private class RollupFlowFullRecalcDispatcherTests {
   }
 
   @IsTest
+  static void shouldPerformParentAPINameFullRecalcFromFlowInput() {
+    Rollup.onlyUseMockMetadata = true;
+    Rollup.rollupMetadata = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        DeveloperName = 'Dummy_Account_Revenue_Rollup',
+        CalcItem__c = 'ContactPointAddress',
+        RollupFieldOnCalcItem__c = 'PreferenceRank',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupObject__c = 'Account',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'SUM',
+        CalcItemWhereClause__c = 'PreferenceRank = 1'
+      ),
+      new Rollup__mdt(
+        DeveloperName = 'Dummy_Account_Number_Of_Employees_Rollup',
+        CalcItem__c = 'ContactPointAddress',
+        RollupFieldOnCalcItem__c = 'PreferenceRank',
+        LookupFieldOnCalcItem__c = 'ParentId',
+        LookupObject__c = 'Account',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'NumberOfEmployees',
+        RollupOperation__c = 'COUNT',
+        CalcItemWhereClause__c = 'Name = \'oneCMDT\''
+      )
+    };
+    RollupFlowFullRecalcDispatcher.FlowInput input = new RollupFlowFullRecalcDispatcher.FlowInput();
+    input.rollupDeveloperNames = 'Account';
+
+    Test.startTest();
+    RollupFlowRecalculator.performFullRecalcRollups(new List<RollupFlowFullRecalcDispatcher.FlowInput>{ input });
+    Test.stopTest();
+
+    Account acc = [SELECT AnnualRevenue, NumberOfEmployees FROM Account];
+    System.assertEquals(6, acc.AnnualRevenue);
+    System.assertEquals(1, acc.NumberOfEmployees);
+    System.assertEquals('Completed', [SELECT Status FROM AsyncApexJob WHERE JobType = 'Queueable' LIMIT 1]?.Status);
+  }
+
+  @IsTest
   static void supportsMultipleChildrenGrandparentTypesAtOnce() {
     Account acc = [SELECT Id, OwnerId FROM Account];
 

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -1971,6 +1971,37 @@ private class RollupFullRecalcTests {
   }
 
   @IsTest
+  static void shouldAddStateRecordAtStartOfFullRecalc() {
+    Account acc = [SELECT Id FROM Account];
+    insert new List<Opportunity>{ new Opportunity(StageName = 'fullRecalc', CloseDate = System.today(), AccountId = acc.Id, Name = 'fullRecalc', Amount = 1) };
+
+    Rollup.defaultControl = new RollupControl__mdt(
+      MaxLookupRowsBeforeBatching__c = 0,
+      BatchChunkSize__c = 2,
+      IsRollupLoggingEnabled__c = true,
+      Id = RollupTestUtils.createId(RollupControl__mdt.SObjectType)
+    );
+    List<Rollup__mdt> metas = new List<Rollup__mdt>{
+      new Rollup__mdt(
+        CalcItem__c = 'Opportunity',
+        RollupFieldOnCalcItem__c = 'Amount',
+        LookupFieldOnCalcItem__c = 'AccountId',
+        LookupObject__c = 'Account',
+        LookupFieldOnLookupObject__c = 'Id',
+        RollupFieldOnLookupObject__c = 'AnnualRevenue',
+        RollupOperation__c = 'SUM',
+        RollupControl__c = Rollup.defaultControl.Id
+      )
+    };
+
+    // purposefully do not use start/stopTest to ensure job does not finish running
+    String jobId = Rollup.performBulkFullRecalc(metas, Rollup.InvocationPoint.FROM_FULL_RECALC_LWC.name());
+
+    Assert.areEqual(1, [SELECT COUNT() FROM AsyncApexJob WHERE ApexClass.Name = :RollupFullBatchRecalculator.class.getName()]);
+    Assert.areEqual(1, [SELECT COUNT() FROM RollupState__c WHERE RelatedJobId__c = :jobId], 'Must populate rollup state');
+  }
+
+  @IsTest
   static void shouldNotBlowUpWithDateFunctionInWhereClause() {
     Account acc = [SELECT Id FROM Account];
 

--- a/extra-tests/classes/RollupIntegrationTests.cls
+++ b/extra-tests/classes/RollupIntegrationTests.cls
@@ -378,6 +378,17 @@ private class RollupIntegrationTests implements Database.Batchable<SObject> {
         LookupFieldOnLookupObject__c = 'Id',
         GrandparentRelationshipFieldPath__c = 'Contacts.Individual.ConsumerCreditScore',
         OneToManyGrandparentFields__c = 'Contact.AccountId'
+      ),
+      new Rollup__mdt(
+        CalcItem__c = 'Account',
+        LookupObject__c = 'Individual',
+        LookupFieldOnCalcItem__c = 'Id',
+        RollupOperation__c = 'COUNT',
+        RollupFieldOnLookupObject__c = 'InfluencerRating',
+        RollupFieldOnCalcItem__c = 'CleanStatus',
+        LookupFieldOnLookupObject__c = 'Id',
+        GrandparentRelationshipFieldPath__c = 'Contacts.Individual.ConsumerCreditScore',
+        OneToManyGrandparentFields__c = 'Contact.AccountId'
       )
     };
     Rollup.shouldRun = true;
@@ -389,12 +400,13 @@ private class RollupIntegrationTests implements Database.Batchable<SObject> {
     Rollup.runFromTrigger();
     Test.stopTest();
 
-    Individual updatedIndy = [SELECT Id, ConsumerCreditScore FROM Individual WHERE Id = :indy.Id];
+    Individual updatedIndy = [SELECT Id, ConsumerCreditScore, InfluencerRating FROM Individual WHERE Id = :indy.Id];
     System.assertEquals(
       acc.AnnualRevenue,
       updatedIndy.ConsumerCreditScore,
       'Apex grandparent rollup should run with reparenting change to intermediate records'
     );
+    System.assertEquals(1, updatedIndy.InfluencerRating);
   }
 
   @IsTest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -5,7 +5,7 @@
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
             "versionName": "Allows individual rollup records to be disabled on Rollup Metadata records",
-            "versionNumber": "1.2.8.0",
+            "versionNumber": "1.2.9.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/rollup/core/classes/RollupFlowFullRecalcDispatcher.cls
+++ b/rollup/core/classes/RollupFlowFullRecalcDispatcher.cls
@@ -1,29 +1,40 @@
 @SuppressWarnings('PMD.AvoidGlobalModifier')
 global without sharing class RollupFlowFullRecalcDispatcher {
   global class FlowInput {
-    @InvocableVariable(label='Comma-separated list of API Names of the Rollup__mdt Records you want to run')
+    @InvocableVariable(label='Comma-separated list of API Names you want to run')
     global String rollupDeveloperNames;
   }
 
-  @InvocableMethod(category='Rollups' label='Full Recalc CMDT-driven Invocable')
+  public interface FlowFullRecalcPreprocessor {
+    Schema.SObjectField getTarget();
+    String getExceptionMessage();
+  }
+
+  @InvocableMethod(category='Rollups' label='Full Recalc Comma-Separated Rollup DeveloperNames')
   public static List<Rollup.FlowOutput> performFullRecalcRollups(List<FlowInput> inputs) {
-    Set<String> rollupDeveloperNames = new Set<String>();
+    return new RollupFlowFullRecalcDispatcher().process(inputs, new DeveloperNamePreprocessor());
+  }
+
+  public List<Rollup.FlowOutput> process(List<FlowInput> inputs, FlowFullRecalcPreprocessor preprocessor) {
+    Set<String> targetNames = new Set<String>();
     for (FlowInput input : inputs) {
       if (String.isBlank(input.rollupDeveloperNames)) {
-        throw new IllegalArgumentException('Comma-separated list of Rollup__mdt DeveloperName(s) was not provided');
+        throw new IllegalArgumentException(preprocessor.getExceptionMessage());
       }
       List<String> splitListOfApiNames = input.rollupDeveloperNames.stripHtmlTags().split(',');
       for (String apiName : splitListOfApiNames) {
-        rollupDeveloperNames.add(apiName.trim());
+        targetNames.add(apiName.trim());
       }
     }
+
     List<Rollup__mdt> localRollupMetadata = Rollup.getMetadataFromCache(Rollup__mdt.SObjectType);
     List<Rollup__mdt> selectedRollupMetadata = new List<Rollup__mdt>();
     for (Rollup__mdt rollup : localRollupMetadata) {
-      if (rollupDeveloperNames.contains(rollup.DeveloperName)) {
+      if (targetNames.contains('' + rollup.get(preprocessor.getTarget().toString()))) {
         selectedRollupMetadata.add(rollup);
       }
     }
+
     List<Rollup.FlowOutput> flowOutputs = new List<Rollup.FlowOutput>();
     Rollup.FlowOutput flowOutput = new Rollup.FlowOutput();
     flowOutput.message = 'No matching metadata, did not start bulk full recalc';
@@ -33,5 +44,15 @@ global without sharing class RollupFlowFullRecalcDispatcher {
       flowOutput.message = 'Job enqueued with Id: ' + enqueuedJobId;
     }
     return flowOutputs;
+  }
+
+  private class DeveloperNamePreprocessor implements FlowFullRecalcPreprocessor {
+    public Schema.SObjectField getTarget() {
+      return Rollup__mdt.DeveloperName;
+    }
+
+    public String getExceptionMessage() {
+      return 'Comma-separated list of Rollup__mdt DeveloperName(s) was not provided';
+    }
   }
 }

--- a/rollup/core/classes/RollupFlowRecalculator.cls
+++ b/rollup/core/classes/RollupFlowRecalculator.cls
@@ -1,0 +1,16 @@
+public without sharing class RollupFlowRecalculator {
+  @InvocableMethod(category='Rollups' label='Full Recalc Comma-Separated Parent API Names')
+  public static List<Rollup.FlowOutput> performFullRecalcRollups(List<RollupFlowFullRecalcDispatcher.FlowInput> inputs) {
+    return new RollupFlowFullRecalcDispatcher().process(inputs, new ParentNamePreprocessor());
+  }
+
+  private class ParentNamePreprocessor implements RollupFlowFullRecalcDispatcher.FlowFullRecalcPreprocessor {
+    public Schema.SObjectField getTarget() {
+      return Schema.Rollup__mdt.LookupObject__c;
+    }
+
+    public String getExceptionMessage() {
+      return 'Comma-separated list of parent API name(s) was not provided';
+    }
+  }
+}

--- a/rollup/core/classes/RollupFlowRecalculator.cls-meta.xml
+++ b/rollup/core/classes/RollupFlowRecalculator.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>63.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -67,7 +67,9 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupF
     }
 
     this.calcItems = this.retriever.fetch();
-    return super.startAsyncWork();
+    String jobId = super.startAsyncWork();
+    insert new RollupState__c(RelatedJobId__c = jobId);
+    return jobId;
   }
 
   private String runBatch() {

--- a/rollup/core/classes/RollupFullBatchRecalculator.cls
+++ b/rollup/core/classes/RollupFullBatchRecalculator.cls
@@ -51,6 +51,7 @@ public without sharing virtual class RollupFullBatchRecalculator extends RollupF
     return RollupFullBatchRecalculator.class.getName();
   }
 
+  @SuppressWarnings('PMD.ApexCRUDViolation')
   protected virtual override String startAsyncWork() {
     if (this.finalizer != null) {
       while (this.cabooses.isEmpty() == false) {

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -2,7 +2,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.7.9';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.7.10';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupRelationshipFieldFinder.cls
+++ b/rollup/core/classes/RollupRelationshipFieldFinder.cls
@@ -603,7 +603,7 @@ public without sharing class RollupRelationshipFieldFinder {
   }
 
   private void retrieveGrandparentAdjacentChildren() {
-    if (this.records?.isEmpty() != false) {
+    if (this.records?.isEmpty() != false || this.metadata.OneToManyGrandParentFields__c != null) {
       return;
     }
 
@@ -691,8 +691,7 @@ public without sharing class RollupRelationshipFieldFinder {
   }
 
   private List<SObject> getJunctionRecords(List<SObject> records, String junctionObjectName, String priorLookup) {
-    String oneToManyFieldName = this.oneToManyParts.get(junctionObjectName);
-    this.oneToManyParts.remove(junctionObjectName);
+    String oneToManyFieldName = this.oneToManyParts.remove(junctionObjectName);
     Schema.SObjectType sObjectType = RollupFieldInitializer.Current.getDescribeFromName(junctionObjectName).getSObjectType();
     this.currentRelationshipName = this.getCurrentRelationshipName(sObjectType);
     Set<Id> junctionRecordIds = new Set<Id>();

--- a/rollup/core/classes/RollupRelationshipFieldFinder.cls
+++ b/rollup/core/classes/RollupRelationshipFieldFinder.cls
@@ -760,14 +760,10 @@ public without sharing class RollupRelationshipFieldFinder {
           this.trackTraversalIds(oneToManyLookup, otherJunctionRecord.Id, field, null);
           oneToManyLookups.add(String.valueOf(oneToManyLookup));
         }
+        Set<String> queryFields = new Set<String>{ this.metadata.LookupFieldOnCalcItem__c, this.metadata.RollupFieldOnCalcItem__c };
+        queryFields.addAll(this.uniqueChildrenFieldNames);
         List<SObject> otherChildrenRecords = this.repo.setQuery(
-            RollupQueryBuilder.Current.getQuery(
-              records.get(0).getSObjectType(),
-              new List<String>{ this.metadata.LookupFieldOnCalcItem__c, this.metadata.RollupFieldOnCalcItem__c },
-              'Id',
-              '=',
-              'Id != :records'
-            )
+            RollupQueryBuilder.Current.getQuery(records.get(0).getSObjectType(), new List<String>(queryFields), 'Id', '=', 'Id != :records')
           )
           .setArg(oneToManyLookups)
           .setArg('records', records)

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -6,7 +6,7 @@
             "path": "rollup",
             "scopeProfiles": true,
             "versionName": "Allows individual rollup records to be disabled on Rollup Metadata records",
-            "versionNumber": "1.7.9.0",
+            "versionNumber": "1.7.10.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -106,6 +106,7 @@
         "apex-rollup@1.7.6": "04t6g000008Ofr7AAC",
         "apex-rollup@1.7.7": "04t6g000008OfrlAAC",
         "apex-rollup@1.7.8": "04t6g000008OfrvAAC",
-        "apex-rollup@1.7.9": "04t6g000008OfsPAAS"
+        "apex-rollup@1.7.9": "04t6g000008OfsPAAS",
+        "apex-rollup@1.7.10": "04t6g000008OftNAAS"
     }
 }


### PR DESCRIPTION
* Fixes an issue reported in #662 where the full recalc app would report a job as having completed before it actually had
* Additional field safety when selecting children records within `RollupRelationshipFieldFinder`
* Added new Flow full recalc code path for comma-separated list of parent API names