### PR TITLE
v1.7.13 - Should Skip Resetting Parent Fields For Default Values

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000sxuWIAQ">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000sxvFIAQ">
   <img alt="Deploy to Salesforce" src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000sxuWIAQ">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000sxvFIAQ">
   <img alt="Deploy to Salesforce Sandbox" src="./media/deploy-package-to-sandbox.png">
 </a>
 <br/>

--- a/extra-tests/classes/RollupFullRecalcTests.cls
+++ b/extra-tests/classes/RollupFullRecalcTests.cls
@@ -530,7 +530,6 @@ private class RollupFullRecalcTests {
     insert events;
 
     Rollup.defaultControl = Rollup.getDefaultControl();
-    Rollup.defaultControl.ShouldSkipResettingParentFields__c = true;
     Rollup.rollupMetadata = new List<Rollup__mdt>{
       new Rollup__mdt(
         CalcItem__c = 'Event',
@@ -2650,5 +2649,52 @@ private class RollupFullRecalcTests {
       this.isNoOp = false;
       this.queryCount = 1;
     }
+  }
+
+  @IsTest
+  static void shouldNotResetNonMatchingParentsWhenMultipleParentTypesArePresent() {
+    Rollup.defaultControl = new RollupControl__mdt(IsRollupLoggingEnabled__c = true, ShouldSkipResettingParentFields__c = true);
+    Rollup.onlyUseMockMetadata = true;
+    Account parent = [SELECT Id FROM Account];
+    Individual indy = new Individual(FirstName = 'Test', LastName = 'User', ConsumerCreditScore = 25);
+    insert indy;
+
+    insert new List<SObject>{
+      new ContactPointAddress(ParentId = parent.Id, Name = 'child 1 first object', PreferenceRank = 25),
+      new ContactPointAddress(ParentId = indy.Id, Name = indy.Id, PreferenceRank = 25)
+    };
+
+    Test.startTest();
+    Rollup.performBulkFullRecalc(
+      new List<Rollup__mdt>{
+        new Rollup__mdt(
+          CalcItem__c = 'ContactPointAddress',
+          LookupFieldOnCalcItem__c = 'Name',
+          RollupFieldOnCalcItem__c = 'PreferenceRank',
+          RollupOperation__c = 'SUM',
+          LookupObject__c = 'Individual',
+          LookupFieldOnLookupObject__c = 'Id',
+          RollupFieldOnLookupObject__c = 'ConsumerCreditScore',
+          CalcItemWhereClause__c = 'PreferenceRank != 25',
+          FullRecalculationDefaultNumberValue__c = 0
+        ),
+        new Rollup__mdt(
+          CalcItem__c = 'ContactPointAddress',
+          LookupFieldOnCalcItem__c = 'ParentId',
+          RollupFieldOnCalcItem__c = 'PreferenceRank',
+          RollupOperation__c = 'SUM',
+          LookupObject__c = 'Account',
+          LookupFieldOnLookupObject__c = 'Id',
+          RollupFieldOnLookupObject__c = 'AnnualRevenue',
+          CalcItemWhereClause__c = 'PreferenceRank = 25',
+          FullRecalculationDefaultNumberValue__c = 0
+        )
+      },
+      Rollup.InvocationPoint.FROM_FULL_RECALC_LWC.name()
+    );
+    Test.stopTest();
+
+    Assert.areEqual(25, [SELECT AnnualRevenue FROM Account WHERE Id = :parent.Id].AnnualRevenue);
+    Assert.areEqual(25, [SELECT ConsumerCreditScore FROM Individual WHERE Id = :indy.Id].ConsumerCreditScore);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.7.12",
+  "version": "1.7.13",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000sxubIAA">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000sxvKIAQ">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000sxubIAA">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000sxvKIAQ">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Removes Data.com test dependencies, update to sf code-analyzer",
-            "versionNumber": "1.2.9.0",
+            "versionName": "Should skip resetting parent fields applies to default values on full recalc",
+            "versionNumber": "1.2.10.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -26,6 +26,7 @@
         "apex-rollup-namespaced@1.2.6": "04t6g000008OfrqAAC",
         "apex-rollup-namespaced@1.2.7": "04t6g000008Ofs0AAC",
         "apex-rollup-namespaced@1.2.8": "04t6g000008OfsUAAS",
-        "apex-rollup-namespaced@1.2.9": "04tKf000000sxubIAA"
+        "apex-rollup-namespaced@1.2.9": "04tKf000000sxubIAA",
+        "apex-rollup-namespaced@1.2.10": "04tKf000000sxvKIAQ"
     }
 }

--- a/rollup/core/classes/Rollup.cls
+++ b/rollup/core/classes/Rollup.cls
@@ -588,9 +588,9 @@ global without sharing virtual class Rollup implements RollupLogger.ToStringObje
     List<RollupFullRecalcProcessor> processors = transformWrappedMetadataToFullRecalcRollups(childToMetaWrapper, localInvokePoint);
     isFullRecalcApp = false;
     if (processors.size() > 1 && processors[0].rollupControl.ShouldRunAs__c != RollupMetaPicklists.ShouldRunAs.Synchronous) {
-      RollupFullRecalcProcessor conductor = processors[0];
-      while (processors.size() > 1) {
-        conductor.rollups.add(processors.remove(1));
+      RollupFullRecalcProcessor conductor = processors.remove(0);
+      while (processors.size() > 0) {
+        conductor.rollups.add(processors.remove(0));
       }
       return conductor.runCalc();
     }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -1357,7 +1357,11 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
         // this guard clause prevents a full recalculation from taking place unnecessarily if a reparenting operation
         // has already been setup to adjust the lookup item's rollup field
         if (oldLookupItems.containsKey(key) == false) {
-          Object priorValToUse = roll.isFullRecalc && hasNotAlreadyBeenReset ? defaultVal : priorVal;
+          Object priorValToUse = roll.isFullRecalc &&
+            hasNotAlreadyBeenReset &&
+            this.rollupControl.ShouldSkipResettingParentFields__c == false
+            ? defaultVal
+            : priorVal;
           calc = this.getCalculator(rollupOp, calc, roll, bag, lookupRecord, priorValToUse, key, roll.lookupFieldOnCalcItem);
           this.conditionallyPerformUpdate(priorVal, calc, lookupRecord, roll, recordsToUpdate, ParentUpdateType.LOOKUP, localCalcItems);
         }

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -2,7 +2,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.7.12';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.7.13';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -109,6 +109,7 @@
         "apex-rollup@1.7.9": "04t6g000008OfsPAAS",
         "apex-rollup@1.7.10": "04t6g000008OftNAAS",
         "apex-rollup@1.7.11": "04t6g000008OfuLAAS",
-        "apex-rollup@1.7.12": "04tKf000000sxuWIAQ"
+        "apex-rollup@1.7.12": "04tKf000000sxuWIAQ",
+        "apex-rollup@1.7.13": "04tKf000000sxvFIAQ"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,8 +5,8 @@
             "package": "apex-rollup",
             "path": "rollup",
             "scopeProfiles": true,
-            "versionName": "Removes Data.com test dependencies, update to sf code-analyzer",
-            "versionNumber": "1.7.12.0",
+            "versionName": "Should skip resetting parent fields applies to default values on full recalc",
+            "versionNumber": "1.7.13.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
* Fixes an issue discussed in #674 where Should Skip Resetting Parent Fields flag should also prevent default values from being applied during full recalcs