### PR TITLE
v1.7.16 - Recalc Rollup Buttons Properly Wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000sy3ZIAQ">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000sy3oIAA">
   <img alt="Deploy to Salesforce" src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000sy3ZIAQ">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000sy3oIAA">
   <img alt="Deploy to Salesforce Sandbox" src="./media/deploy-package-to-sandbox.png">
 </a>
 <br/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.7.15",
+  "version": "1.7.16",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000sy3eIAA">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000sy3tIAA">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000sy3eIAA">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000sy3tIAA">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Recalc parent quick action & allowance for order bys to override picklist rankings & CONCAT bugfix for null values",
-            "versionNumber": "1.2.12.0",
+            "versionName": "Recalc parent quick action properly waits for rollups to complete",
+            "versionNumber": "1.2.13.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -29,6 +29,7 @@
         "apex-rollup-namespaced@1.2.9": "04tKf000000sxubIAA",
         "apex-rollup-namespaced@1.2.10": "04tKf000000sxvKIAQ",
         "apex-rollup-namespaced@1.2.11": "04tKf000000sxy4IAA",
-        "apex-rollup-namespaced@1.2.12": "04tKf000000sy3eIAA"
+        "apex-rollup-namespaced@1.2.12": "04tKf000000sy3eIAA",
+        "apex-rollup-namespaced@1.2.13": "04tKf000000sy3tIAA"
     }
 }

--- a/rollup/app/lwc/recalculateParentRollupFlexipage/recalculateParentRollupFlexipage.html
+++ b/rollup/app/lwc/recalculateParentRollupFlexipage/recalculateParentRollupFlexipage.html
@@ -9,4 +9,5 @@
       </template>
     </div>
   </template>
+  <c-rollup-job-poller class="slds-hide"></c-rollup-job-poller>
 </template>

--- a/rollup/app/lwc/recalculateParentRollupFlexipage/recalculateParentRollupFlexipage.js
+++ b/rollup/app/lwc/recalculateParentRollupFlexipage/recalculateParentRollupFlexipage.js
@@ -45,7 +45,11 @@ export default class RecalculateParentRollupFlexipage extends LightningElement {
 
     if (this._matchingMetas.length > 0) {
       try {
-        await performSerializedBulkFullRecalc({ serializedMetadata: JSON.stringify(this._matchingMetas), invokePointName: 'FROM_SINGULAR_PARENT_RECALC_LWC' });
+        const serverResponse = await performSerializedBulkFullRecalc({
+          serializedMetadata: JSON.stringify(this._matchingMetas),
+          invokePointName: 'FROM_SINGULAR_PARENT_RECALC_LWC'
+        });
+        await this.template.querySelector('c-rollup-job-poller').runJobPoller(serverResponse);
         this.dispatchEvent(new RefreshEvent());
       } catch (err) {
         this.logErrorToConsole(err);

--- a/rollup/app/lwc/recalculateParentRollupQuickAction/recalculateParentRollupQuickAction.html
+++ b/rollup/app/lwc/recalculateParentRollupQuickAction/recalculateParentRollupQuickAction.html
@@ -1,7 +1,7 @@
 <template>
   <template lwc:if={isExecuting}>
-    <div class="slds-is-relative">
-      <lightning-spinner style="top: -32px" size="small" variant="neutral"></lightning-spinner>
+    <div class="slds-backdrop slds-backdrop_open">
+      <lightning-spinner alternative-text="Recalculating rollup..." size="medium" variant="neutral"></lightning-spinner>
     </div>
   </template>
   <c-recalculate-parent-rollup-flexipage

--- a/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.html
+++ b/rollup/app/lwc/rollupForceRecalculation/rollupForceRecalculation.html
@@ -193,9 +193,7 @@
         <lightning-spinner alternative-text="Please wait while rollup is processed" title="Rolling up ...."></lightning-spinner>
       </template>
     </section>
-    <template if:true={rollupStatus}>
-      <div class="slds-m-top_small">Rollup job status: <b>{rollupStatus}{jobIdToDisplay}</b></div>
-    </template>
+    <c-rollup-job-poller></c-rollup-job-poller>
     <template if:true={error}>
       <div class="slds-m-top_small" data-id="rollupError">An error occurred: {error}</div>
     </template>

--- a/rollup/app/lwc/rollupJobPoller/__tests__/rollupJobPoller.test.js
+++ b/rollup/app/lwc/rollupJobPoller/__tests__/rollupJobPoller.test.js
@@ -1,0 +1,49 @@
+import { createElement } from 'lwc';
+
+import getBatchRollupStatus from '@salesforce/apex/Rollup.getBatchRollupStatus';
+import RollupJobPoller from 'c/rollupJobPoller';
+
+jest.mock(
+  '@salesforce/apex/Rollup.getBatchRollupStatus',
+  () => {
+    return {
+      default: jest.fn()
+    };
+  },
+  { virtual: true }
+);
+
+describe('recalc parent rollup from flexipage tests', () => {
+  afterEach(() => {
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+    jest.clearAllMocks();
+  });
+
+  it('should handle error on load gracefully', async () => {
+    const element = createElement('c-rollup-job-poller', {
+      is: RollupJobPoller
+    });
+    document.body.appendChild(element);
+
+    element.runJobPoller();
+    await Promise.resolve();
+
+    expect(element.shadowRoot.querySelector('div').textContent).toBe('Rollup job status: failed to enqueue, check Apex Debug Logs for more info');
+  });
+
+  it('should display the rollup job status', async () => {
+    getBatchRollupStatus.mockResolvedValue('Queued');
+    const element = createElement('c-rollup-job-poller', {
+      is: RollupJobPoller
+    });
+    document.body.appendChild(element);
+
+    element.runJobPoller('707somethingValid');
+    await Promise.resolve('Mount re-render');
+    await Promise.resolve('Poll re-render');
+
+    expect(element.shadowRoot.querySelector('div').textContent).toBe('Rollup job status: Queued for job: 707somethingValid');
+  });
+});

--- a/rollup/app/lwc/rollupJobPoller/rollupJobPoller.html
+++ b/rollup/app/lwc/rollupJobPoller/rollupJobPoller.html
@@ -1,0 +1,5 @@
+<template>
+  <template lwc:if={rollupStatus}>
+    <div class="slds-m-top_small">Rollup job status: <b>{rollupStatus}{jobIdToDisplay}</b></div>
+  </template>
+</template>

--- a/rollup/app/lwc/rollupJobPoller/rollupJobPoller.js
+++ b/rollup/app/lwc/rollupJobPoller/rollupJobPoller.js
@@ -1,0 +1,47 @@
+import { api, LightningElement } from 'lwc';
+
+import { isValidAsyncJob } from 'c/rollupUtils';
+import getBatchRollupStatus from '@salesforce/apex/Rollup.getBatchRollupStatus';
+
+const RESOLVED_JOB_STATUSES = ['Completed', 'Failed', 'Aborted'];
+
+export default class RollupJobPoller extends LightningElement {
+  @api
+  async runJobPoller(jobId) {
+    return this._poll(jobId);
+  }
+
+  jobIdToDisplay;
+  rollupStatus;
+
+  async _poll(jobId) {
+    if (!jobId) {
+      this.rollupStatus = 'failed to enqueue, check Apex Debug Logs for more info';
+      return;
+    }
+
+    this.jobIdToDisplay = jobId;
+    if (this.jobIdToDisplay) {
+      this.jobIdToDisplay = ' for job: ' + this.jobIdToDisplay;
+    }
+
+    this.rollupStatus = await getBatchRollupStatus({ jobId });
+
+    if (RESOLVED_JOB_STATUSES.includes(this.rollupStatus) === false && this._validateAsyncJob(jobId)) {
+      // some arbitrary wait time - for a huge recalculation job, it could take a while to finish
+      const waitTimeMs = 10000;
+      /* eslint-disable-next-line */
+      await new Promise(innerRes => setTimeout(innerRes, waitTimeMs));
+      await this._poll(jobId);
+    }
+  }
+
+  _validateAsyncJob = val => {
+    const isValid = isValidAsyncJob(val);
+    if (!isValid) {
+      this.jobId = '';
+      this.rollupStatus = val;
+    }
+    return isValid;
+  };
+}

--- a/rollup/app/lwc/rollupJobPoller/rollupJobPoller.js-meta.xml
+++ b/rollup/app/lwc/rollupJobPoller/rollupJobPoller.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>63.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/rollup/app/lwc/rollupUtils/__tests__/rollupUtils.test.js
+++ b/rollup/app/lwc/rollupUtils/__tests__/rollupUtils.test.js
@@ -1,4 +1,4 @@
-import { getRollupMetadata } from 'c/rollupUtils';
+import { isValidAsyncJob, getRollupMetadata } from 'c/rollupUtils';
 import { mockMetadata } from '../../__mockData__';
 
 jest.mock(
@@ -17,5 +17,10 @@ describe('utils tests', () => {
 
     delete mockMetadata.Contact[0].CalcItem__r;
     expect(returnedMetadata).toEqual(mockMetadata);
+  });
+
+  it('knows a valid async job id from an invalid one using key prefix', () => {
+    expect(isValidAsyncJob('707...')).toBeTruthy();
+    expect(isValidAsyncJob('No process Id')).toBeFalsy();
   });
 });

--- a/rollup/app/lwc/rollupUtils/rollupUtils.js
+++ b/rollup/app/lwc/rollupUtils/rollupUtils.js
@@ -1,5 +1,7 @@
 import getRollupMetadataByCalcItem from '@salesforce/apex/Rollup.getRollupMetadataByCalcItem';
 
+const isValidAsyncJob = val => val?.slice(0, 3) === '707';
+
 /**
  *
  * @param {object} record
@@ -38,4 +40,4 @@ const transformToSerializableChildren = (record, key, children) => {
   }
 };
 
-export { getRollupMetadata, transformToSerializableChildren };
+export { isValidAsyncJob, getRollupMetadata, transformToSerializableChildren };

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -2,7 +2,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.7.15';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.7.16-beta';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -2,7 +2,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.7.16-beta';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.7.16';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/rollup/core/classes/RollupParentResetProcessor.cls
+++ b/rollup/core/classes/RollupParentResetProcessor.cls
@@ -75,7 +75,7 @@ public without sharing class RollupParentResetProcessor extends RollupFullBatchR
     } else if (this.countOfItems > 0) {
       isRecursiveRun = true;
       for (RollupAsyncProcessor proc : this.rollups) {
-        proc.runCalc();
+        processId = proc.runCalc();
       }
       isRecursiveRun = false;
       this.runSync();

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,8 +5,8 @@
             "package": "apex-rollup",
             "path": "rollup",
             "scopeProfiles": true,
-            "versionName": "Recalc parent quick action & allowance for order bys to override picklist rankings & CONCAT bugfix for null values",
-            "versionNumber": "1.7.15.0",
+            "versionName": "Recalc parent quick action properly waits for rollups to complete",
+            "versionNumber": "1.7.16.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -109,6 +109,7 @@
         "apex-rollup@1.7.12": "04tKf000000sxuWIAQ",
         "apex-rollup@1.7.13": "04tKf000000sxvFIAQ",
         "apex-rollup@1.7.14": "04tKf000000sxxzIAA",
-        "apex-rollup@1.7.15": "04tKf000000sy3ZIAQ"
+        "apex-rollup@1.7.15": "04tKf000000sy3ZIAQ",
+        "apex-rollup@1.7.16": "04tKf000000sy3oIAA"
     }
 }


### PR DESCRIPTION
* Fixes #686 by properly awaiting singular parent recalc buttons. _Most_ calculations occur synchronously, but if an async job is kicked off due to a large number of children records, the component(s) will still wait till the recalculation has completely finished