### PR TITLE
v1.7.25 - Fixes known issue with packaging first reported in #697

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000syBUIAY">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000syBeIAI">
   <img alt="Deploy to Salesforce" src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000syBUIAY">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000syBeIAI">
   <img alt="Deploy to Salesforce Sandbox" src="./media/deploy-package-to-sandbox.png">
 </a>
 <br/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.7.24",
+  "version": "1.7.25",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000syBZIAY">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000syBjIAI">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000syBZIAY">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKf000000syBjIAI">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Restores ability to schedule rollups with a query starting from a parent object",
-            "versionNumber": "1.2.21.0",
+            "versionName": "Fixes managed packaging known issue a028c00000qQ7V6AAK",
+            "versionNumber": "1.2.22.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -38,6 +38,7 @@
         "apex-rollup-namespaced@1.2.18": "04tKf000000syACIAY",
         "apex-rollup-namespaced@1.2.19": "04tKf000000syAWIAY",
         "apex-rollup-namespaced@1.2.20": "04tKf000000syAlIAI",
-        "apex-rollup-namespaced@1.2.21": "04tKf000000syBZIAY"
+        "apex-rollup-namespaced@1.2.21": "04tKf000000syBZIAY",
+        "apex-rollup-namespaced@1.2.22": "04tKf000000syBjIAI"
     }
 }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -399,7 +399,7 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
     }
   }
 
-  public without sharing virtual class QueueableProcessor extends RollupAsyncProcessor implements System.Queueable {
+  global without sharing virtual class QueueableProcessor extends RollupAsyncProcessor implements System.Queueable {
     protected QueueableProcessor(InvocationPoint rollupInvokePoint) {
       super(rollupInvokePoint);
     }

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -2,7 +2,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.7.24';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.7.25';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -106,6 +106,7 @@
         "apex-rollup@1.7.21": "04tKf000000syA7IAI",
         "apex-rollup@1.7.22": "04tKf000000syARIAY",
         "apex-rollup@1.7.23": "04tKf000000syAgIAI",
-        "apex-rollup@1.7.24": "04tKf000000syBUIAY"
+        "apex-rollup@1.7.24": "04tKf000000syBUIAY",
+        "apex-rollup@1.7.25": "04tKf000000syBeIAI"
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,8 +5,8 @@
             "package": "apex-rollup",
             "path": "rollup",
             "scopeProfiles": true,
-            "versionName": "Restores ability to schedule rollups with a query starting from a parent object",
-            "versionNumber": "1.7.24.0",
+            "versionName": "Fixes managed packaging known issue a028c00000qQ7V6AAK",
+            "versionNumber": "1.7.25.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {


### PR DESCRIPTION
* Updates visibility modifier for `RollupAsyncProcessor.QueueableProcessor`, which in a regression to packaging unexpectedly broke ancestor version compatibility for some ISVs