### PR TITLE
feat(logging): enhanced logging

### DIFF
--- a/extra-tests/classes/RollupLoggerTests.cls
+++ b/extra-tests/classes/RollupLoggerTests.cls
@@ -88,6 +88,15 @@ private class RollupLoggerTests {
       localLogObject = logObject;
       localLogLevel = logLevel;
     }
+    public void logDiagnostic(String logString, System.LoggingLevel logLevel) {
+      locallogString = logString;
+      localLogLevel = logLevel;
+    }
+    public void logDiagnostic(String logString, Object logObject, System.LoggingLevel logLevel) {
+      locallogString = logString;
+      localLogObject = logObject;
+      localLogLevel = logLevel;
+    }
     public void save() {
       wasSaved = true;
     }
@@ -101,5 +110,75 @@ private class RollupLoggerTests {
       locallogString = logString;
       localLogLevel = logLevel;
     }
+  }
+
+  @IsTest
+  static void diagnosticLevelLogsWhenSetToDiagnostic() {
+    Rollup.defaultControl = new RollupControl__mdt(RollupLoggingLevel__c = 'Diagnostic');
+    RollupPlugin.pluginMocks = new List<RollupPlugin__mdt>{ new RollupPlugin__mdt(DeveloperName = ExampleLogger.class.getName()) };
+    locallogString = null;
+    String diagnosticMessage = 'diagnostic test message';
+
+    Test.startTest();
+    RollupLogger.Instance.logDiagnostic(diagnosticMessage, System.LoggingLevel.INFO);
+    Test.stopTest();
+
+    Assert.areEqual(diagnosticMessage, locallogString, 'Diagnostic messages should log when level is Diagnostic');
+  }
+
+  @IsTest
+  static void debugLevelDoesNotLogWhenSetToDiagnostic() {
+    Rollup.defaultControl = new RollupControl__mdt(RollupLoggingLevel__c = 'Diagnostic');
+    RollupPlugin.pluginMocks = new List<RollupPlugin__mdt>{ new RollupPlugin__mdt(DeveloperName = ExampleLogger.class.getName()) };
+    locallogString = null;
+
+    Test.startTest();
+    RollupLogger.Instance.log('debug message', System.LoggingLevel.DEBUG);
+    Test.stopTest();
+
+    Assert.isNull(locallogString, 'Debug messages should not log when level is Diagnostic');
+  }
+
+  @IsTest
+  static void bothLevelsLogWhenSetToDebug() {
+    Rollup.defaultControl = new RollupControl__mdt(RollupLoggingLevel__c = 'Debug');
+    RollupPlugin.pluginMocks = new List<RollupPlugin__mdt>{ new RollupPlugin__mdt(DeveloperName = ExampleLogger.class.getName()) };
+    locallogString = null;
+
+    Test.startTest();
+    RollupLogger.Instance.log('debug message', System.LoggingLevel.DEBUG);
+    Assert.areEqual('debug message', locallogString, 'Debug messages should log when level is Debug');
+
+    RollupLogger.Instance.logDiagnostic('diagnostic message', System.LoggingLevel.INFO);
+    Test.stopTest();
+
+    Assert.areEqual('diagnostic message', locallogString, 'Diagnostic messages should also log when level is Debug');
+  }
+
+  @IsTest
+  static void nothingLogsWhenSetToNone() {
+    Rollup.defaultControl = new RollupControl__mdt(RollupLoggingLevel__c = 'None');
+    RollupPlugin.pluginMocks = new List<RollupPlugin__mdt>{ new RollupPlugin__mdt(DeveloperName = ExampleLogger.class.getName()) };
+    locallogString = null;
+
+    Test.startTest();
+    RollupLogger.Instance.log('debug message', System.LoggingLevel.DEBUG);
+    RollupLogger.Instance.logDiagnostic('diagnostic message', System.LoggingLevel.INFO);
+    Test.stopTest();
+
+    Assert.areEqual('logging isn\'t enabled, further log messages paused unless otherwise re-activated', locallogString, 'Only disabled message should appear when level is None');
+  }
+
+  @IsTest
+  static void backwardCompatibilityWithIsRollupLoggingEnabled() {
+    Rollup.defaultControl = new RollupControl__mdt(IsRollupLoggingEnabled__c = true, RollupLoggingLevel__c = null);
+    RollupPlugin.pluginMocks = new List<RollupPlugin__mdt>{ new RollupPlugin__mdt(DeveloperName = ExampleLogger.class.getName()) };
+    locallogString = null;
+
+    Test.startTest();
+    RollupLogger.Instance.log('test message', System.LoggingLevel.DEBUG);
+    Test.stopTest();
+
+    Assert.areEqual('test message', locallogString, 'Legacy IsRollupLoggingEnabled__c = true should enable debug-level logging');
   }
 }

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -6,6 +6,12 @@ global without sharing virtual class RollupLogger implements ILogger {
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 
+  global enum LoggingVerbosity {
+    NONE,
+    DIAGNOSTIC,
+    DEBUG
+  }
+
   private final System.LoggingLevel currentLoggingLevel;
 
   protected RollupLogger() {
@@ -31,6 +37,8 @@ global without sharing virtual class RollupLogger implements ILogger {
   global interface ILogger {
     void log(String logString, System.LoggingLevel logLevel);
     void log(String logString, Object logObject, System.LoggingLevel logLevel);
+    void logDiagnostic(String logString, System.LoggingLevel logLevel);
+    void logDiagnostic(String logString, Object logObject, System.LoggingLevel logLevel);
     void save();
     ILogger updateRollupControl(RollupControl__mdt control);
   }
@@ -40,6 +48,16 @@ global without sharing virtual class RollupLogger implements ILogger {
   }
 
   global virtual void log(String logString, Object logObject, System.LoggingLevel logLevel) {
+    if (logLevel.ordinal() >= this.currentLoggingLevel.ordinal()) {
+      this.innerLog(logString, logObject, logLevel);
+    }
+  }
+
+  public void logDiagnostic(String logString, System.LoggingLevel logLevel) {
+    this.logDiagnostic(logString, null, logLevel);
+  }
+
+  global virtual void logDiagnostic(String logString, Object logObject, System.LoggingLevel logLevel) {
     if (logLevel.ordinal() >= this.currentLoggingLevel.ordinal()) {
       this.innerLog(logString, logObject, logLevel);
     }
@@ -177,20 +195,50 @@ global without sharing virtual class RollupLogger implements ILogger {
     }
 
     public void log(String logString, Object logObject, System.LoggingLevel logLevel) {
-      if (this.control.IsRollupLoggingEnabled__c == false && this.hasDisabledMessageBeenLogged == false) {
+      LoggingVerbosity verbosity = this.getEffectiveVerbosity();
+      if (verbosity == LoggingVerbosity.NONE && this.hasDisabledMessageBeenLogged == false) {
         this.hasDisabledMessageBeenLogged = true;
-        this.control.IsRollupLoggingEnabled__c = true;
-        this.log('logging isn\'t enabled, further log messages paused unless otherwise re-activated', System.LoggingLevel.INFO);
-        this.control.IsRollupLoggingEnabled__c = false;
-      } else if (this.control.IsRollupLoggingEnabled__c) {
-        for (ILogger logger : this.loggers) {
-          logger.log(logString, logObject, logLevel);
-        }
+        this.innerLog('logging isn\'t enabled, further log messages paused unless otherwise re-activated', null, System.LoggingLevel.INFO);
+      } else if (verbosity == LoggingVerbosity.DEBUG) {
+        this.innerLog(logString, logObject, logLevel);
+      }
+      // If verbosity is DIAGNOSTIC, debug-level messages are suppressed
+    }
+
+    public void logDiagnostic(String logString, System.LoggingLevel logLevel) {
+      this.logDiagnostic(logString, null, logLevel);
+    }
+
+    public void logDiagnostic(String logString, Object logObject, System.LoggingLevel logLevel) {
+      LoggingVerbosity verbosity = this.getEffectiveVerbosity();
+      if (verbosity == LoggingVerbosity.DIAGNOSTIC || verbosity == LoggingVerbosity.DEBUG) {
+        this.innerLog(logString, logObject, logLevel);
       }
     }
 
+    private void innerLog(String logString, Object logObject, System.LoggingLevel logLevel) {
+      for (ILogger logger : this.loggers) {
+        logger.log(logString, logObject, logLevel);
+      }
+    }
+
+    private LoggingVerbosity getEffectiveVerbosity() {
+      String loggingLevel = this.control.RollupLoggingLevel__c;
+      if (String.isNotBlank(loggingLevel)) {
+        if (loggingLevel == RollupMetaPicklists.LoggingLevel.Debug) {
+          return LoggingVerbosity.DEBUG;
+        } else if (loggingLevel == RollupMetaPicklists.LoggingLevel.Diagnostic) {
+          return LoggingVerbosity.DIAGNOSTIC;
+        }
+        return LoggingVerbosity.NONE;
+      }
+      // Backward compatibility: use IsRollupLoggingEnabled__c when RollupLoggingLevel__c is not set
+      return this.control.IsRollupLoggingEnabled__c == true ? LoggingVerbosity.DEBUG : LoggingVerbosity.NONE;
+    }
+
     public void save() {
-      if (this.control.IsRollupLoggingEnabled__c != false) {
+      LoggingVerbosity verbosity = this.getEffectiveVerbosity();
+      if (verbosity != LoggingVerbosity.NONE) {
         for (ILogger logger : this.loggers) {
           logger.save();
         }
@@ -198,12 +246,18 @@ global without sharing virtual class RollupLogger implements ILogger {
     }
 
     public CombinedLogger updateRollupControl(RollupControl__mdt control) {
-      String updateMessage = 'updating control record';
-      if (control.IsRollupLoggingEnabled__c == true && this.control.IsRollupLoggingEnabled__c != true) {
-        updateMessage = 'logging is now re-enabled, ' + updateMessage;
-      }
+      LoggingVerbosity oldVerbosity = this.getEffectiveVerbosity();
       this.control = control;
-      this.log(updateMessage, control, System.LoggingLevel.INFO);
+      LoggingVerbosity newVerbosity = this.getEffectiveVerbosity();
+
+      String updateMessage = 'updating control record';
+      if (newVerbosity != LoggingVerbosity.NONE && oldVerbosity == LoggingVerbosity.NONE) {
+        updateMessage = 'logging is now re-enabled at ' + newVerbosity.name() + ' level, ' + updateMessage;
+        this.hasDisabledMessageBeenLogged = false;
+      } else if (newVerbosity != oldVerbosity) {
+        updateMessage = 'logging level changed from ' + oldVerbosity.name() + ' to ' + newVerbosity.name() + ', ' + updateMessage;
+      }
+      this.logDiagnostic(updateMessage, control, System.LoggingLevel.INFO);
       return this;
     }
   }

--- a/rollup/core/classes/RollupMetaPicklists.cls
+++ b/rollup/core/classes/RollupMetaPicklists.cls
@@ -38,6 +38,14 @@ public virtual without sharing class RollupMetaPicklists {
     private set;
   }
 
+  public static final LoggingLevel LoggingLevel {
+    get {
+      LoggingLevel = LoggingLevel ?? new LoggingLevel();
+      return LoggingLevel;
+    }
+    private set;
+  }
+
   private RollupMetaPicklists(Schema.SObjectField fieldToken) {
     this.validValues = new Set<String>();
 
@@ -145,6 +153,36 @@ public virtual without sharing class RollupMetaPicklists {
       get {
         this.UserLevel = this.UserLevel ?? this.validate('User');
         return this.UserLevel;
+      }
+      private set;
+    }
+  }
+
+  public class LoggingLevel extends RollupMetaPicklists {
+    public LoggingLevel() {
+      super(RollupControl__mdt.RollupLoggingLevel__c);
+    }
+
+    public final String None {
+      get {
+        this.None = this.None ?? this.validate('None');
+        return this.None;
+      }
+      private set;
+    }
+
+    public final String Diagnostic {
+      get {
+        this.Diagnostic = this.Diagnostic ?? this.validate('Diagnostic');
+        return this.Diagnostic;
+      }
+      private set;
+    }
+
+    public final String Debug {
+      get {
+        this.Debug = this.Debug ?? this.validate('Debug');
+        return this.Debug;
       }
       private set;
     }

--- a/rollup/core/objects/RollupControl__mdt/fields/RollupLoggingLevel__c.field-meta.xml
+++ b/rollup/core/objects/RollupControl__mdt/fields/RollupLoggingLevel__c.field-meta.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RollupLoggingLevel__c</fullName>
+    <description>Controls the verbosity of rollup logging. None disables logging entirely. Diagnostic logs high-level operational information (rollup names, query strings, query counts, major decisions). Debug logs everything for detailed troubleshooting.</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>Controls the verbosity of rollup logging. None disables logging entirely. Diagnostic logs high-level operational information. Debug logs everything for detailed troubleshooting.</inlineHelpText>
+    <label>Rollup Logging Level</label>
+    <required>false</required>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>None</fullName>
+                <default>true</default>
+                <label>None</label>
+            </value>
+            <value>
+                <fullName>Diagnostic</fullName>
+                <default>false</default>
+                <label>Diagnostic</label>
+            </value>
+            <value>
+                <fullName>Debug</fullName>
+                <default>false</default>
+                <label>Debug</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>


### PR DESCRIPTION
At high volume, it can be hard to identify the correct log(s) to read to understand the behavior of apex-rollup, especially around the pivot point where it switches to executing a full recalc.

To help with this, this PR enhances existing logging work by adding a new logging option. Instead of 'on' or 'off' logging now supports 'Diagnostic' and 'Debug' logging.

When set to Diagnostic the following are logged:

queries, their bind variables and access levels
query Counts
When set to Debug it functions as it currently does, logging not only the queries, bind variables and access levels but also per-record changes.