### PR TITLE
v1.7.40 - Reparenting bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ As well, don't miss [the Wiki](../../wiki), which includes even more info for co
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tg70000007hmbAAA">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tg7000000CG0zAAG">
   <img alt="Deploy to Salesforce" src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tg70000007hmbAAA">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tg7000000CG0zAAG">
   <img alt="Deploy to Salesforce Sandbox" src="./media/deploy-package-to-sandbox.png">
 </a>
 <br/>

--- a/extra-tests/classes/RollupTests.cls
+++ b/extra-tests/classes/RollupTests.cls
@@ -2814,6 +2814,28 @@ private class RollupTests {
   }
 
   @IsTest
+  static void shouldClearConcatDistinctOnDetachToNull() {
+    Account oldAcc = [SELECT Id, AccountNumber FROM Account];
+    oldAcc.AccountNumber = 'A';
+    RollupAsyncProcessor.stubParentRecords = new List<SObject>{ oldAcc };
+
+    ContactPointAddress cpa = new ContactPointAddress(Name = 'A', ParentId = null, Id = RollupTestUtils.createId(ContactPointAddress.SObjectType));
+
+    RollupTestUtils.DMLMock mock = RollupTestUtils.loadMock(new List<ContactPointAddress>{ cpa });
+    Rollup.apexContext = TriggerOperation.AFTER_UPDATE;
+
+    // child's old state: was attached to oldAcc
+    Rollup.oldRecordsMap = new Map<Id, ContactPointAddress>{ cpa.Id => new ContactPointAddress(ParentId = oldAcc.Id, Name = 'A', Id = cpa.Id) };
+
+    Test.startTest();
+    Rollup.concatDistinctFromApex(ContactPointAddress.Name, ContactPointAddress.ParentId, Account.Id, Account.AccountNumber, Account.SObjectType).runCalc();
+    Test.stopTest();
+
+    System.assertEquals(1, mock.Records.size(), 'Old parent should have been updated after detach: ' + mock.Records);
+    System.assertEquals('', oldAcc.AccountNumber, 'CONCAT_DISTINCT should be null on old parent after child detaches to null');
+  }
+
+  @IsTest
   static void shouldCorrectlyReparentForStringCount() {
     Account acc = [SELECT Id, AnnualRevenue FROM Account];
     Account oldAcc = new Account(AnnualRevenue = 1, Name = 'Something');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-rollup",
-  "version": "1.7.39",
+  "version": "1.7.40",
   "description": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
   "repository": {
     "type": "git",

--- a/rollup-namespaced/README.md
+++ b/rollup-namespaced/README.md
@@ -18,12 +18,12 @@ For more info, see the base `README`.
 
 ## Deployment & Setup
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tg70000007ht3AAA">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tg7000000CG7RAAW">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tg70000007ht3AAA">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tg7000000CG7RAAW">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/rollup-namespaced/sfdx-project.json
+++ b/rollup-namespaced/sfdx-project.json
@@ -4,8 +4,8 @@
             "default": true,
             "package": "apex-rollup-namespaced",
             "path": "rollup-namespaced/source/rollup",
-            "versionName": "Adds the ability to perform full recalculations for more than one parent",
-            "versionNumber": "1.2.35.0",
+            "versionName": "Fixes https://github.com/jamessimone/apex-rollup/issues/766 by ensuring recalculations occur when a parent lookup is cleared",
+            "versionNumber": "1.2.36.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -52,6 +52,7 @@
         "apex-rollup-namespaced@1.2.32": "04tg70000002WJxAAM",
         "apex-rollup-namespaced@1.2.33": "04tg7000000384HAAQ",
         "apex-rollup-namespaced@1.2.34": "04tg70000005BndAAE",
-        "apex-rollup-namespaced@1.2.35": "04tg70000007ht3AAA"
+        "apex-rollup-namespaced@1.2.35": "04tg70000007ht3AAA",
+        "apex-rollup-namespaced@1.2.36": "04tg7000000CG7RAAW"
     }
 }

--- a/rollup/core/classes/RollupAsyncProcessor.cls
+++ b/rollup/core/classes/RollupAsyncProcessor.cls
@@ -989,7 +989,10 @@ global virtual without sharing class RollupAsyncProcessor extends Rollup impleme
           }
           lookupFieldToCalcItems.put(key, bag);
         }
-        bag.add(calcItem);
+
+        if (hasBlankKey == false) {
+          bag.add(calcItem);
+        }
 
         // if the lookup key differs from what it was on the old child object,
         // include that value as well so that we can fix reparented records' rollup values

--- a/rollup/core/classes/RollupLogger.cls
+++ b/rollup/core/classes/RollupLogger.cls
@@ -2,7 +2,7 @@
 global without sharing virtual class RollupLogger implements ILogger {
   @TestVisible
   // this gets updated via the pipeline as the version number gets incremented
-  private static final String CURRENT_VERSION_NUMBER = 'v1.7.39';
+  private static final String CURRENT_VERSION_NUMBER = 'v1.7.40';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final RollupPlugin PLUGIN = new RollupPlugin();
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,8 +5,8 @@
             "package": "apex-rollup",
             "path": "rollup",
             "scopeProfiles": true,
-            "versionName": "Adds the ability to perform full recalculations for more than one parent",
-            "versionNumber": "1.7.39.0",
+            "versionName": "Fixes https://github.com/jamessimone/apex-rollup/issues/766 by ensuring recalculations occur when a parent lookup is cleared",
+            "versionNumber": "1.7.40.0",
             "versionDescription": "Fast, configurable, elastically scaling custom rollup solution. Apex Invocable action, one-liner Apex trigger/CMDT-driven logic, and scheduled Apex-ready.",
             "releaseNotesUrl": "https://github.com/jamessimone/apex-rollup/releases/latest",
             "unpackagedMetadata": {
@@ -101,10 +101,6 @@
         "Apex Rollup - Rollup Callback@0.0.3-0": "04t6g000008Sis0AAC",
         "Nebula Logger - Core@4.14.4-optionally-auto-call-lightning-logger-lwc": "04t5Y0000015oRNQAY",
         "apex-rollup": "0Ho6g000000TNcOCAW",
-        "apex-rollup@1.7.33": "04tKf000000syETIAY",
-        "apex-rollup@1.7.34": "04tKf000000syGFIAY",
-        "apex-rollup@1.7.35": "04tg70000001HziAAE",
-        "apex-rollup@1.7.36": "04tg70000002WDVAA2",
         "apex-rollup@1.7.37": "04tg700000037wDAAQ",
         "apex-rollup@1.7.38": "04tg70000005Bm1AAE",
         "apex-rollup@1.7.39": "04tg70000007hmbAAA"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -103,6 +103,7 @@
         "apex-rollup": "0Ho6g000000TNcOCAW",
         "apex-rollup@1.7.37": "04tg700000037wDAAQ",
         "apex-rollup@1.7.38": "04tg70000005Bm1AAE",
-        "apex-rollup@1.7.39": "04tg70000007hmbAAA"
+        "apex-rollup@1.7.39": "04tg70000007hmbAAA",
+        "apex-rollup@1.7.40": "04tg7000000CG0zAAG"
     }
 }


### PR DESCRIPTION
* Fixes #766 by ensuring recalculations properly flow all the way through when parent lookups are cleared from children records