### PR TITLE
remove .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.org/


### PR DESCRIPTION
The project .npmrc file is just pointing to the default npm registry. Removing this allows any developers with corporate repository proxies to work with this repo